### PR TITLE
feat: springboot bootstrap 설정

### DIFF
--- a/BUILD.bazel
+++ b/BUILD.bazel
@@ -14,14 +14,14 @@ gazelle(
     command = "update-repos",
 )
 
-alias(name = "admission", actual = "//systems/admission/module-a:main")
-alias(name = "application", actual = "//systems/application/module-a:main")
-alias(name = "configuration", actual = "//systems/configuration/module-a:main")
-alias(name = "document", actual = "//systems/document/module-a:main")
-alias(name = "gateway", actual = "//systems/gateway/module-a:main")
-alias(name = "identity", actual = "//systems/identity/module-a:main")
-alias(name = "notification", actual = "//systems/notification/module-a:main")
-alias(name = "schedule", actual = "//systems/schedule/module-a:main")
+alias(name = "admission", actual = "//systems/admission/admission-bootstrap:main")
+alias(name = "application", actual = "//systems/application/application-bootstrap:main")
+alias(name = "configuration", actual = "//systems/configuration/configuration-bootstrap:main")
+alias(name = "document", actual = "//systems/document/document-bootstrap:main")
+alias(name = "gateway", actual = "//systems/gateway/gateway-bootstrap:main")
+alias(name = "identity", actual = "//systems/identity/identity-bootstrap:main")
+alias(name = "notification", actual = "//systems/notification/notification-bootstrap:main")
+alias(name = "schedule", actual = "//systems/schedule/schedule-bootstrap:main")
 
 alias(name = "analytics", actual = "//systems/analytics/cmd/server:server")
 alias(name = "evaluation", actual = "//systems/evaluation/cmd/server:server")

--- a/systems/admission/admission-adapter-in/BUILD.bazel
+++ b/systems/admission/admission-adapter-in/BUILD.bazel
@@ -1,13 +1,11 @@
-load("@rules_kotlin//kotlin:jvm.bzl", "kt_jvm_binary", "kt_jvm_test")
-load("//systems/admission/module-a:deps.bzl", "MODULE_DEPS", "TEST_DEPS")
+load("@rules_kotlin//kotlin:jvm.bzl", "kt_jvm_library", "kt_jvm_test")
+load(":deps.bzl", "MODULE_DEPS", "TEST_DEPS")
 
 package(default_visibility = ["//visibility:public"])
 
-kt_jvm_binary(
+kt_jvm_library(
     name = "main",
     srcs = glob(["src/main/kotlin/**/*.kt"]),
-    main_class = "hs.kr.entrydsm.example.ExampleApplicationKt",
-    plugins = ["//:spring_allopen"],
     deps = MODULE_DEPS,
     javac_opts = "//:javac_options",
     kotlinc_opts = "//:kotlinc_options",
@@ -16,8 +14,7 @@ kt_jvm_binary(
 kt_jvm_test(
     name = "test",
     srcs = glob(["src/test/kotlin/**/*.kt"]),
-    test_class = "hs.kr.entrydsm.example.ExampleApplicationTest",
-    plugins = ["//:spring_allopen"],
+    test_class = "hs.kr.entrydsm.admission.adapterin.AdmissionAdapterInModuleTest",
     deps = MODULE_DEPS + TEST_DEPS,
     javac_opts = "//:javac_options",
     kotlinc_opts = "//:kotlinc_options",

--- a/systems/admission/admission-adapter-in/deps.bzl
+++ b/systems/admission/admission-adapter-in/deps.bzl
@@ -1,16 +1,7 @@
-SPRING_DEPS = [
-    "@maven//:org_springframework_boot_spring_boot_starter_web",
-    "@maven//:org_springframework_boot_spring_boot_starter_actuator",
-]
-
-KOTLIN_DEPS = [
-    "@maven//:org_jetbrains_kotlin_kotlin_reflect",
-    "@maven//:com_fasterxml_jackson_module_jackson_module_kotlin",
-]
+KOTLIN_DEPS = []
 
 TEST_DEPS = [
-    "@maven//:org_springframework_boot_spring_boot_starter_test",
     "@maven//:junit_junit",
 ]
 
-MODULE_DEPS = SPRING_DEPS + KOTLIN_DEPS
+MODULE_DEPS = KOTLIN_DEPS

--- a/systems/admission/admission-adapter-in/src/main/kotlin/hs/kr/entrydsm/ExampleApplication.kt
+++ b/systems/admission/admission-adapter-in/src/main/kotlin/hs/kr/entrydsm/ExampleApplication.kt
@@ -1,11 +1,3 @@
-package hs.kr.entrydsm.example
+package hs.kr.entrydsm.admission.adapterin
 
-import org.springframework.boot.autoconfigure.SpringBootApplication
-import org.springframework.boot.runApplication
-
-@SpringBootApplication
-class ExampleApplication
-
-fun main(args: Array<String>) {
-    runApplication<ExampleApplication>(*args)
-}
+class AdmissionAdapterInModule

--- a/systems/admission/admission-adapter-in/src/test/kotlin/hs/kr/entrydsm/TestMain.kt
+++ b/systems/admission/admission-adapter-in/src/test/kotlin/hs/kr/entrydsm/TestMain.kt
@@ -1,11 +1,11 @@
-package hs.kr.entrydsm.example
+package hs.kr.entrydsm.admission.adapterin
 
-import org.junit.Assert.assertEquals
+import org.junit.Assert.assertTrue
 import org.junit.Test
 
-class ExampleApplicationTest {
+class AdmissionAdapterInModuleTest {
     @Test
-    fun contextLoads() {
-        assertEquals(4, 2 + 2)
+    fun moduleLoads() {
+        assertTrue(true)
     }
 }

--- a/systems/admission/admission-adapter-out/BUILD.bazel
+++ b/systems/admission/admission-adapter-out/BUILD.bazel
@@ -1,13 +1,11 @@
-load("@rules_kotlin//kotlin:jvm.bzl", "kt_jvm_binary", "kt_jvm_test")
-load("//systems/admission/module-a:deps.bzl", "MODULE_DEPS", "TEST_DEPS")
+load("@rules_kotlin//kotlin:jvm.bzl", "kt_jvm_library", "kt_jvm_test")
+load(":deps.bzl", "MODULE_DEPS", "TEST_DEPS")
 
 package(default_visibility = ["//visibility:public"])
 
-kt_jvm_binary(
+kt_jvm_library(
     name = "main",
     srcs = glob(["src/main/kotlin/**/*.kt"]),
-    main_class = "hs.kr.entrydsm.example.ExampleApplicationKt",
-    plugins = ["//:spring_allopen"],
     deps = MODULE_DEPS,
     javac_opts = "//:javac_options",
     kotlinc_opts = "//:kotlinc_options",
@@ -16,8 +14,7 @@ kt_jvm_binary(
 kt_jvm_test(
     name = "test",
     srcs = glob(["src/test/kotlin/**/*.kt"]),
-    test_class = "hs.kr.entrydsm.example.ExampleApplicationTest",
-    plugins = ["//:spring_allopen"],
+    test_class = "hs.kr.entrydsm.admission.adapterout.AdmissionAdapterOutModuleTest",
     deps = MODULE_DEPS + TEST_DEPS,
     javac_opts = "//:javac_options",
     kotlinc_opts = "//:kotlinc_options",

--- a/systems/admission/admission-adapter-out/deps.bzl
+++ b/systems/admission/admission-adapter-out/deps.bzl
@@ -1,16 +1,7 @@
-SPRING_DEPS = [
-    "@maven//:org_springframework_boot_spring_boot_starter_web",
-    "@maven//:org_springframework_boot_spring_boot_starter_actuator",
-]
-
-KOTLIN_DEPS = [
-    "@maven//:org_jetbrains_kotlin_kotlin_reflect",
-    "@maven//:com_fasterxml_jackson_module_jackson_module_kotlin",
-]
+KOTLIN_DEPS = []
 
 TEST_DEPS = [
-    "@maven//:org_springframework_boot_spring_boot_starter_test",
     "@maven//:junit_junit",
 ]
 
-MODULE_DEPS = SPRING_DEPS + KOTLIN_DEPS
+MODULE_DEPS = KOTLIN_DEPS

--- a/systems/admission/admission-adapter-out/src/main/kotlin/hs/kr/entrydsm/ExampleApplication.kt
+++ b/systems/admission/admission-adapter-out/src/main/kotlin/hs/kr/entrydsm/ExampleApplication.kt
@@ -1,11 +1,3 @@
-package hs.kr.entrydsm.example
+package hs.kr.entrydsm.admission.adapterout
 
-import org.springframework.boot.autoconfigure.SpringBootApplication
-import org.springframework.boot.runApplication
-
-@SpringBootApplication
-class ExampleApplication
-
-fun main(args: Array<String>) {
-    runApplication<ExampleApplication>(*args)
-}
+class AdmissionAdapterOutModule

--- a/systems/admission/admission-adapter-out/src/test/kotlin/hs/kr/entrydsm/TestMain.kt
+++ b/systems/admission/admission-adapter-out/src/test/kotlin/hs/kr/entrydsm/TestMain.kt
@@ -1,11 +1,11 @@
-package hs.kr.entrydsm.example
+package hs.kr.entrydsm.admission.adapterout
 
-import org.junit.Assert.assertEquals
+import org.junit.Assert.assertTrue
 import org.junit.Test
 
-class ExampleApplicationTest {
+class AdmissionAdapterOutModuleTest {
     @Test
-    fun contextLoads() {
-        assertEquals(4, 2 + 2)
+    fun moduleLoads() {
+        assertTrue(true)
     }
 }

--- a/systems/admission/admission-application/BUILD.bazel
+++ b/systems/admission/admission-application/BUILD.bazel
@@ -1,13 +1,11 @@
-load("@rules_kotlin//kotlin:jvm.bzl", "kt_jvm_binary", "kt_jvm_test")
-load("//systems/admission/module-a:deps.bzl", "MODULE_DEPS", "TEST_DEPS")
+load("@rules_kotlin//kotlin:jvm.bzl", "kt_jvm_library", "kt_jvm_test")
+load(":deps.bzl", "MODULE_DEPS", "TEST_DEPS")
 
 package(default_visibility = ["//visibility:public"])
 
-kt_jvm_binary(
+kt_jvm_library(
     name = "main",
     srcs = glob(["src/main/kotlin/**/*.kt"]),
-    main_class = "hs.kr.entrydsm.example.ExampleApplicationKt",
-    plugins = ["//:spring_allopen"],
     deps = MODULE_DEPS,
     javac_opts = "//:javac_options",
     kotlinc_opts = "//:kotlinc_options",
@@ -16,8 +14,7 @@ kt_jvm_binary(
 kt_jvm_test(
     name = "test",
     srcs = glob(["src/test/kotlin/**/*.kt"]),
-    test_class = "hs.kr.entrydsm.example.ExampleApplicationTest",
-    plugins = ["//:spring_allopen"],
+    test_class = "hs.kr.entrydsm.admission.application.AdmissionApplicationModuleTest",
     deps = MODULE_DEPS + TEST_DEPS,
     javac_opts = "//:javac_options",
     kotlinc_opts = "//:kotlinc_options",

--- a/systems/admission/admission-application/deps.bzl
+++ b/systems/admission/admission-application/deps.bzl
@@ -1,16 +1,7 @@
-SPRING_DEPS = [
-    "@maven//:org_springframework_boot_spring_boot_starter_web",
-    "@maven//:org_springframework_boot_spring_boot_starter_actuator",
-]
-
-KOTLIN_DEPS = [
-    "@maven//:org_jetbrains_kotlin_kotlin_reflect",
-    "@maven//:com_fasterxml_jackson_module_jackson_module_kotlin",
-]
+KOTLIN_DEPS = []
 
 TEST_DEPS = [
-    "@maven//:org_springframework_boot_spring_boot_starter_test",
     "@maven//:junit_junit",
 ]
 
-MODULE_DEPS = SPRING_DEPS + KOTLIN_DEPS
+MODULE_DEPS = KOTLIN_DEPS

--- a/systems/admission/admission-application/src/main/kotlin/hs/kr/entrydsm/ExampleApplication.kt
+++ b/systems/admission/admission-application/src/main/kotlin/hs/kr/entrydsm/ExampleApplication.kt
@@ -1,11 +1,3 @@
-package hs.kr.entrydsm.example
+package hs.kr.entrydsm.admission.application
 
-import org.springframework.boot.autoconfigure.SpringBootApplication
-import org.springframework.boot.runApplication
-
-@SpringBootApplication
-class ExampleApplication
-
-fun main(args: Array<String>) {
-    runApplication<ExampleApplication>(*args)
-}
+class AdmissionApplicationModule

--- a/systems/admission/admission-application/src/test/kotlin/hs/kr/entrydsm/TestMain.kt
+++ b/systems/admission/admission-application/src/test/kotlin/hs/kr/entrydsm/TestMain.kt
@@ -1,11 +1,11 @@
-package hs.kr.entrydsm.example
+package hs.kr.entrydsm.admission.application
 
-import org.junit.Assert.assertEquals
+import org.junit.Assert.assertTrue
 import org.junit.Test
 
-class ExampleApplicationTest {
+class AdmissionApplicationModuleTest {
     @Test
-    fun contextLoads() {
-        assertEquals(4, 2 + 2)
+    fun moduleLoads() {
+        assertTrue(true)
     }
 }

--- a/systems/admission/admission-bootstrap/BUILD.bazel
+++ b/systems/admission/admission-bootstrap/BUILD.bazel
@@ -1,14 +1,20 @@
 load("@rules_kotlin//kotlin:jvm.bzl", "kt_jvm_binary", "kt_jvm_test")
-load("//systems/admission/module-a:deps.bzl", "MODULE_DEPS", "TEST_DEPS")
+load(":deps.bzl", "MODULE_DEPS", "TEST_DEPS")
 
 package(default_visibility = ["//visibility:public"])
 
 kt_jvm_binary(
     name = "main",
     srcs = glob(["src/main/kotlin/**/*.kt"]),
-    main_class = "hs.kr.entrydsm.example.ExampleApplicationKt",
+    resources = glob(["src/main/resources/**"]),
+    main_class = "hs.kr.entrydsm.admission.AdmissionBootstrapApplicationKt",
     plugins = ["//:spring_allopen"],
-    deps = MODULE_DEPS,
+    deps = MODULE_DEPS + [
+        "//systems/admission/admission-adapter-in:main",
+        "//systems/admission/admission-adapter-out:main",
+        "//systems/admission/admission-application:main",
+        "//systems/admission/admission-domain:main",
+    ],
     javac_opts = "//:javac_options",
     kotlinc_opts = "//:kotlinc_options",
 )
@@ -16,7 +22,7 @@ kt_jvm_binary(
 kt_jvm_test(
     name = "test",
     srcs = glob(["src/test/kotlin/**/*.kt"]),
-    test_class = "hs.kr.entrydsm.example.ExampleApplicationTest",
+    test_class = "hs.kr.entrydsm.admission.AdmissionBootstrapApplicationTest",
     plugins = ["//:spring_allopen"],
     deps = MODULE_DEPS + TEST_DEPS,
     javac_opts = "//:javac_options",

--- a/systems/admission/admission-bootstrap/src/main/kotlin/hs/kr/entrydsm/ExampleApplication.kt
+++ b/systems/admission/admission-bootstrap/src/main/kotlin/hs/kr/entrydsm/ExampleApplication.kt
@@ -1,11 +1,11 @@
-package hs.kr.entrydsm.example
+package hs.kr.entrydsm.admission
 
 import org.springframework.boot.autoconfigure.SpringBootApplication
 import org.springframework.boot.runApplication
 
 @SpringBootApplication
-class ExampleApplication
+class AdmissionBootstrapApplication
 
 fun main(args: Array<String>) {
-    runApplication<ExampleApplication>(*args)
+    runApplication<AdmissionBootstrapApplication>(*args)
 }

--- a/systems/admission/admission-bootstrap/src/main/resources/application.yaml
+++ b/systems/admission/admission-bootstrap/src/main/resources/application.yaml
@@ -1,0 +1,21 @@
+spring:
+  application:
+    name: admission
+  profiles:
+    default: local
+  main:
+    lazy-initialization: true
+server:
+  shutdown: graceful
+management:
+  endpoints:
+    web:
+      exposure:
+        include: health,info
+  endpoint:
+    health:
+      probes:
+        enabled: true
+logging:
+  level:
+    root: INFO

--- a/systems/admission/admission-bootstrap/src/test/kotlin/hs/kr/entrydsm/TestMain.kt
+++ b/systems/admission/admission-bootstrap/src/test/kotlin/hs/kr/entrydsm/TestMain.kt
@@ -1,11 +1,11 @@
-package hs.kr.entrydsm.example
+package hs.kr.entrydsm.admission
 
-import org.junit.Assert.assertEquals
+import org.junit.Assert.assertTrue
 import org.junit.Test
 
-class ExampleApplicationTest {
+class AdmissionBootstrapApplicationTest {
     @Test
     fun contextLoads() {
-        assertEquals(4, 2 + 2)
+        assertTrue(true)
     }
 }

--- a/systems/admission/admission-domain/BUILD.bazel
+++ b/systems/admission/admission-domain/BUILD.bazel
@@ -1,13 +1,11 @@
-load("@rules_kotlin//kotlin:jvm.bzl", "kt_jvm_binary", "kt_jvm_test")
-load("//systems/admission/module-a:deps.bzl", "MODULE_DEPS", "TEST_DEPS")
+load("@rules_kotlin//kotlin:jvm.bzl", "kt_jvm_library", "kt_jvm_test")
+load(":deps.bzl", "MODULE_DEPS", "TEST_DEPS")
 
 package(default_visibility = ["//visibility:public"])
 
-kt_jvm_binary(
+kt_jvm_library(
     name = "main",
     srcs = glob(["src/main/kotlin/**/*.kt"]),
-    main_class = "hs.kr.entrydsm.example.ExampleApplicationKt",
-    plugins = ["//:spring_allopen"],
     deps = MODULE_DEPS,
     javac_opts = "//:javac_options",
     kotlinc_opts = "//:kotlinc_options",
@@ -16,8 +14,7 @@ kt_jvm_binary(
 kt_jvm_test(
     name = "test",
     srcs = glob(["src/test/kotlin/**/*.kt"]),
-    test_class = "hs.kr.entrydsm.example.ExampleApplicationTest",
-    plugins = ["//:spring_allopen"],
+    test_class = "hs.kr.entrydsm.admission.domain.AdmissionDomainModuleTest",
     deps = MODULE_DEPS + TEST_DEPS,
     javac_opts = "//:javac_options",
     kotlinc_opts = "//:kotlinc_options",

--- a/systems/admission/admission-domain/deps.bzl
+++ b/systems/admission/admission-domain/deps.bzl
@@ -1,16 +1,7 @@
-SPRING_DEPS = [
-    "@maven//:org_springframework_boot_spring_boot_starter_web",
-    "@maven//:org_springframework_boot_spring_boot_starter_actuator",
-]
-
-KOTLIN_DEPS = [
-    "@maven//:org_jetbrains_kotlin_kotlin_reflect",
-    "@maven//:com_fasterxml_jackson_module_jackson_module_kotlin",
-]
+KOTLIN_DEPS = []
 
 TEST_DEPS = [
-    "@maven//:org_springframework_boot_spring_boot_starter_test",
     "@maven//:junit_junit",
 ]
 
-MODULE_DEPS = SPRING_DEPS + KOTLIN_DEPS
+MODULE_DEPS = KOTLIN_DEPS

--- a/systems/admission/admission-domain/src/main/kotlin/hs/kr/entrydsm/ExampleApplication.kt
+++ b/systems/admission/admission-domain/src/main/kotlin/hs/kr/entrydsm/ExampleApplication.kt
@@ -1,11 +1,3 @@
-package hs.kr.entrydsm.example
+package hs.kr.entrydsm.admission.domain
 
-import org.springframework.boot.autoconfigure.SpringBootApplication
-import org.springframework.boot.runApplication
-
-@SpringBootApplication
-class ExampleApplication
-
-fun main(args: Array<String>) {
-    runApplication<ExampleApplication>(*args)
-}
+class AdmissionDomainModule

--- a/systems/admission/admission-domain/src/test/kotlin/hs/kr/entrydsm/TestMain.kt
+++ b/systems/admission/admission-domain/src/test/kotlin/hs/kr/entrydsm/TestMain.kt
@@ -1,11 +1,11 @@
-package hs.kr.entrydsm.example
+package hs.kr.entrydsm.admission.domain
 
-import org.junit.Assert.assertEquals
+import org.junit.Assert.assertTrue
 import org.junit.Test
 
-class ExampleApplicationTest {
+class AdmissionDomainModuleTest {
     @Test
-    fun contextLoads() {
-        assertEquals(4, 2 + 2)
+    fun moduleLoads() {
+        assertTrue(true)
     }
 }

--- a/systems/application/application-adapter-in/BUILD.bazel
+++ b/systems/application/application-adapter-in/BUILD.bazel
@@ -1,13 +1,11 @@
-load("@rules_kotlin//kotlin:jvm.bzl", "kt_jvm_binary", "kt_jvm_test")
-load("//systems/admission/module-a:deps.bzl", "MODULE_DEPS", "TEST_DEPS")
+load("@rules_kotlin//kotlin:jvm.bzl", "kt_jvm_library", "kt_jvm_test")
+load(":deps.bzl", "MODULE_DEPS", "TEST_DEPS")
 
 package(default_visibility = ["//visibility:public"])
 
-kt_jvm_binary(
+kt_jvm_library(
     name = "main",
     srcs = glob(["src/main/kotlin/**/*.kt"]),
-    main_class = "hs.kr.entrydsm.example.ExampleApplicationKt",
-    plugins = ["//:spring_allopen"],
     deps = MODULE_DEPS,
     javac_opts = "//:javac_options",
     kotlinc_opts = "//:kotlinc_options",
@@ -16,8 +14,7 @@ kt_jvm_binary(
 kt_jvm_test(
     name = "test",
     srcs = glob(["src/test/kotlin/**/*.kt"]),
-    test_class = "hs.kr.entrydsm.example.ExampleApplicationTest",
-    plugins = ["//:spring_allopen"],
+    test_class = "hs.kr.entrydsm.application.adapterin.ApplicationAdapterInModuleTest",
     deps = MODULE_DEPS + TEST_DEPS,
     javac_opts = "//:javac_options",
     kotlinc_opts = "//:kotlinc_options",

--- a/systems/application/application-adapter-in/deps.bzl
+++ b/systems/application/application-adapter-in/deps.bzl
@@ -1,16 +1,7 @@
-SPRING_DEPS = [
-    "@maven//:org_springframework_boot_spring_boot_starter_web",
-    "@maven//:org_springframework_boot_spring_boot_starter_actuator",
-]
-
-KOTLIN_DEPS = [
-    "@maven//:org_jetbrains_kotlin_kotlin_reflect",
-    "@maven//:com_fasterxml_jackson_module_jackson_module_kotlin",
-]
+KOTLIN_DEPS = []
 
 TEST_DEPS = [
-    "@maven//:org_springframework_boot_spring_boot_starter_test",
     "@maven//:junit_junit",
 ]
 
-MODULE_DEPS = SPRING_DEPS + KOTLIN_DEPS
+MODULE_DEPS = KOTLIN_DEPS

--- a/systems/application/application-adapter-in/src/main/kotlin/hs/kr/entrydsm/ExampleApplication.kt
+++ b/systems/application/application-adapter-in/src/main/kotlin/hs/kr/entrydsm/ExampleApplication.kt
@@ -1,11 +1,3 @@
-package hs.kr.entrydsm.example
+package hs.kr.entrydsm.application.adapterin
 
-import org.springframework.boot.autoconfigure.SpringBootApplication
-import org.springframework.boot.runApplication
-
-@SpringBootApplication
-class ExampleApplication
-
-fun main(args: Array<String>) {
-    runApplication<ExampleApplication>(*args)
-}
+class ApplicationAdapterInModule

--- a/systems/application/application-adapter-in/src/test/kotlin/hs/kr/entrydsm/TestMain.kt
+++ b/systems/application/application-adapter-in/src/test/kotlin/hs/kr/entrydsm/TestMain.kt
@@ -1,11 +1,11 @@
-package hs.kr.entrydsm.example
+package hs.kr.entrydsm.application.adapterin
 
-import org.junit.Assert.assertEquals
+import org.junit.Assert.assertTrue
 import org.junit.Test
 
-class ExampleApplicationTest {
+class ApplicationAdapterInModuleTest {
     @Test
-    fun contextLoads() {
-        assertEquals(4, 2 + 2)
+    fun moduleLoads() {
+        assertTrue(true)
     }
 }

--- a/systems/application/application-adapter-out/BUILD.bazel
+++ b/systems/application/application-adapter-out/BUILD.bazel
@@ -1,13 +1,11 @@
-load("@rules_kotlin//kotlin:jvm.bzl", "kt_jvm_binary", "kt_jvm_test")
-load("//systems/admission/module-a:deps.bzl", "MODULE_DEPS", "TEST_DEPS")
+load("@rules_kotlin//kotlin:jvm.bzl", "kt_jvm_library", "kt_jvm_test")
+load(":deps.bzl", "MODULE_DEPS", "TEST_DEPS")
 
 package(default_visibility = ["//visibility:public"])
 
-kt_jvm_binary(
+kt_jvm_library(
     name = "main",
     srcs = glob(["src/main/kotlin/**/*.kt"]),
-    main_class = "hs.kr.entrydsm.example.ExampleApplicationKt",
-    plugins = ["//:spring_allopen"],
     deps = MODULE_DEPS,
     javac_opts = "//:javac_options",
     kotlinc_opts = "//:kotlinc_options",
@@ -16,8 +14,7 @@ kt_jvm_binary(
 kt_jvm_test(
     name = "test",
     srcs = glob(["src/test/kotlin/**/*.kt"]),
-    test_class = "hs.kr.entrydsm.example.ExampleApplicationTest",
-    plugins = ["//:spring_allopen"],
+    test_class = "hs.kr.entrydsm.application.adapterout.ApplicationAdapterOutModuleTest",
     deps = MODULE_DEPS + TEST_DEPS,
     javac_opts = "//:javac_options",
     kotlinc_opts = "//:kotlinc_options",

--- a/systems/application/application-adapter-out/deps.bzl
+++ b/systems/application/application-adapter-out/deps.bzl
@@ -1,16 +1,7 @@
-SPRING_DEPS = [
-    "@maven//:org_springframework_boot_spring_boot_starter_web",
-    "@maven//:org_springframework_boot_spring_boot_starter_actuator",
-]
-
-KOTLIN_DEPS = [
-    "@maven//:org_jetbrains_kotlin_kotlin_reflect",
-    "@maven//:com_fasterxml_jackson_module_jackson_module_kotlin",
-]
+KOTLIN_DEPS = []
 
 TEST_DEPS = [
-    "@maven//:org_springframework_boot_spring_boot_starter_test",
     "@maven//:junit_junit",
 ]
 
-MODULE_DEPS = SPRING_DEPS + KOTLIN_DEPS
+MODULE_DEPS = KOTLIN_DEPS

--- a/systems/application/application-adapter-out/src/main/kotlin/hs/kr/entrydsm/ExampleApplication.kt
+++ b/systems/application/application-adapter-out/src/main/kotlin/hs/kr/entrydsm/ExampleApplication.kt
@@ -1,11 +1,3 @@
-package hs.kr.entrydsm.example
+package hs.kr.entrydsm.application.adapterout
 
-import org.springframework.boot.autoconfigure.SpringBootApplication
-import org.springframework.boot.runApplication
-
-@SpringBootApplication
-class ExampleApplication
-
-fun main(args: Array<String>) {
-    runApplication<ExampleApplication>(*args)
-}
+class ApplicationAdapterOutModule

--- a/systems/application/application-adapter-out/src/test/kotlin/hs/kr/entrydsm/TestMain.kt
+++ b/systems/application/application-adapter-out/src/test/kotlin/hs/kr/entrydsm/TestMain.kt
@@ -1,11 +1,11 @@
-package hs.kr.entrydsm.example
+package hs.kr.entrydsm.application.adapterout
 
-import org.junit.Assert.assertEquals
+import org.junit.Assert.assertTrue
 import org.junit.Test
 
-class ExampleApplicationTest {
+class ApplicationAdapterOutModuleTest {
     @Test
-    fun contextLoads() {
-        assertEquals(4, 2 + 2)
+    fun moduleLoads() {
+        assertTrue(true)
     }
 }

--- a/systems/application/application-application/BUILD.bazel
+++ b/systems/application/application-application/BUILD.bazel
@@ -1,13 +1,11 @@
-load("@rules_kotlin//kotlin:jvm.bzl", "kt_jvm_binary", "kt_jvm_test")
-load("//systems/admission/module-a:deps.bzl", "MODULE_DEPS", "TEST_DEPS")
+load("@rules_kotlin//kotlin:jvm.bzl", "kt_jvm_library", "kt_jvm_test")
+load(":deps.bzl", "MODULE_DEPS", "TEST_DEPS")
 
 package(default_visibility = ["//visibility:public"])
 
-kt_jvm_binary(
+kt_jvm_library(
     name = "main",
     srcs = glob(["src/main/kotlin/**/*.kt"]),
-    main_class = "hs.kr.entrydsm.example.ExampleApplicationKt",
-    plugins = ["//:spring_allopen"],
     deps = MODULE_DEPS,
     javac_opts = "//:javac_options",
     kotlinc_opts = "//:kotlinc_options",
@@ -16,8 +14,7 @@ kt_jvm_binary(
 kt_jvm_test(
     name = "test",
     srcs = glob(["src/test/kotlin/**/*.kt"]),
-    test_class = "hs.kr.entrydsm.example.ExampleApplicationTest",
-    plugins = ["//:spring_allopen"],
+    test_class = "hs.kr.entrydsm.application.application.ApplicationApplicationModuleTest",
     deps = MODULE_DEPS + TEST_DEPS,
     javac_opts = "//:javac_options",
     kotlinc_opts = "//:kotlinc_options",

--- a/systems/application/application-application/deps.bzl
+++ b/systems/application/application-application/deps.bzl
@@ -1,16 +1,7 @@
-SPRING_DEPS = [
-    "@maven//:org_springframework_boot_spring_boot_starter_web",
-    "@maven//:org_springframework_boot_spring_boot_starter_actuator",
-]
-
-KOTLIN_DEPS = [
-    "@maven//:org_jetbrains_kotlin_kotlin_reflect",
-    "@maven//:com_fasterxml_jackson_module_jackson_module_kotlin",
-]
+KOTLIN_DEPS = []
 
 TEST_DEPS = [
-    "@maven//:org_springframework_boot_spring_boot_starter_test",
     "@maven//:junit_junit",
 ]
 
-MODULE_DEPS = SPRING_DEPS + KOTLIN_DEPS
+MODULE_DEPS = KOTLIN_DEPS

--- a/systems/application/application-application/src/main/kotlin/hs/kr/entrydsm/ExampleApplication.kt
+++ b/systems/application/application-application/src/main/kotlin/hs/kr/entrydsm/ExampleApplication.kt
@@ -1,11 +1,3 @@
-package hs.kr.entrydsm.example
+package hs.kr.entrydsm.application.application
 
-import org.springframework.boot.autoconfigure.SpringBootApplication
-import org.springframework.boot.runApplication
-
-@SpringBootApplication
-class ExampleApplication
-
-fun main(args: Array<String>) {
-    runApplication<ExampleApplication>(*args)
-}
+class ApplicationApplicationModule

--- a/systems/application/application-application/src/test/kotlin/hs/kr/entrydsm/TestMain.kt
+++ b/systems/application/application-application/src/test/kotlin/hs/kr/entrydsm/TestMain.kt
@@ -1,11 +1,11 @@
-package hs.kr.entrydsm.example
+package hs.kr.entrydsm.application.application
 
-import org.junit.Assert.assertEquals
+import org.junit.Assert.assertTrue
 import org.junit.Test
 
-class ExampleApplicationTest {
+class ApplicationApplicationModuleTest {
     @Test
-    fun contextLoads() {
-        assertEquals(4, 2 + 2)
+    fun moduleLoads() {
+        assertTrue(true)
     }
 }

--- a/systems/application/application-bootstrap/BUILD.bazel
+++ b/systems/application/application-bootstrap/BUILD.bazel
@@ -1,14 +1,20 @@
 load("@rules_kotlin//kotlin:jvm.bzl", "kt_jvm_binary", "kt_jvm_test")
-load("//systems/admission/module-a:deps.bzl", "MODULE_DEPS", "TEST_DEPS")
+load(":deps.bzl", "MODULE_DEPS", "TEST_DEPS")
 
 package(default_visibility = ["//visibility:public"])
 
 kt_jvm_binary(
     name = "main",
     srcs = glob(["src/main/kotlin/**/*.kt"]),
-    main_class = "hs.kr.entrydsm.example.ExampleApplicationKt",
+    resources = glob(["src/main/resources/**"]),
+    main_class = "hs.kr.entrydsm.application.ApplicationBootstrapApplicationKt",
     plugins = ["//:spring_allopen"],
-    deps = MODULE_DEPS,
+    deps = MODULE_DEPS + [
+        "//systems/application/application-adapter-in:main",
+        "//systems/application/application-adapter-out:main",
+        "//systems/application/application-application:main",
+        "//systems/application/application-domain:main",
+    ],
     javac_opts = "//:javac_options",
     kotlinc_opts = "//:kotlinc_options",
 )
@@ -16,7 +22,7 @@ kt_jvm_binary(
 kt_jvm_test(
     name = "test",
     srcs = glob(["src/test/kotlin/**/*.kt"]),
-    test_class = "hs.kr.entrydsm.example.ExampleApplicationTest",
+    test_class = "hs.kr.entrydsm.application.ApplicationBootstrapApplicationTest",
     plugins = ["//:spring_allopen"],
     deps = MODULE_DEPS + TEST_DEPS,
     javac_opts = "//:javac_options",

--- a/systems/application/application-bootstrap/src/main/kotlin/hs/kr/entrydsm/ExampleApplication.kt
+++ b/systems/application/application-bootstrap/src/main/kotlin/hs/kr/entrydsm/ExampleApplication.kt
@@ -1,11 +1,11 @@
-package hs.kr.entrydsm.example
+package hs.kr.entrydsm.application
 
 import org.springframework.boot.autoconfigure.SpringBootApplication
 import org.springframework.boot.runApplication
 
 @SpringBootApplication
-class ExampleApplication
+class ApplicationBootstrapApplication
 
 fun main(args: Array<String>) {
-    runApplication<ExampleApplication>(*args)
+    runApplication<ApplicationBootstrapApplication>(*args)
 }

--- a/systems/application/application-bootstrap/src/main/resources/application.yaml
+++ b/systems/application/application-bootstrap/src/main/resources/application.yaml
@@ -1,0 +1,21 @@
+spring:
+  application:
+    name: application
+  profiles:
+    default: local
+  main:
+    lazy-initialization: true
+server:
+  shutdown: graceful
+management:
+  endpoints:
+    web:
+      exposure:
+        include: health,info
+  endpoint:
+    health:
+      probes:
+        enabled: true
+logging:
+  level:
+    root: INFO

--- a/systems/application/application-bootstrap/src/test/kotlin/hs/kr/entrydsm/TestMain.kt
+++ b/systems/application/application-bootstrap/src/test/kotlin/hs/kr/entrydsm/TestMain.kt
@@ -1,11 +1,11 @@
-package hs.kr.entrydsm.example
+package hs.kr.entrydsm.application
 
-import org.junit.Assert.assertEquals
+import org.junit.Assert.assertTrue
 import org.junit.Test
 
-class ExampleApplicationTest {
+class ApplicationBootstrapApplicationTest {
     @Test
     fun contextLoads() {
-        assertEquals(4, 2 + 2)
+        assertTrue(true)
     }
 }

--- a/systems/application/application-domain/BUILD.bazel
+++ b/systems/application/application-domain/BUILD.bazel
@@ -1,13 +1,11 @@
-load("@rules_kotlin//kotlin:jvm.bzl", "kt_jvm_binary", "kt_jvm_test")
-load("//systems/admission/module-a:deps.bzl", "MODULE_DEPS", "TEST_DEPS")
+load("@rules_kotlin//kotlin:jvm.bzl", "kt_jvm_library", "kt_jvm_test")
+load(":deps.bzl", "MODULE_DEPS", "TEST_DEPS")
 
 package(default_visibility = ["//visibility:public"])
 
-kt_jvm_binary(
+kt_jvm_library(
     name = "main",
     srcs = glob(["src/main/kotlin/**/*.kt"]),
-    main_class = "hs.kr.entrydsm.example.ExampleApplicationKt",
-    plugins = ["//:spring_allopen"],
     deps = MODULE_DEPS,
     javac_opts = "//:javac_options",
     kotlinc_opts = "//:kotlinc_options",
@@ -16,8 +14,7 @@ kt_jvm_binary(
 kt_jvm_test(
     name = "test",
     srcs = glob(["src/test/kotlin/**/*.kt"]),
-    test_class = "hs.kr.entrydsm.example.ExampleApplicationTest",
-    plugins = ["//:spring_allopen"],
+    test_class = "hs.kr.entrydsm.application.domain.ApplicationDomainModuleTest",
     deps = MODULE_DEPS + TEST_DEPS,
     javac_opts = "//:javac_options",
     kotlinc_opts = "//:kotlinc_options",

--- a/systems/application/application-domain/deps.bzl
+++ b/systems/application/application-domain/deps.bzl
@@ -1,16 +1,7 @@
-SPRING_DEPS = [
-    "@maven//:org_springframework_boot_spring_boot_starter_web",
-    "@maven//:org_springframework_boot_spring_boot_starter_actuator",
-]
-
-KOTLIN_DEPS = [
-    "@maven//:org_jetbrains_kotlin_kotlin_reflect",
-    "@maven//:com_fasterxml_jackson_module_jackson_module_kotlin",
-]
+KOTLIN_DEPS = []
 
 TEST_DEPS = [
-    "@maven//:org_springframework_boot_spring_boot_starter_test",
     "@maven//:junit_junit",
 ]
 
-MODULE_DEPS = SPRING_DEPS + KOTLIN_DEPS
+MODULE_DEPS = KOTLIN_DEPS

--- a/systems/application/application-domain/src/main/kotlin/hs/kr/entrydsm/ExampleApplication.kt
+++ b/systems/application/application-domain/src/main/kotlin/hs/kr/entrydsm/ExampleApplication.kt
@@ -1,11 +1,3 @@
-package hs.kr.entrydsm.example
+package hs.kr.entrydsm.application.domain
 
-import org.springframework.boot.autoconfigure.SpringBootApplication
-import org.springframework.boot.runApplication
-
-@SpringBootApplication
-class ExampleApplication
-
-fun main(args: Array<String>) {
-    runApplication<ExampleApplication>(*args)
-}
+class ApplicationDomainModule

--- a/systems/application/application-domain/src/test/kotlin/hs/kr/entrydsm/TestMain.kt
+++ b/systems/application/application-domain/src/test/kotlin/hs/kr/entrydsm/TestMain.kt
@@ -1,11 +1,11 @@
-package hs.kr.entrydsm.example
+package hs.kr.entrydsm.application.domain
 
-import org.junit.Assert.assertEquals
+import org.junit.Assert.assertTrue
 import org.junit.Test
 
-class ExampleApplicationTest {
+class ApplicationDomainModuleTest {
     @Test
-    fun contextLoads() {
-        assertEquals(4, 2 + 2)
+    fun moduleLoads() {
+        assertTrue(true)
     }
 }

--- a/systems/configuration/configuration-adapter-in/BUILD.bazel
+++ b/systems/configuration/configuration-adapter-in/BUILD.bazel
@@ -1,13 +1,11 @@
-load("@rules_kotlin//kotlin:jvm.bzl", "kt_jvm_binary", "kt_jvm_test")
-load("//systems/admission/module-a:deps.bzl", "MODULE_DEPS", "TEST_DEPS")
+load("@rules_kotlin//kotlin:jvm.bzl", "kt_jvm_library", "kt_jvm_test")
+load(":deps.bzl", "MODULE_DEPS", "TEST_DEPS")
 
 package(default_visibility = ["//visibility:public"])
 
-kt_jvm_binary(
+kt_jvm_library(
     name = "main",
     srcs = glob(["src/main/kotlin/**/*.kt"]),
-    main_class = "hs.kr.entrydsm.example.ExampleApplicationKt",
-    plugins = ["//:spring_allopen"],
     deps = MODULE_DEPS,
     javac_opts = "//:javac_options",
     kotlinc_opts = "//:kotlinc_options",
@@ -16,8 +14,7 @@ kt_jvm_binary(
 kt_jvm_test(
     name = "test",
     srcs = glob(["src/test/kotlin/**/*.kt"]),
-    test_class = "hs.kr.entrydsm.example.ExampleApplicationTest",
-    plugins = ["//:spring_allopen"],
+    test_class = "hs.kr.entrydsm.configuration.adapterin.ConfigurationAdapterInModuleTest",
     deps = MODULE_DEPS + TEST_DEPS,
     javac_opts = "//:javac_options",
     kotlinc_opts = "//:kotlinc_options",

--- a/systems/configuration/configuration-adapter-in/deps.bzl
+++ b/systems/configuration/configuration-adapter-in/deps.bzl
@@ -1,16 +1,7 @@
-SPRING_DEPS = [
-    "@maven//:org_springframework_boot_spring_boot_starter_web",
-    "@maven//:org_springframework_boot_spring_boot_starter_actuator",
-]
-
-KOTLIN_DEPS = [
-    "@maven//:org_jetbrains_kotlin_kotlin_reflect",
-    "@maven//:com_fasterxml_jackson_module_jackson_module_kotlin",
-]
+KOTLIN_DEPS = []
 
 TEST_DEPS = [
-    "@maven//:org_springframework_boot_spring_boot_starter_test",
     "@maven//:junit_junit",
 ]
 
-MODULE_DEPS = SPRING_DEPS + KOTLIN_DEPS
+MODULE_DEPS = KOTLIN_DEPS

--- a/systems/configuration/configuration-adapter-in/src/main/kotlin/hs/kr/entrydsm/ExampleApplication.kt
+++ b/systems/configuration/configuration-adapter-in/src/main/kotlin/hs/kr/entrydsm/ExampleApplication.kt
@@ -1,11 +1,3 @@
-package hs.kr.entrydsm.example
+package hs.kr.entrydsm.configuration.adapterin
 
-import org.springframework.boot.autoconfigure.SpringBootApplication
-import org.springframework.boot.runApplication
-
-@SpringBootApplication
-class ExampleApplication
-
-fun main(args: Array<String>) {
-    runApplication<ExampleApplication>(*args)
-}
+class ConfigurationAdapterInModule

--- a/systems/configuration/configuration-adapter-in/src/test/kotlin/hs/kr/entrydsm/TestMain.kt
+++ b/systems/configuration/configuration-adapter-in/src/test/kotlin/hs/kr/entrydsm/TestMain.kt
@@ -1,11 +1,11 @@
-package hs.kr.entrydsm.example
+package hs.kr.entrydsm.configuration.adapterin
 
-import org.junit.Assert.assertEquals
+import org.junit.Assert.assertTrue
 import org.junit.Test
 
-class ExampleApplicationTest {
+class ConfigurationAdapterInModuleTest {
     @Test
-    fun contextLoads() {
-        assertEquals(4, 2 + 2)
+    fun moduleLoads() {
+        assertTrue(true)
     }
 }

--- a/systems/configuration/configuration-adapter-out/BUILD.bazel
+++ b/systems/configuration/configuration-adapter-out/BUILD.bazel
@@ -1,13 +1,11 @@
-load("@rules_kotlin//kotlin:jvm.bzl", "kt_jvm_binary", "kt_jvm_test")
-load("//systems/admission/module-a:deps.bzl", "MODULE_DEPS", "TEST_DEPS")
+load("@rules_kotlin//kotlin:jvm.bzl", "kt_jvm_library", "kt_jvm_test")
+load(":deps.bzl", "MODULE_DEPS", "TEST_DEPS")
 
 package(default_visibility = ["//visibility:public"])
 
-kt_jvm_binary(
+kt_jvm_library(
     name = "main",
     srcs = glob(["src/main/kotlin/**/*.kt"]),
-    main_class = "hs.kr.entrydsm.example.ExampleApplicationKt",
-    plugins = ["//:spring_allopen"],
     deps = MODULE_DEPS,
     javac_opts = "//:javac_options",
     kotlinc_opts = "//:kotlinc_options",
@@ -16,8 +14,7 @@ kt_jvm_binary(
 kt_jvm_test(
     name = "test",
     srcs = glob(["src/test/kotlin/**/*.kt"]),
-    test_class = "hs.kr.entrydsm.example.ExampleApplicationTest",
-    plugins = ["//:spring_allopen"],
+    test_class = "hs.kr.entrydsm.configuration.adapterout.ConfigurationAdapterOutModuleTest",
     deps = MODULE_DEPS + TEST_DEPS,
     javac_opts = "//:javac_options",
     kotlinc_opts = "//:kotlinc_options",

--- a/systems/configuration/configuration-adapter-out/deps.bzl
+++ b/systems/configuration/configuration-adapter-out/deps.bzl
@@ -1,16 +1,7 @@
-SPRING_DEPS = [
-    "@maven//:org_springframework_boot_spring_boot_starter_web",
-    "@maven//:org_springframework_boot_spring_boot_starter_actuator",
-]
-
-KOTLIN_DEPS = [
-    "@maven//:org_jetbrains_kotlin_kotlin_reflect",
-    "@maven//:com_fasterxml_jackson_module_jackson_module_kotlin",
-]
+KOTLIN_DEPS = []
 
 TEST_DEPS = [
-    "@maven//:org_springframework_boot_spring_boot_starter_test",
     "@maven//:junit_junit",
 ]
 
-MODULE_DEPS = SPRING_DEPS + KOTLIN_DEPS
+MODULE_DEPS = KOTLIN_DEPS

--- a/systems/configuration/configuration-adapter-out/src/main/kotlin/hs/kr/entrydsm/ExampleApplication.kt
+++ b/systems/configuration/configuration-adapter-out/src/main/kotlin/hs/kr/entrydsm/ExampleApplication.kt
@@ -1,11 +1,3 @@
-package hs.kr.entrydsm.example
+package hs.kr.entrydsm.configuration.adapterout
 
-import org.springframework.boot.autoconfigure.SpringBootApplication
-import org.springframework.boot.runApplication
-
-@SpringBootApplication
-class ExampleApplication
-
-fun main(args: Array<String>) {
-    runApplication<ExampleApplication>(*args)
-}
+class ConfigurationAdapterOutModule

--- a/systems/configuration/configuration-adapter-out/src/test/kotlin/hs/kr/entrydsm/TestMain.kt
+++ b/systems/configuration/configuration-adapter-out/src/test/kotlin/hs/kr/entrydsm/TestMain.kt
@@ -1,11 +1,11 @@
-package hs.kr.entrydsm.example
+package hs.kr.entrydsm.configuration.adapterout
 
-import org.junit.Assert.assertEquals
+import org.junit.Assert.assertTrue
 import org.junit.Test
 
-class ExampleApplicationTest {
+class ConfigurationAdapterOutModuleTest {
     @Test
-    fun contextLoads() {
-        assertEquals(4, 2 + 2)
+    fun moduleLoads() {
+        assertTrue(true)
     }
 }

--- a/systems/configuration/configuration-application/BUILD.bazel
+++ b/systems/configuration/configuration-application/BUILD.bazel
@@ -1,13 +1,11 @@
-load("@rules_kotlin//kotlin:jvm.bzl", "kt_jvm_binary", "kt_jvm_test")
-load("//systems/admission/module-a:deps.bzl", "MODULE_DEPS", "TEST_DEPS")
+load("@rules_kotlin//kotlin:jvm.bzl", "kt_jvm_library", "kt_jvm_test")
+load(":deps.bzl", "MODULE_DEPS", "TEST_DEPS")
 
 package(default_visibility = ["//visibility:public"])
 
-kt_jvm_binary(
+kt_jvm_library(
     name = "main",
     srcs = glob(["src/main/kotlin/**/*.kt"]),
-    main_class = "hs.kr.entrydsm.example.ExampleApplicationKt",
-    plugins = ["//:spring_allopen"],
     deps = MODULE_DEPS,
     javac_opts = "//:javac_options",
     kotlinc_opts = "//:kotlinc_options",
@@ -16,8 +14,7 @@ kt_jvm_binary(
 kt_jvm_test(
     name = "test",
     srcs = glob(["src/test/kotlin/**/*.kt"]),
-    test_class = "hs.kr.entrydsm.example.ExampleApplicationTest",
-    plugins = ["//:spring_allopen"],
+    test_class = "hs.kr.entrydsm.configuration.application.ConfigurationApplicationModuleTest",
     deps = MODULE_DEPS + TEST_DEPS,
     javac_opts = "//:javac_options",
     kotlinc_opts = "//:kotlinc_options",

--- a/systems/configuration/configuration-application/deps.bzl
+++ b/systems/configuration/configuration-application/deps.bzl
@@ -1,16 +1,7 @@
-SPRING_DEPS = [
-    "@maven//:org_springframework_boot_spring_boot_starter_web",
-    "@maven//:org_springframework_boot_spring_boot_starter_actuator",
-]
-
-KOTLIN_DEPS = [
-    "@maven//:org_jetbrains_kotlin_kotlin_reflect",
-    "@maven//:com_fasterxml_jackson_module_jackson_module_kotlin",
-]
+KOTLIN_DEPS = []
 
 TEST_DEPS = [
-    "@maven//:org_springframework_boot_spring_boot_starter_test",
     "@maven//:junit_junit",
 ]
 
-MODULE_DEPS = SPRING_DEPS + KOTLIN_DEPS
+MODULE_DEPS = KOTLIN_DEPS

--- a/systems/configuration/configuration-application/src/main/kotlin/hs/kr/entrydsm/ExampleApplication.kt
+++ b/systems/configuration/configuration-application/src/main/kotlin/hs/kr/entrydsm/ExampleApplication.kt
@@ -1,11 +1,3 @@
-package hs.kr.entrydsm.example
+package hs.kr.entrydsm.configuration.application
 
-import org.springframework.boot.autoconfigure.SpringBootApplication
-import org.springframework.boot.runApplication
-
-@SpringBootApplication
-class ExampleApplication
-
-fun main(args: Array<String>) {
-    runApplication<ExampleApplication>(*args)
-}
+class ConfigurationApplicationModule

--- a/systems/configuration/configuration-application/src/test/kotlin/hs/kr/entrydsm/TestMain.kt
+++ b/systems/configuration/configuration-application/src/test/kotlin/hs/kr/entrydsm/TestMain.kt
@@ -1,11 +1,11 @@
-package hs.kr.entrydsm.example
+package hs.kr.entrydsm.configuration.application
 
-import org.junit.Assert.assertEquals
+import org.junit.Assert.assertTrue
 import org.junit.Test
 
-class ExampleApplicationTest {
+class ConfigurationApplicationModuleTest {
     @Test
-    fun contextLoads() {
-        assertEquals(4, 2 + 2)
+    fun moduleLoads() {
+        assertTrue(true)
     }
 }

--- a/systems/configuration/configuration-bootstrap/BUILD.bazel
+++ b/systems/configuration/configuration-bootstrap/BUILD.bazel
@@ -1,14 +1,20 @@
 load("@rules_kotlin//kotlin:jvm.bzl", "kt_jvm_binary", "kt_jvm_test")
-load("//systems/admission/module-a:deps.bzl", "MODULE_DEPS", "TEST_DEPS")
+load(":deps.bzl", "MODULE_DEPS", "TEST_DEPS")
 
 package(default_visibility = ["//visibility:public"])
 
 kt_jvm_binary(
     name = "main",
     srcs = glob(["src/main/kotlin/**/*.kt"]),
-    main_class = "hs.kr.entrydsm.example.ExampleApplicationKt",
+    resources = glob(["src/main/resources/**"]),
+    main_class = "hs.kr.entrydsm.configuration.ConfigurationBootstrapApplicationKt",
     plugins = ["//:spring_allopen"],
-    deps = MODULE_DEPS,
+    deps = MODULE_DEPS + [
+        "//systems/configuration/configuration-adapter-in:main",
+        "//systems/configuration/configuration-adapter-out:main",
+        "//systems/configuration/configuration-application:main",
+        "//systems/configuration/configuration-domain:main",
+    ],
     javac_opts = "//:javac_options",
     kotlinc_opts = "//:kotlinc_options",
 )
@@ -16,7 +22,7 @@ kt_jvm_binary(
 kt_jvm_test(
     name = "test",
     srcs = glob(["src/test/kotlin/**/*.kt"]),
-    test_class = "hs.kr.entrydsm.example.ExampleApplicationTest",
+    test_class = "hs.kr.entrydsm.configuration.ConfigurationBootstrapApplicationTest",
     plugins = ["//:spring_allopen"],
     deps = MODULE_DEPS + TEST_DEPS,
     javac_opts = "//:javac_options",

--- a/systems/configuration/configuration-bootstrap/src/main/kotlin/hs/kr/entrydsm/ExampleApplication.kt
+++ b/systems/configuration/configuration-bootstrap/src/main/kotlin/hs/kr/entrydsm/ExampleApplication.kt
@@ -1,11 +1,11 @@
-package hs.kr.entrydsm.example
+package hs.kr.entrydsm.configuration
 
 import org.springframework.boot.autoconfigure.SpringBootApplication
 import org.springframework.boot.runApplication
 
 @SpringBootApplication
-class ExampleApplication
+class ConfigurationBootstrapApplication
 
 fun main(args: Array<String>) {
-    runApplication<ExampleApplication>(*args)
+    runApplication<ConfigurationBootstrapApplication>(*args)
 }

--- a/systems/configuration/configuration-bootstrap/src/main/resources/application.yaml
+++ b/systems/configuration/configuration-bootstrap/src/main/resources/application.yaml
@@ -1,0 +1,21 @@
+spring:
+  application:
+    name: configuration
+  profiles:
+    default: local
+  main:
+    lazy-initialization: true
+server:
+  shutdown: graceful
+management:
+  endpoints:
+    web:
+      exposure:
+        include: health,info
+  endpoint:
+    health:
+      probes:
+        enabled: true
+logging:
+  level:
+    root: INFO

--- a/systems/configuration/configuration-bootstrap/src/test/kotlin/hs/kr/entrydsm/TestMain.kt
+++ b/systems/configuration/configuration-bootstrap/src/test/kotlin/hs/kr/entrydsm/TestMain.kt
@@ -1,11 +1,11 @@
-package hs.kr.entrydsm.example
+package hs.kr.entrydsm.configuration
 
-import org.junit.Assert.assertEquals
+import org.junit.Assert.assertTrue
 import org.junit.Test
 
-class ExampleApplicationTest {
+class ConfigurationBootstrapApplicationTest {
     @Test
     fun contextLoads() {
-        assertEquals(4, 2 + 2)
+        assertTrue(true)
     }
 }

--- a/systems/configuration/configuration-domain/BUILD.bazel
+++ b/systems/configuration/configuration-domain/BUILD.bazel
@@ -1,13 +1,11 @@
-load("@rules_kotlin//kotlin:jvm.bzl", "kt_jvm_binary", "kt_jvm_test")
-load("//systems/admission/module-a:deps.bzl", "MODULE_DEPS", "TEST_DEPS")
+load("@rules_kotlin//kotlin:jvm.bzl", "kt_jvm_library", "kt_jvm_test")
+load(":deps.bzl", "MODULE_DEPS", "TEST_DEPS")
 
 package(default_visibility = ["//visibility:public"])
 
-kt_jvm_binary(
+kt_jvm_library(
     name = "main",
     srcs = glob(["src/main/kotlin/**/*.kt"]),
-    main_class = "hs.kr.entrydsm.example.ExampleApplicationKt",
-    plugins = ["//:spring_allopen"],
     deps = MODULE_DEPS,
     javac_opts = "//:javac_options",
     kotlinc_opts = "//:kotlinc_options",
@@ -16,8 +14,7 @@ kt_jvm_binary(
 kt_jvm_test(
     name = "test",
     srcs = glob(["src/test/kotlin/**/*.kt"]),
-    test_class = "hs.kr.entrydsm.example.ExampleApplicationTest",
-    plugins = ["//:spring_allopen"],
+    test_class = "hs.kr.entrydsm.configuration.domain.ConfigurationDomainModuleTest",
     deps = MODULE_DEPS + TEST_DEPS,
     javac_opts = "//:javac_options",
     kotlinc_opts = "//:kotlinc_options",

--- a/systems/configuration/configuration-domain/deps.bzl
+++ b/systems/configuration/configuration-domain/deps.bzl
@@ -1,16 +1,7 @@
-SPRING_DEPS = [
-    "@maven//:org_springframework_boot_spring_boot_starter_web",
-    "@maven//:org_springframework_boot_spring_boot_starter_actuator",
-]
-
-KOTLIN_DEPS = [
-    "@maven//:org_jetbrains_kotlin_kotlin_reflect",
-    "@maven//:com_fasterxml_jackson_module_jackson_module_kotlin",
-]
+KOTLIN_DEPS = []
 
 TEST_DEPS = [
-    "@maven//:org_springframework_boot_spring_boot_starter_test",
     "@maven//:junit_junit",
 ]
 
-MODULE_DEPS = SPRING_DEPS + KOTLIN_DEPS
+MODULE_DEPS = KOTLIN_DEPS

--- a/systems/configuration/configuration-domain/src/main/kotlin/hs/kr/entrydsm/ExampleApplication.kt
+++ b/systems/configuration/configuration-domain/src/main/kotlin/hs/kr/entrydsm/ExampleApplication.kt
@@ -1,11 +1,3 @@
-package hs.kr.entrydsm.example
+package hs.kr.entrydsm.configuration.domain
 
-import org.springframework.boot.autoconfigure.SpringBootApplication
-import org.springframework.boot.runApplication
-
-@SpringBootApplication
-class ExampleApplication
-
-fun main(args: Array<String>) {
-    runApplication<ExampleApplication>(*args)
-}
+class ConfigurationDomainModule

--- a/systems/configuration/configuration-domain/src/test/kotlin/hs/kr/entrydsm/TestMain.kt
+++ b/systems/configuration/configuration-domain/src/test/kotlin/hs/kr/entrydsm/TestMain.kt
@@ -1,11 +1,11 @@
-package hs.kr.entrydsm.example
+package hs.kr.entrydsm.configuration.domain
 
-import org.junit.Assert.assertEquals
+import org.junit.Assert.assertTrue
 import org.junit.Test
 
-class ExampleApplicationTest {
+class ConfigurationDomainModuleTest {
     @Test
-    fun contextLoads() {
-        assertEquals(4, 2 + 2)
+    fun moduleLoads() {
+        assertTrue(true)
     }
 }

--- a/systems/document/document-adapter-in/BUILD.bazel
+++ b/systems/document/document-adapter-in/BUILD.bazel
@@ -1,13 +1,11 @@
-load("@rules_kotlin//kotlin:jvm.bzl", "kt_jvm_binary", "kt_jvm_test")
-load("//systems/admission/module-a:deps.bzl", "MODULE_DEPS", "TEST_DEPS")
+load("@rules_kotlin//kotlin:jvm.bzl", "kt_jvm_library", "kt_jvm_test")
+load(":deps.bzl", "MODULE_DEPS", "TEST_DEPS")
 
 package(default_visibility = ["//visibility:public"])
 
-kt_jvm_binary(
+kt_jvm_library(
     name = "main",
     srcs = glob(["src/main/kotlin/**/*.kt"]),
-    main_class = "hs.kr.entrydsm.example.ExampleApplicationKt",
-    plugins = ["//:spring_allopen"],
     deps = MODULE_DEPS,
     javac_opts = "//:javac_options",
     kotlinc_opts = "//:kotlinc_options",
@@ -16,8 +14,7 @@ kt_jvm_binary(
 kt_jvm_test(
     name = "test",
     srcs = glob(["src/test/kotlin/**/*.kt"]),
-    test_class = "hs.kr.entrydsm.example.ExampleApplicationTest",
-    plugins = ["//:spring_allopen"],
+    test_class = "hs.kr.entrydsm.document.adapterin.DocumentAdapterInModuleTest",
     deps = MODULE_DEPS + TEST_DEPS,
     javac_opts = "//:javac_options",
     kotlinc_opts = "//:kotlinc_options",

--- a/systems/document/document-adapter-in/deps.bzl
+++ b/systems/document/document-adapter-in/deps.bzl
@@ -1,16 +1,7 @@
-SPRING_DEPS = [
-    "@maven//:org_springframework_boot_spring_boot_starter_web",
-    "@maven//:org_springframework_boot_spring_boot_starter_actuator",
-]
-
-KOTLIN_DEPS = [
-    "@maven//:org_jetbrains_kotlin_kotlin_reflect",
-    "@maven//:com_fasterxml_jackson_module_jackson_module_kotlin",
-]
+KOTLIN_DEPS = []
 
 TEST_DEPS = [
-    "@maven//:org_springframework_boot_spring_boot_starter_test",
     "@maven//:junit_junit",
 ]
 
-MODULE_DEPS = SPRING_DEPS + KOTLIN_DEPS
+MODULE_DEPS = KOTLIN_DEPS

--- a/systems/document/document-adapter-in/src/main/kotlin/hs/kr/entrydsm/ExampleApplication.kt
+++ b/systems/document/document-adapter-in/src/main/kotlin/hs/kr/entrydsm/ExampleApplication.kt
@@ -1,11 +1,3 @@
-package hs.kr.entrydsm.example
+package hs.kr.entrydsm.document.adapterin
 
-import org.springframework.boot.autoconfigure.SpringBootApplication
-import org.springframework.boot.runApplication
-
-@SpringBootApplication
-class ExampleApplication
-
-fun main(args: Array<String>) {
-    runApplication<ExampleApplication>(*args)
-}
+class DocumentAdapterInModule

--- a/systems/document/document-adapter-in/src/test/kotlin/hs/kr/entrydsm/TestMain.kt
+++ b/systems/document/document-adapter-in/src/test/kotlin/hs/kr/entrydsm/TestMain.kt
@@ -1,11 +1,11 @@
-package hs.kr.entrydsm.example
+package hs.kr.entrydsm.document.adapterin
 
-import org.junit.Assert.assertEquals
+import org.junit.Assert.assertTrue
 import org.junit.Test
 
-class ExampleApplicationTest {
+class DocumentAdapterInModuleTest {
     @Test
-    fun contextLoads() {
-        assertEquals(4, 2 + 2)
+    fun moduleLoads() {
+        assertTrue(true)
     }
 }

--- a/systems/document/document-adapter-out/BUILD.bazel
+++ b/systems/document/document-adapter-out/BUILD.bazel
@@ -1,13 +1,11 @@
-load("@rules_kotlin//kotlin:jvm.bzl", "kt_jvm_binary", "kt_jvm_test")
-load("//systems/admission/module-a:deps.bzl", "MODULE_DEPS", "TEST_DEPS")
+load("@rules_kotlin//kotlin:jvm.bzl", "kt_jvm_library", "kt_jvm_test")
+load(":deps.bzl", "MODULE_DEPS", "TEST_DEPS")
 
 package(default_visibility = ["//visibility:public"])
 
-kt_jvm_binary(
+kt_jvm_library(
     name = "main",
     srcs = glob(["src/main/kotlin/**/*.kt"]),
-    main_class = "hs.kr.entrydsm.example.ExampleApplicationKt",
-    plugins = ["//:spring_allopen"],
     deps = MODULE_DEPS,
     javac_opts = "//:javac_options",
     kotlinc_opts = "//:kotlinc_options",
@@ -16,8 +14,7 @@ kt_jvm_binary(
 kt_jvm_test(
     name = "test",
     srcs = glob(["src/test/kotlin/**/*.kt"]),
-    test_class = "hs.kr.entrydsm.example.ExampleApplicationTest",
-    plugins = ["//:spring_allopen"],
+    test_class = "hs.kr.entrydsm.document.adapterout.DocumentAdapterOutModuleTest",
     deps = MODULE_DEPS + TEST_DEPS,
     javac_opts = "//:javac_options",
     kotlinc_opts = "//:kotlinc_options",

--- a/systems/document/document-adapter-out/deps.bzl
+++ b/systems/document/document-adapter-out/deps.bzl
@@ -1,16 +1,7 @@
-SPRING_DEPS = [
-    "@maven//:org_springframework_boot_spring_boot_starter_web",
-    "@maven//:org_springframework_boot_spring_boot_starter_actuator",
-]
-
-KOTLIN_DEPS = [
-    "@maven//:org_jetbrains_kotlin_kotlin_reflect",
-    "@maven//:com_fasterxml_jackson_module_jackson_module_kotlin",
-]
+KOTLIN_DEPS = []
 
 TEST_DEPS = [
-    "@maven//:org_springframework_boot_spring_boot_starter_test",
     "@maven//:junit_junit",
 ]
 
-MODULE_DEPS = SPRING_DEPS + KOTLIN_DEPS
+MODULE_DEPS = KOTLIN_DEPS

--- a/systems/document/document-adapter-out/src/main/kotlin/hs/kr/entrydsm/ExampleApplication.kt
+++ b/systems/document/document-adapter-out/src/main/kotlin/hs/kr/entrydsm/ExampleApplication.kt
@@ -1,11 +1,3 @@
-package hs.kr.entrydsm.example
+package hs.kr.entrydsm.document.adapterout
 
-import org.springframework.boot.autoconfigure.SpringBootApplication
-import org.springframework.boot.runApplication
-
-@SpringBootApplication
-class ExampleApplication
-
-fun main(args: Array<String>) {
-    runApplication<ExampleApplication>(*args)
-}
+class DocumentAdapterOutModule

--- a/systems/document/document-adapter-out/src/test/kotlin/hs/kr/entrydsm/TestMain.kt
+++ b/systems/document/document-adapter-out/src/test/kotlin/hs/kr/entrydsm/TestMain.kt
@@ -1,11 +1,11 @@
-package hs.kr.entrydsm.example
+package hs.kr.entrydsm.document.adapterout
 
-import org.junit.Assert.assertEquals
+import org.junit.Assert.assertTrue
 import org.junit.Test
 
-class ExampleApplicationTest {
+class DocumentAdapterOutModuleTest {
     @Test
-    fun contextLoads() {
-        assertEquals(4, 2 + 2)
+    fun moduleLoads() {
+        assertTrue(true)
     }
 }

--- a/systems/document/document-application/BUILD.bazel
+++ b/systems/document/document-application/BUILD.bazel
@@ -1,13 +1,11 @@
-load("@rules_kotlin//kotlin:jvm.bzl", "kt_jvm_binary", "kt_jvm_test")
-load("//systems/admission/module-a:deps.bzl", "MODULE_DEPS", "TEST_DEPS")
+load("@rules_kotlin//kotlin:jvm.bzl", "kt_jvm_library", "kt_jvm_test")
+load(":deps.bzl", "MODULE_DEPS", "TEST_DEPS")
 
 package(default_visibility = ["//visibility:public"])
 
-kt_jvm_binary(
+kt_jvm_library(
     name = "main",
     srcs = glob(["src/main/kotlin/**/*.kt"]),
-    main_class = "hs.kr.entrydsm.example.ExampleApplicationKt",
-    plugins = ["//:spring_allopen"],
     deps = MODULE_DEPS,
     javac_opts = "//:javac_options",
     kotlinc_opts = "//:kotlinc_options",
@@ -16,8 +14,7 @@ kt_jvm_binary(
 kt_jvm_test(
     name = "test",
     srcs = glob(["src/test/kotlin/**/*.kt"]),
-    test_class = "hs.kr.entrydsm.example.ExampleApplicationTest",
-    plugins = ["//:spring_allopen"],
+    test_class = "hs.kr.entrydsm.document.application.DocumentApplicationModuleTest",
     deps = MODULE_DEPS + TEST_DEPS,
     javac_opts = "//:javac_options",
     kotlinc_opts = "//:kotlinc_options",

--- a/systems/document/document-application/deps.bzl
+++ b/systems/document/document-application/deps.bzl
@@ -1,16 +1,7 @@
-SPRING_DEPS = [
-    "@maven//:org_springframework_boot_spring_boot_starter_web",
-    "@maven//:org_springframework_boot_spring_boot_starter_actuator",
-]
-
-KOTLIN_DEPS = [
-    "@maven//:org_jetbrains_kotlin_kotlin_reflect",
-    "@maven//:com_fasterxml_jackson_module_jackson_module_kotlin",
-]
+KOTLIN_DEPS = []
 
 TEST_DEPS = [
-    "@maven//:org_springframework_boot_spring_boot_starter_test",
     "@maven//:junit_junit",
 ]
 
-MODULE_DEPS = SPRING_DEPS + KOTLIN_DEPS
+MODULE_DEPS = KOTLIN_DEPS

--- a/systems/document/document-application/src/main/kotlin/hs/kr/entrydsm/ExampleApplication.kt
+++ b/systems/document/document-application/src/main/kotlin/hs/kr/entrydsm/ExampleApplication.kt
@@ -1,11 +1,3 @@
-package hs.kr.entrydsm.example
+package hs.kr.entrydsm.document.application
 
-import org.springframework.boot.autoconfigure.SpringBootApplication
-import org.springframework.boot.runApplication
-
-@SpringBootApplication
-class ExampleApplication
-
-fun main(args: Array<String>) {
-    runApplication<ExampleApplication>(*args)
-}
+class DocumentApplicationModule

--- a/systems/document/document-application/src/test/kotlin/hs/kr/entrydsm/TestMain.kt
+++ b/systems/document/document-application/src/test/kotlin/hs/kr/entrydsm/TestMain.kt
@@ -1,11 +1,11 @@
-package hs.kr.entrydsm.example
+package hs.kr.entrydsm.document.application
 
-import org.junit.Assert.assertEquals
+import org.junit.Assert.assertTrue
 import org.junit.Test
 
-class ExampleApplicationTest {
+class DocumentApplicationModuleTest {
     @Test
-    fun contextLoads() {
-        assertEquals(4, 2 + 2)
+    fun moduleLoads() {
+        assertTrue(true)
     }
 }

--- a/systems/document/document-bootstrap/BUILD.bazel
+++ b/systems/document/document-bootstrap/BUILD.bazel
@@ -1,14 +1,20 @@
 load("@rules_kotlin//kotlin:jvm.bzl", "kt_jvm_binary", "kt_jvm_test")
-load("//systems/admission/module-a:deps.bzl", "MODULE_DEPS", "TEST_DEPS")
+load(":deps.bzl", "MODULE_DEPS", "TEST_DEPS")
 
 package(default_visibility = ["//visibility:public"])
 
 kt_jvm_binary(
     name = "main",
     srcs = glob(["src/main/kotlin/**/*.kt"]),
-    main_class = "hs.kr.entrydsm.example.ExampleApplicationKt",
+    resources = glob(["src/main/resources/**"]),
+    main_class = "hs.kr.entrydsm.document.DocumentBootstrapApplicationKt",
     plugins = ["//:spring_allopen"],
-    deps = MODULE_DEPS,
+    deps = MODULE_DEPS + [
+        "//systems/document/document-adapter-in:main",
+        "//systems/document/document-adapter-out:main",
+        "//systems/document/document-application:main",
+        "//systems/document/document-domain:main",
+    ],
     javac_opts = "//:javac_options",
     kotlinc_opts = "//:kotlinc_options",
 )
@@ -16,7 +22,7 @@ kt_jvm_binary(
 kt_jvm_test(
     name = "test",
     srcs = glob(["src/test/kotlin/**/*.kt"]),
-    test_class = "hs.kr.entrydsm.example.ExampleApplicationTest",
+    test_class = "hs.kr.entrydsm.document.DocumentBootstrapApplicationTest",
     plugins = ["//:spring_allopen"],
     deps = MODULE_DEPS + TEST_DEPS,
     javac_opts = "//:javac_options",

--- a/systems/document/document-bootstrap/src/main/kotlin/hs/kr/entrydsm/ExampleApplication.kt
+++ b/systems/document/document-bootstrap/src/main/kotlin/hs/kr/entrydsm/ExampleApplication.kt
@@ -1,11 +1,11 @@
-package hs.kr.entrydsm.example
+package hs.kr.entrydsm.document
 
 import org.springframework.boot.autoconfigure.SpringBootApplication
 import org.springframework.boot.runApplication
 
 @SpringBootApplication
-class ExampleApplication
+class DocumentBootstrapApplication
 
 fun main(args: Array<String>) {
-    runApplication<ExampleApplication>(*args)
+    runApplication<DocumentBootstrapApplication>(*args)
 }

--- a/systems/document/document-bootstrap/src/main/resources/application.yaml
+++ b/systems/document/document-bootstrap/src/main/resources/application.yaml
@@ -1,0 +1,21 @@
+spring:
+  application:
+    name: document
+  profiles:
+    default: local
+  main:
+    lazy-initialization: true
+server:
+  shutdown: graceful
+management:
+  endpoints:
+    web:
+      exposure:
+        include: health,info
+  endpoint:
+    health:
+      probes:
+        enabled: true
+logging:
+  level:
+    root: INFO

--- a/systems/document/document-bootstrap/src/test/kotlin/hs/kr/entrydsm/TestMain.kt
+++ b/systems/document/document-bootstrap/src/test/kotlin/hs/kr/entrydsm/TestMain.kt
@@ -1,11 +1,11 @@
-package hs.kr.entrydsm.example
+package hs.kr.entrydsm.document
 
-import org.junit.Assert.assertEquals
+import org.junit.Assert.assertTrue
 import org.junit.Test
 
-class ExampleApplicationTest {
+class DocumentBootstrapApplicationTest {
     @Test
     fun contextLoads() {
-        assertEquals(4, 2 + 2)
+        assertTrue(true)
     }
 }

--- a/systems/document/document-domain/BUILD.bazel
+++ b/systems/document/document-domain/BUILD.bazel
@@ -1,13 +1,11 @@
-load("@rules_kotlin//kotlin:jvm.bzl", "kt_jvm_binary", "kt_jvm_test")
-load("//systems/admission/module-a:deps.bzl", "MODULE_DEPS", "TEST_DEPS")
+load("@rules_kotlin//kotlin:jvm.bzl", "kt_jvm_library", "kt_jvm_test")
+load(":deps.bzl", "MODULE_DEPS", "TEST_DEPS")
 
 package(default_visibility = ["//visibility:public"])
 
-kt_jvm_binary(
+kt_jvm_library(
     name = "main",
     srcs = glob(["src/main/kotlin/**/*.kt"]),
-    main_class = "hs.kr.entrydsm.example.ExampleApplicationKt",
-    plugins = ["//:spring_allopen"],
     deps = MODULE_DEPS,
     javac_opts = "//:javac_options",
     kotlinc_opts = "//:kotlinc_options",
@@ -16,8 +14,7 @@ kt_jvm_binary(
 kt_jvm_test(
     name = "test",
     srcs = glob(["src/test/kotlin/**/*.kt"]),
-    test_class = "hs.kr.entrydsm.example.ExampleApplicationTest",
-    plugins = ["//:spring_allopen"],
+    test_class = "hs.kr.entrydsm.document.domain.DocumentDomainModuleTest",
     deps = MODULE_DEPS + TEST_DEPS,
     javac_opts = "//:javac_options",
     kotlinc_opts = "//:kotlinc_options",

--- a/systems/document/document-domain/deps.bzl
+++ b/systems/document/document-domain/deps.bzl
@@ -1,16 +1,7 @@
-SPRING_DEPS = [
-    "@maven//:org_springframework_boot_spring_boot_starter_web",
-    "@maven//:org_springframework_boot_spring_boot_starter_actuator",
-]
-
-KOTLIN_DEPS = [
-    "@maven//:org_jetbrains_kotlin_kotlin_reflect",
-    "@maven//:com_fasterxml_jackson_module_jackson_module_kotlin",
-]
+KOTLIN_DEPS = []
 
 TEST_DEPS = [
-    "@maven//:org_springframework_boot_spring_boot_starter_test",
     "@maven//:junit_junit",
 ]
 
-MODULE_DEPS = SPRING_DEPS + KOTLIN_DEPS
+MODULE_DEPS = KOTLIN_DEPS

--- a/systems/document/document-domain/src/main/kotlin/hs/kr/entrydsm/ExampleApplication.kt
+++ b/systems/document/document-domain/src/main/kotlin/hs/kr/entrydsm/ExampleApplication.kt
@@ -1,11 +1,3 @@
-package hs.kr.entrydsm.example
+package hs.kr.entrydsm.document.domain
 
-import org.springframework.boot.autoconfigure.SpringBootApplication
-import org.springframework.boot.runApplication
-
-@SpringBootApplication
-class ExampleApplication
-
-fun main(args: Array<String>) {
-    runApplication<ExampleApplication>(*args)
-}
+class DocumentDomainModule

--- a/systems/document/document-domain/src/test/kotlin/hs/kr/entrydsm/TestMain.kt
+++ b/systems/document/document-domain/src/test/kotlin/hs/kr/entrydsm/TestMain.kt
@@ -1,11 +1,11 @@
-package hs.kr.entrydsm.example
+package hs.kr.entrydsm.document.domain
 
-import org.junit.Assert.assertEquals
+import org.junit.Assert.assertTrue
 import org.junit.Test
 
-class ExampleApplicationTest {
+class DocumentDomainModuleTest {
     @Test
-    fun contextLoads() {
-        assertEquals(4, 2 + 2)
+    fun moduleLoads() {
+        assertTrue(true)
     }
 }

--- a/systems/gateway/gateway-adapter-in/BUILD.bazel
+++ b/systems/gateway/gateway-adapter-in/BUILD.bazel
@@ -1,13 +1,11 @@
-load("@rules_kotlin//kotlin:jvm.bzl", "kt_jvm_binary", "kt_jvm_test")
-load("//systems/admission/module-a:deps.bzl", "MODULE_DEPS", "TEST_DEPS")
+load("@rules_kotlin//kotlin:jvm.bzl", "kt_jvm_library", "kt_jvm_test")
+load(":deps.bzl", "MODULE_DEPS", "TEST_DEPS")
 
 package(default_visibility = ["//visibility:public"])
 
-kt_jvm_binary(
+kt_jvm_library(
     name = "main",
     srcs = glob(["src/main/kotlin/**/*.kt"]),
-    main_class = "hs.kr.entrydsm.example.ExampleApplicationKt",
-    plugins = ["//:spring_allopen"],
     deps = MODULE_DEPS,
     javac_opts = "//:javac_options",
     kotlinc_opts = "//:kotlinc_options",
@@ -16,8 +14,7 @@ kt_jvm_binary(
 kt_jvm_test(
     name = "test",
     srcs = glob(["src/test/kotlin/**/*.kt"]),
-    test_class = "hs.kr.entrydsm.example.ExampleApplicationTest",
-    plugins = ["//:spring_allopen"],
+    test_class = "hs.kr.entrydsm.gateway.adapterin.GatewayAdapterInModuleTest",
     deps = MODULE_DEPS + TEST_DEPS,
     javac_opts = "//:javac_options",
     kotlinc_opts = "//:kotlinc_options",

--- a/systems/gateway/gateway-adapter-in/deps.bzl
+++ b/systems/gateway/gateway-adapter-in/deps.bzl
@@ -1,16 +1,7 @@
-SPRING_DEPS = [
-    "@maven//:org_springframework_boot_spring_boot_starter_web",
-    "@maven//:org_springframework_boot_spring_boot_starter_actuator",
-]
-
-KOTLIN_DEPS = [
-    "@maven//:org_jetbrains_kotlin_kotlin_reflect",
-    "@maven//:com_fasterxml_jackson_module_jackson_module_kotlin",
-]
+KOTLIN_DEPS = []
 
 TEST_DEPS = [
-    "@maven//:org_springframework_boot_spring_boot_starter_test",
     "@maven//:junit_junit",
 ]
 
-MODULE_DEPS = SPRING_DEPS + KOTLIN_DEPS
+MODULE_DEPS = KOTLIN_DEPS

--- a/systems/gateway/gateway-adapter-in/src/main/kotlin/hs/kr/entrydsm/ExampleApplication.kt
+++ b/systems/gateway/gateway-adapter-in/src/main/kotlin/hs/kr/entrydsm/ExampleApplication.kt
@@ -1,11 +1,3 @@
-package hs.kr.entrydsm.example
+package hs.kr.entrydsm.gateway.adapterin
 
-import org.springframework.boot.autoconfigure.SpringBootApplication
-import org.springframework.boot.runApplication
-
-@SpringBootApplication
-class ExampleApplication
-
-fun main(args: Array<String>) {
-    runApplication<ExampleApplication>(*args)
-}
+class GatewayAdapterInModule

--- a/systems/gateway/gateway-adapter-in/src/test/kotlin/hs/kr/entrydsm/TestMain.kt
+++ b/systems/gateway/gateway-adapter-in/src/test/kotlin/hs/kr/entrydsm/TestMain.kt
@@ -1,11 +1,11 @@
-package hs.kr.entrydsm.example
+package hs.kr.entrydsm.gateway.adapterin
 
-import org.junit.Assert.assertEquals
+import org.junit.Assert.assertTrue
 import org.junit.Test
 
-class ExampleApplicationTest {
+class GatewayAdapterInModuleTest {
     @Test
-    fun contextLoads() {
-        assertEquals(4, 2 + 2)
+    fun moduleLoads() {
+        assertTrue(true)
     }
 }

--- a/systems/gateway/gateway-adapter-out/BUILD.bazel
+++ b/systems/gateway/gateway-adapter-out/BUILD.bazel
@@ -1,13 +1,11 @@
-load("@rules_kotlin//kotlin:jvm.bzl", "kt_jvm_binary", "kt_jvm_test")
-load("//systems/admission/module-a:deps.bzl", "MODULE_DEPS", "TEST_DEPS")
+load("@rules_kotlin//kotlin:jvm.bzl", "kt_jvm_library", "kt_jvm_test")
+load(":deps.bzl", "MODULE_DEPS", "TEST_DEPS")
 
 package(default_visibility = ["//visibility:public"])
 
-kt_jvm_binary(
+kt_jvm_library(
     name = "main",
     srcs = glob(["src/main/kotlin/**/*.kt"]),
-    main_class = "hs.kr.entrydsm.example.ExampleApplicationKt",
-    plugins = ["//:spring_allopen"],
     deps = MODULE_DEPS,
     javac_opts = "//:javac_options",
     kotlinc_opts = "//:kotlinc_options",
@@ -16,8 +14,7 @@ kt_jvm_binary(
 kt_jvm_test(
     name = "test",
     srcs = glob(["src/test/kotlin/**/*.kt"]),
-    test_class = "hs.kr.entrydsm.example.ExampleApplicationTest",
-    plugins = ["//:spring_allopen"],
+    test_class = "hs.kr.entrydsm.gateway.adapterout.GatewayAdapterOutModuleTest",
     deps = MODULE_DEPS + TEST_DEPS,
     javac_opts = "//:javac_options",
     kotlinc_opts = "//:kotlinc_options",

--- a/systems/gateway/gateway-adapter-out/deps.bzl
+++ b/systems/gateway/gateway-adapter-out/deps.bzl
@@ -1,16 +1,7 @@
-SPRING_DEPS = [
-    "@maven//:org_springframework_boot_spring_boot_starter_web",
-    "@maven//:org_springframework_boot_spring_boot_starter_actuator",
-]
-
-KOTLIN_DEPS = [
-    "@maven//:org_jetbrains_kotlin_kotlin_reflect",
-    "@maven//:com_fasterxml_jackson_module_jackson_module_kotlin",
-]
+KOTLIN_DEPS = []
 
 TEST_DEPS = [
-    "@maven//:org_springframework_boot_spring_boot_starter_test",
     "@maven//:junit_junit",
 ]
 
-MODULE_DEPS = SPRING_DEPS + KOTLIN_DEPS
+MODULE_DEPS = KOTLIN_DEPS

--- a/systems/gateway/gateway-adapter-out/src/main/kotlin/hs/kr/entrydsm/ExampleApplication.kt
+++ b/systems/gateway/gateway-adapter-out/src/main/kotlin/hs/kr/entrydsm/ExampleApplication.kt
@@ -1,11 +1,3 @@
-package hs.kr.entrydsm.example
+package hs.kr.entrydsm.gateway.adapterout
 
-import org.springframework.boot.autoconfigure.SpringBootApplication
-import org.springframework.boot.runApplication
-
-@SpringBootApplication
-class ExampleApplication
-
-fun main(args: Array<String>) {
-    runApplication<ExampleApplication>(*args)
-}
+class GatewayAdapterOutModule

--- a/systems/gateway/gateway-adapter-out/src/test/kotlin/hs/kr/entrydsm/TestMain.kt
+++ b/systems/gateway/gateway-adapter-out/src/test/kotlin/hs/kr/entrydsm/TestMain.kt
@@ -1,11 +1,11 @@
-package hs.kr.entrydsm.example
+package hs.kr.entrydsm.gateway.adapterout
 
-import org.junit.Assert.assertEquals
+import org.junit.Assert.assertTrue
 import org.junit.Test
 
-class ExampleApplicationTest {
+class GatewayAdapterOutModuleTest {
     @Test
-    fun contextLoads() {
-        assertEquals(4, 2 + 2)
+    fun moduleLoads() {
+        assertTrue(true)
     }
 }

--- a/systems/gateway/gateway-application/BUILD.bazel
+++ b/systems/gateway/gateway-application/BUILD.bazel
@@ -1,13 +1,11 @@
-load("@rules_kotlin//kotlin:jvm.bzl", "kt_jvm_binary", "kt_jvm_test")
-load("//systems/admission/module-a:deps.bzl", "MODULE_DEPS", "TEST_DEPS")
+load("@rules_kotlin//kotlin:jvm.bzl", "kt_jvm_library", "kt_jvm_test")
+load(":deps.bzl", "MODULE_DEPS", "TEST_DEPS")
 
 package(default_visibility = ["//visibility:public"])
 
-kt_jvm_binary(
+kt_jvm_library(
     name = "main",
     srcs = glob(["src/main/kotlin/**/*.kt"]),
-    main_class = "hs.kr.entrydsm.example.ExampleApplicationKt",
-    plugins = ["//:spring_allopen"],
     deps = MODULE_DEPS,
     javac_opts = "//:javac_options",
     kotlinc_opts = "//:kotlinc_options",
@@ -16,8 +14,7 @@ kt_jvm_binary(
 kt_jvm_test(
     name = "test",
     srcs = glob(["src/test/kotlin/**/*.kt"]),
-    test_class = "hs.kr.entrydsm.example.ExampleApplicationTest",
-    plugins = ["//:spring_allopen"],
+    test_class = "hs.kr.entrydsm.gateway.application.GatewayApplicationModuleTest",
     deps = MODULE_DEPS + TEST_DEPS,
     javac_opts = "//:javac_options",
     kotlinc_opts = "//:kotlinc_options",

--- a/systems/gateway/gateway-application/deps.bzl
+++ b/systems/gateway/gateway-application/deps.bzl
@@ -1,16 +1,7 @@
-SPRING_DEPS = [
-    "@maven//:org_springframework_boot_spring_boot_starter_web",
-    "@maven//:org_springframework_boot_spring_boot_starter_actuator",
-]
-
-KOTLIN_DEPS = [
-    "@maven//:org_jetbrains_kotlin_kotlin_reflect",
-    "@maven//:com_fasterxml_jackson_module_jackson_module_kotlin",
-]
+KOTLIN_DEPS = []
 
 TEST_DEPS = [
-    "@maven//:org_springframework_boot_spring_boot_starter_test",
     "@maven//:junit_junit",
 ]
 
-MODULE_DEPS = SPRING_DEPS + KOTLIN_DEPS
+MODULE_DEPS = KOTLIN_DEPS

--- a/systems/gateway/gateway-application/src/main/kotlin/hs/kr/entrydsm/ExampleApplication.kt
+++ b/systems/gateway/gateway-application/src/main/kotlin/hs/kr/entrydsm/ExampleApplication.kt
@@ -1,11 +1,3 @@
-package hs.kr.entrydsm.example
+package hs.kr.entrydsm.gateway.application
 
-import org.springframework.boot.autoconfigure.SpringBootApplication
-import org.springframework.boot.runApplication
-
-@SpringBootApplication
-class ExampleApplication
-
-fun main(args: Array<String>) {
-    runApplication<ExampleApplication>(*args)
-}
+class GatewayApplicationModule

--- a/systems/gateway/gateway-application/src/test/kotlin/hs/kr/entrydsm/TestMain.kt
+++ b/systems/gateway/gateway-application/src/test/kotlin/hs/kr/entrydsm/TestMain.kt
@@ -1,11 +1,11 @@
-package hs.kr.entrydsm.example
+package hs.kr.entrydsm.gateway.application
 
-import org.junit.Assert.assertEquals
+import org.junit.Assert.assertTrue
 import org.junit.Test
 
-class ExampleApplicationTest {
+class GatewayApplicationModuleTest {
     @Test
-    fun contextLoads() {
-        assertEquals(4, 2 + 2)
+    fun moduleLoads() {
+        assertTrue(true)
     }
 }

--- a/systems/gateway/gateway-bootstrap/BUILD.bazel
+++ b/systems/gateway/gateway-bootstrap/BUILD.bazel
@@ -1,14 +1,20 @@
 load("@rules_kotlin//kotlin:jvm.bzl", "kt_jvm_binary", "kt_jvm_test")
-load("//systems/admission/module-a:deps.bzl", "MODULE_DEPS", "TEST_DEPS")
+load(":deps.bzl", "MODULE_DEPS", "TEST_DEPS")
 
 package(default_visibility = ["//visibility:public"])
 
 kt_jvm_binary(
     name = "main",
     srcs = glob(["src/main/kotlin/**/*.kt"]),
-    main_class = "hs.kr.entrydsm.example.ExampleApplicationKt",
+    resources = glob(["src/main/resources/**"]),
+    main_class = "hs.kr.entrydsm.gateway.GatewayBootstrapApplicationKt",
     plugins = ["//:spring_allopen"],
-    deps = MODULE_DEPS,
+    deps = MODULE_DEPS + [
+        "//systems/gateway/gateway-adapter-in:main",
+        "//systems/gateway/gateway-adapter-out:main",
+        "//systems/gateway/gateway-application:main",
+        "//systems/gateway/gateway-domain:main",
+    ],
     javac_opts = "//:javac_options",
     kotlinc_opts = "//:kotlinc_options",
 )
@@ -16,7 +22,7 @@ kt_jvm_binary(
 kt_jvm_test(
     name = "test",
     srcs = glob(["src/test/kotlin/**/*.kt"]),
-    test_class = "hs.kr.entrydsm.example.ExampleApplicationTest",
+    test_class = "hs.kr.entrydsm.gateway.GatewayBootstrapApplicationTest",
     plugins = ["//:spring_allopen"],
     deps = MODULE_DEPS + TEST_DEPS,
     javac_opts = "//:javac_options",

--- a/systems/gateway/gateway-bootstrap/src/main/kotlin/hs/kr/entrydsm/ExampleApplication.kt
+++ b/systems/gateway/gateway-bootstrap/src/main/kotlin/hs/kr/entrydsm/ExampleApplication.kt
@@ -1,11 +1,11 @@
-package hs.kr.entrydsm.example
+package hs.kr.entrydsm.gateway
 
 import org.springframework.boot.autoconfigure.SpringBootApplication
 import org.springframework.boot.runApplication
 
 @SpringBootApplication
-class ExampleApplication
+class GatewayBootstrapApplication
 
 fun main(args: Array<String>) {
-    runApplication<ExampleApplication>(*args)
+    runApplication<GatewayBootstrapApplication>(*args)
 }

--- a/systems/gateway/gateway-bootstrap/src/main/resources/application.yaml
+++ b/systems/gateway/gateway-bootstrap/src/main/resources/application.yaml
@@ -1,0 +1,21 @@
+spring:
+  application:
+    name: gateway
+  profiles:
+    default: local
+  main:
+    lazy-initialization: true
+server:
+  shutdown: graceful
+management:
+  endpoints:
+    web:
+      exposure:
+        include: health,info
+  endpoint:
+    health:
+      probes:
+        enabled: true
+logging:
+  level:
+    root: INFO

--- a/systems/gateway/gateway-bootstrap/src/test/kotlin/hs/kr/entrydsm/TestMain.kt
+++ b/systems/gateway/gateway-bootstrap/src/test/kotlin/hs/kr/entrydsm/TestMain.kt
@@ -1,11 +1,11 @@
-package hs.kr.entrydsm.example
+package hs.kr.entrydsm.gateway
 
-import org.junit.Assert.assertEquals
+import org.junit.Assert.assertTrue
 import org.junit.Test
 
-class ExampleApplicationTest {
+class GatewayBootstrapApplicationTest {
     @Test
     fun contextLoads() {
-        assertEquals(4, 2 + 2)
+        assertTrue(true)
     }
 }

--- a/systems/gateway/gateway-domain/BUILD.bazel
+++ b/systems/gateway/gateway-domain/BUILD.bazel
@@ -1,13 +1,11 @@
-load("@rules_kotlin//kotlin:jvm.bzl", "kt_jvm_binary", "kt_jvm_test")
-load("//systems/admission/module-a:deps.bzl", "MODULE_DEPS", "TEST_DEPS")
+load("@rules_kotlin//kotlin:jvm.bzl", "kt_jvm_library", "kt_jvm_test")
+load(":deps.bzl", "MODULE_DEPS", "TEST_DEPS")
 
 package(default_visibility = ["//visibility:public"])
 
-kt_jvm_binary(
+kt_jvm_library(
     name = "main",
     srcs = glob(["src/main/kotlin/**/*.kt"]),
-    main_class = "hs.kr.entrydsm.example.ExampleApplicationKt",
-    plugins = ["//:spring_allopen"],
     deps = MODULE_DEPS,
     javac_opts = "//:javac_options",
     kotlinc_opts = "//:kotlinc_options",
@@ -16,8 +14,7 @@ kt_jvm_binary(
 kt_jvm_test(
     name = "test",
     srcs = glob(["src/test/kotlin/**/*.kt"]),
-    test_class = "hs.kr.entrydsm.example.ExampleApplicationTest",
-    plugins = ["//:spring_allopen"],
+    test_class = "hs.kr.entrydsm.gateway.domain.GatewayDomainModuleTest",
     deps = MODULE_DEPS + TEST_DEPS,
     javac_opts = "//:javac_options",
     kotlinc_opts = "//:kotlinc_options",

--- a/systems/gateway/gateway-domain/deps.bzl
+++ b/systems/gateway/gateway-domain/deps.bzl
@@ -1,16 +1,7 @@
-SPRING_DEPS = [
-    "@maven//:org_springframework_boot_spring_boot_starter_web",
-    "@maven//:org_springframework_boot_spring_boot_starter_actuator",
-]
-
-KOTLIN_DEPS = [
-    "@maven//:org_jetbrains_kotlin_kotlin_reflect",
-    "@maven//:com_fasterxml_jackson_module_jackson_module_kotlin",
-]
+KOTLIN_DEPS = []
 
 TEST_DEPS = [
-    "@maven//:org_springframework_boot_spring_boot_starter_test",
     "@maven//:junit_junit",
 ]
 
-MODULE_DEPS = SPRING_DEPS + KOTLIN_DEPS
+MODULE_DEPS = KOTLIN_DEPS

--- a/systems/gateway/gateway-domain/src/main/kotlin/hs/kr/entrydsm/ExampleApplication.kt
+++ b/systems/gateway/gateway-domain/src/main/kotlin/hs/kr/entrydsm/ExampleApplication.kt
@@ -1,11 +1,3 @@
-package hs.kr.entrydsm.example
+package hs.kr.entrydsm.gateway.domain
 
-import org.springframework.boot.autoconfigure.SpringBootApplication
-import org.springframework.boot.runApplication
-
-@SpringBootApplication
-class ExampleApplication
-
-fun main(args: Array<String>) {
-    runApplication<ExampleApplication>(*args)
-}
+class GatewayDomainModule

--- a/systems/gateway/gateway-domain/src/test/kotlin/hs/kr/entrydsm/TestMain.kt
+++ b/systems/gateway/gateway-domain/src/test/kotlin/hs/kr/entrydsm/TestMain.kt
@@ -1,11 +1,11 @@
-package hs.kr.entrydsm.example
+package hs.kr.entrydsm.gateway.domain
 
-import org.junit.Assert.assertEquals
+import org.junit.Assert.assertTrue
 import org.junit.Test
 
-class ExampleApplicationTest {
+class GatewayDomainModuleTest {
     @Test
-    fun contextLoads() {
-        assertEquals(4, 2 + 2)
+    fun moduleLoads() {
+        assertTrue(true)
     }
 }

--- a/systems/identity/identity-adapter-in/BUILD.bazel
+++ b/systems/identity/identity-adapter-in/BUILD.bazel
@@ -1,13 +1,11 @@
-load("@rules_kotlin//kotlin:jvm.bzl", "kt_jvm_binary", "kt_jvm_test")
-load("//systems/admission/module-a:deps.bzl", "MODULE_DEPS", "TEST_DEPS")
+load("@rules_kotlin//kotlin:jvm.bzl", "kt_jvm_library", "kt_jvm_test")
+load(":deps.bzl", "MODULE_DEPS", "TEST_DEPS")
 
 package(default_visibility = ["//visibility:public"])
 
-kt_jvm_binary(
+kt_jvm_library(
     name = "main",
     srcs = glob(["src/main/kotlin/**/*.kt"]),
-    main_class = "hs.kr.entrydsm.example.ExampleApplicationKt",
-    plugins = ["//:spring_allopen"],
     deps = MODULE_DEPS,
     javac_opts = "//:javac_options",
     kotlinc_opts = "//:kotlinc_options",
@@ -16,8 +14,7 @@ kt_jvm_binary(
 kt_jvm_test(
     name = "test",
     srcs = glob(["src/test/kotlin/**/*.kt"]),
-    test_class = "hs.kr.entrydsm.example.ExampleApplicationTest",
-    plugins = ["//:spring_allopen"],
+    test_class = "hs.kr.entrydsm.identity.adapterin.IdentityAdapterInModuleTest",
     deps = MODULE_DEPS + TEST_DEPS,
     javac_opts = "//:javac_options",
     kotlinc_opts = "//:kotlinc_options",

--- a/systems/identity/identity-adapter-in/deps.bzl
+++ b/systems/identity/identity-adapter-in/deps.bzl
@@ -1,16 +1,7 @@
-SPRING_DEPS = [
-    "@maven//:org_springframework_boot_spring_boot_starter_web",
-    "@maven//:org_springframework_boot_spring_boot_starter_actuator",
-]
-
-KOTLIN_DEPS = [
-    "@maven//:org_jetbrains_kotlin_kotlin_reflect",
-    "@maven//:com_fasterxml_jackson_module_jackson_module_kotlin",
-]
+KOTLIN_DEPS = []
 
 TEST_DEPS = [
-    "@maven//:org_springframework_boot_spring_boot_starter_test",
     "@maven//:junit_junit",
 ]
 
-MODULE_DEPS = SPRING_DEPS + KOTLIN_DEPS
+MODULE_DEPS = KOTLIN_DEPS

--- a/systems/identity/identity-adapter-in/src/main/kotlin/hs/kr/entrydsm/ExampleApplication.kt
+++ b/systems/identity/identity-adapter-in/src/main/kotlin/hs/kr/entrydsm/ExampleApplication.kt
@@ -1,11 +1,3 @@
-package hs.kr.entrydsm.example
+package hs.kr.entrydsm.identity.adapterin
 
-import org.springframework.boot.autoconfigure.SpringBootApplication
-import org.springframework.boot.runApplication
-
-@SpringBootApplication
-class ExampleApplication
-
-fun main(args: Array<String>) {
-    runApplication<ExampleApplication>(*args)
-}
+class IdentityAdapterInModule

--- a/systems/identity/identity-adapter-in/src/test/kotlin/hs/kr/entrydsm/TestMain.kt
+++ b/systems/identity/identity-adapter-in/src/test/kotlin/hs/kr/entrydsm/TestMain.kt
@@ -1,11 +1,11 @@
-package hs.kr.entrydsm.example
+package hs.kr.entrydsm.identity.adapterin
 
-import org.junit.Assert.assertEquals
+import org.junit.Assert.assertTrue
 import org.junit.Test
 
-class ExampleApplicationTest {
+class IdentityAdapterInModuleTest {
     @Test
-    fun contextLoads() {
-        assertEquals(4, 2 + 2)
+    fun moduleLoads() {
+        assertTrue(true)
     }
 }

--- a/systems/identity/identity-adapter-out/BUILD.bazel
+++ b/systems/identity/identity-adapter-out/BUILD.bazel
@@ -1,13 +1,11 @@
-load("@rules_kotlin//kotlin:jvm.bzl", "kt_jvm_binary", "kt_jvm_test")
-load("//systems/admission/module-a:deps.bzl", "MODULE_DEPS", "TEST_DEPS")
+load("@rules_kotlin//kotlin:jvm.bzl", "kt_jvm_library", "kt_jvm_test")
+load(":deps.bzl", "MODULE_DEPS", "TEST_DEPS")
 
 package(default_visibility = ["//visibility:public"])
 
-kt_jvm_binary(
+kt_jvm_library(
     name = "main",
     srcs = glob(["src/main/kotlin/**/*.kt"]),
-    main_class = "hs.kr.entrydsm.example.ExampleApplicationKt",
-    plugins = ["//:spring_allopen"],
     deps = MODULE_DEPS,
     javac_opts = "//:javac_options",
     kotlinc_opts = "//:kotlinc_options",
@@ -16,8 +14,7 @@ kt_jvm_binary(
 kt_jvm_test(
     name = "test",
     srcs = glob(["src/test/kotlin/**/*.kt"]),
-    test_class = "hs.kr.entrydsm.example.ExampleApplicationTest",
-    plugins = ["//:spring_allopen"],
+    test_class = "hs.kr.entrydsm.identity.adapterout.IdentityAdapterOutModuleTest",
     deps = MODULE_DEPS + TEST_DEPS,
     javac_opts = "//:javac_options",
     kotlinc_opts = "//:kotlinc_options",

--- a/systems/identity/identity-adapter-out/deps.bzl
+++ b/systems/identity/identity-adapter-out/deps.bzl
@@ -1,16 +1,7 @@
-SPRING_DEPS = [
-    "@maven//:org_springframework_boot_spring_boot_starter_web",
-    "@maven//:org_springframework_boot_spring_boot_starter_actuator",
-]
-
-KOTLIN_DEPS = [
-    "@maven//:org_jetbrains_kotlin_kotlin_reflect",
-    "@maven//:com_fasterxml_jackson_module_jackson_module_kotlin",
-]
+KOTLIN_DEPS = []
 
 TEST_DEPS = [
-    "@maven//:org_springframework_boot_spring_boot_starter_test",
     "@maven//:junit_junit",
 ]
 
-MODULE_DEPS = SPRING_DEPS + KOTLIN_DEPS
+MODULE_DEPS = KOTLIN_DEPS

--- a/systems/identity/identity-adapter-out/src/main/kotlin/hs/kr/entrydsm/ExampleApplication.kt
+++ b/systems/identity/identity-adapter-out/src/main/kotlin/hs/kr/entrydsm/ExampleApplication.kt
@@ -1,11 +1,3 @@
-package hs.kr.entrydsm.example
+package hs.kr.entrydsm.identity.adapterout
 
-import org.springframework.boot.autoconfigure.SpringBootApplication
-import org.springframework.boot.runApplication
-
-@SpringBootApplication
-class ExampleApplication
-
-fun main(args: Array<String>) {
-    runApplication<ExampleApplication>(*args)
-}
+class IdentityAdapterOutModule

--- a/systems/identity/identity-adapter-out/src/test/kotlin/hs/kr/entrydsm/TestMain.kt
+++ b/systems/identity/identity-adapter-out/src/test/kotlin/hs/kr/entrydsm/TestMain.kt
@@ -1,11 +1,11 @@
-package hs.kr.entrydsm.example
+package hs.kr.entrydsm.identity.adapterout
 
-import org.junit.Assert.assertEquals
+import org.junit.Assert.assertTrue
 import org.junit.Test
 
-class ExampleApplicationTest {
+class IdentityAdapterOutModuleTest {
     @Test
-    fun contextLoads() {
-        assertEquals(4, 2 + 2)
+    fun moduleLoads() {
+        assertTrue(true)
     }
 }

--- a/systems/identity/identity-application/BUILD.bazel
+++ b/systems/identity/identity-application/BUILD.bazel
@@ -1,13 +1,11 @@
-load("@rules_kotlin//kotlin:jvm.bzl", "kt_jvm_binary", "kt_jvm_test")
-load("//systems/admission/module-a:deps.bzl", "MODULE_DEPS", "TEST_DEPS")
+load("@rules_kotlin//kotlin:jvm.bzl", "kt_jvm_library", "kt_jvm_test")
+load(":deps.bzl", "MODULE_DEPS", "TEST_DEPS")
 
 package(default_visibility = ["//visibility:public"])
 
-kt_jvm_binary(
+kt_jvm_library(
     name = "main",
     srcs = glob(["src/main/kotlin/**/*.kt"]),
-    main_class = "hs.kr.entrydsm.example.ExampleApplicationKt",
-    plugins = ["//:spring_allopen"],
     deps = MODULE_DEPS,
     javac_opts = "//:javac_options",
     kotlinc_opts = "//:kotlinc_options",
@@ -16,8 +14,7 @@ kt_jvm_binary(
 kt_jvm_test(
     name = "test",
     srcs = glob(["src/test/kotlin/**/*.kt"]),
-    test_class = "hs.kr.entrydsm.example.ExampleApplicationTest",
-    plugins = ["//:spring_allopen"],
+    test_class = "hs.kr.entrydsm.identity.application.IdentityApplicationModuleTest",
     deps = MODULE_DEPS + TEST_DEPS,
     javac_opts = "//:javac_options",
     kotlinc_opts = "//:kotlinc_options",

--- a/systems/identity/identity-application/deps.bzl
+++ b/systems/identity/identity-application/deps.bzl
@@ -1,16 +1,7 @@
-SPRING_DEPS = [
-    "@maven//:org_springframework_boot_spring_boot_starter_web",
-    "@maven//:org_springframework_boot_spring_boot_starter_actuator",
-]
-
-KOTLIN_DEPS = [
-    "@maven//:org_jetbrains_kotlin_kotlin_reflect",
-    "@maven//:com_fasterxml_jackson_module_jackson_module_kotlin",
-]
+KOTLIN_DEPS = []
 
 TEST_DEPS = [
-    "@maven//:org_springframework_boot_spring_boot_starter_test",
     "@maven//:junit_junit",
 ]
 
-MODULE_DEPS = SPRING_DEPS + KOTLIN_DEPS
+MODULE_DEPS = KOTLIN_DEPS

--- a/systems/identity/identity-application/src/main/kotlin/hs/kr/entrydsm/ExampleApplication.kt
+++ b/systems/identity/identity-application/src/main/kotlin/hs/kr/entrydsm/ExampleApplication.kt
@@ -1,11 +1,3 @@
-package hs.kr.entrydsm.example
+package hs.kr.entrydsm.identity.application
 
-import org.springframework.boot.autoconfigure.SpringBootApplication
-import org.springframework.boot.runApplication
-
-@SpringBootApplication
-class ExampleApplication
-
-fun main(args: Array<String>) {
-    runApplication<ExampleApplication>(*args)
-}
+class IdentityApplicationModule

--- a/systems/identity/identity-application/src/test/kotlin/hs/kr/entrydsm/TestMain.kt
+++ b/systems/identity/identity-application/src/test/kotlin/hs/kr/entrydsm/TestMain.kt
@@ -1,11 +1,11 @@
-package hs.kr.entrydsm.example
+package hs.kr.entrydsm.identity.application
 
-import org.junit.Assert.assertEquals
+import org.junit.Assert.assertTrue
 import org.junit.Test
 
-class ExampleApplicationTest {
+class IdentityApplicationModuleTest {
     @Test
-    fun contextLoads() {
-        assertEquals(4, 2 + 2)
+    fun moduleLoads() {
+        assertTrue(true)
     }
 }

--- a/systems/identity/identity-bootstrap/BUILD.bazel
+++ b/systems/identity/identity-bootstrap/BUILD.bazel
@@ -1,14 +1,20 @@
 load("@rules_kotlin//kotlin:jvm.bzl", "kt_jvm_binary", "kt_jvm_test")
-load("//systems/admission/module-a:deps.bzl", "MODULE_DEPS", "TEST_DEPS")
+load(":deps.bzl", "MODULE_DEPS", "TEST_DEPS")
 
 package(default_visibility = ["//visibility:public"])
 
 kt_jvm_binary(
     name = "main",
     srcs = glob(["src/main/kotlin/**/*.kt"]),
-    main_class = "hs.kr.entrydsm.example.ExampleApplicationKt",
+    resources = glob(["src/main/resources/**"]),
+    main_class = "hs.kr.entrydsm.identity.IdentityBootstrapApplicationKt",
     plugins = ["//:spring_allopen"],
-    deps = MODULE_DEPS,
+    deps = MODULE_DEPS + [
+        "//systems/identity/identity-adapter-in:main",
+        "//systems/identity/identity-adapter-out:main",
+        "//systems/identity/identity-application:main",
+        "//systems/identity/identity-domain:main",
+    ],
     javac_opts = "//:javac_options",
     kotlinc_opts = "//:kotlinc_options",
 )
@@ -16,7 +22,7 @@ kt_jvm_binary(
 kt_jvm_test(
     name = "test",
     srcs = glob(["src/test/kotlin/**/*.kt"]),
-    test_class = "hs.kr.entrydsm.example.ExampleApplicationTest",
+    test_class = "hs.kr.entrydsm.identity.IdentityBootstrapApplicationTest",
     plugins = ["//:spring_allopen"],
     deps = MODULE_DEPS + TEST_DEPS,
     javac_opts = "//:javac_options",

--- a/systems/identity/identity-bootstrap/src/main/kotlin/hs/kr/entrydsm/ExampleApplication.kt
+++ b/systems/identity/identity-bootstrap/src/main/kotlin/hs/kr/entrydsm/ExampleApplication.kt
@@ -1,11 +1,11 @@
-package hs.kr.entrydsm.example
+package hs.kr.entrydsm.identity
 
 import org.springframework.boot.autoconfigure.SpringBootApplication
 import org.springframework.boot.runApplication
 
 @SpringBootApplication
-class ExampleApplication
+class IdentityBootstrapApplication
 
 fun main(args: Array<String>) {
-    runApplication<ExampleApplication>(*args)
+    runApplication<IdentityBootstrapApplication>(*args)
 }

--- a/systems/identity/identity-bootstrap/src/main/resources/application.yaml
+++ b/systems/identity/identity-bootstrap/src/main/resources/application.yaml
@@ -1,0 +1,21 @@
+spring:
+  application:
+    name: identity
+  profiles:
+    default: local
+  main:
+    lazy-initialization: true
+server:
+  shutdown: graceful
+management:
+  endpoints:
+    web:
+      exposure:
+        include: health,info
+  endpoint:
+    health:
+      probes:
+        enabled: true
+logging:
+  level:
+    root: INFO

--- a/systems/identity/identity-bootstrap/src/test/kotlin/hs/kr/entrydsm/TestMain.kt
+++ b/systems/identity/identity-bootstrap/src/test/kotlin/hs/kr/entrydsm/TestMain.kt
@@ -1,11 +1,11 @@
-package hs.kr.entrydsm.example
+package hs.kr.entrydsm.identity
 
-import org.junit.Assert.assertEquals
+import org.junit.Assert.assertTrue
 import org.junit.Test
 
-class ExampleApplicationTest {
+class IdentityBootstrapApplicationTest {
     @Test
     fun contextLoads() {
-        assertEquals(4, 2 + 2)
+        assertTrue(true)
     }
 }

--- a/systems/identity/identity-domain/BUILD.bazel
+++ b/systems/identity/identity-domain/BUILD.bazel
@@ -1,13 +1,11 @@
-load("@rules_kotlin//kotlin:jvm.bzl", "kt_jvm_binary", "kt_jvm_test")
-load("//systems/admission/module-a:deps.bzl", "MODULE_DEPS", "TEST_DEPS")
+load("@rules_kotlin//kotlin:jvm.bzl", "kt_jvm_library", "kt_jvm_test")
+load(":deps.bzl", "MODULE_DEPS", "TEST_DEPS")
 
 package(default_visibility = ["//visibility:public"])
 
-kt_jvm_binary(
+kt_jvm_library(
     name = "main",
     srcs = glob(["src/main/kotlin/**/*.kt"]),
-    main_class = "hs.kr.entrydsm.example.ExampleApplicationKt",
-    plugins = ["//:spring_allopen"],
     deps = MODULE_DEPS,
     javac_opts = "//:javac_options",
     kotlinc_opts = "//:kotlinc_options",
@@ -16,8 +14,7 @@ kt_jvm_binary(
 kt_jvm_test(
     name = "test",
     srcs = glob(["src/test/kotlin/**/*.kt"]),
-    test_class = "hs.kr.entrydsm.example.ExampleApplicationTest",
-    plugins = ["//:spring_allopen"],
+    test_class = "hs.kr.entrydsm.identity.domain.IdentityDomainModuleTest",
     deps = MODULE_DEPS + TEST_DEPS,
     javac_opts = "//:javac_options",
     kotlinc_opts = "//:kotlinc_options",

--- a/systems/identity/identity-domain/deps.bzl
+++ b/systems/identity/identity-domain/deps.bzl
@@ -1,16 +1,7 @@
-SPRING_DEPS = [
-    "@maven//:org_springframework_boot_spring_boot_starter_web",
-    "@maven//:org_springframework_boot_spring_boot_starter_actuator",
-]
-
-KOTLIN_DEPS = [
-    "@maven//:org_jetbrains_kotlin_kotlin_reflect",
-    "@maven//:com_fasterxml_jackson_module_jackson_module_kotlin",
-]
+KOTLIN_DEPS = []
 
 TEST_DEPS = [
-    "@maven//:org_springframework_boot_spring_boot_starter_test",
     "@maven//:junit_junit",
 ]
 
-MODULE_DEPS = SPRING_DEPS + KOTLIN_DEPS
+MODULE_DEPS = KOTLIN_DEPS

--- a/systems/identity/identity-domain/src/main/kotlin/hs/kr/entrydsm/ExampleApplication.kt
+++ b/systems/identity/identity-domain/src/main/kotlin/hs/kr/entrydsm/ExampleApplication.kt
@@ -1,11 +1,3 @@
-package hs.kr.entrydsm.example
+package hs.kr.entrydsm.identity.domain
 
-import org.springframework.boot.autoconfigure.SpringBootApplication
-import org.springframework.boot.runApplication
-
-@SpringBootApplication
-class ExampleApplication
-
-fun main(args: Array<String>) {
-    runApplication<ExampleApplication>(*args)
-}
+class IdentityDomainModule

--- a/systems/identity/identity-domain/src/test/kotlin/hs/kr/entrydsm/TestMain.kt
+++ b/systems/identity/identity-domain/src/test/kotlin/hs/kr/entrydsm/TestMain.kt
@@ -1,11 +1,11 @@
-package hs.kr.entrydsm.example
+package hs.kr.entrydsm.identity.domain
 
-import org.junit.Assert.assertEquals
+import org.junit.Assert.assertTrue
 import org.junit.Test
 
-class ExampleApplicationTest {
+class IdentityDomainModuleTest {
     @Test
-    fun contextLoads() {
-        assertEquals(4, 2 + 2)
+    fun moduleLoads() {
+        assertTrue(true)
     }
 }

--- a/systems/notification/notification-adapter-in/BUILD.bazel
+++ b/systems/notification/notification-adapter-in/BUILD.bazel
@@ -1,13 +1,11 @@
-load("@rules_kotlin//kotlin:jvm.bzl", "kt_jvm_binary", "kt_jvm_test")
-load("//systems/admission/module-a:deps.bzl", "MODULE_DEPS", "TEST_DEPS")
+load("@rules_kotlin//kotlin:jvm.bzl", "kt_jvm_library", "kt_jvm_test")
+load(":deps.bzl", "MODULE_DEPS", "TEST_DEPS")
 
 package(default_visibility = ["//visibility:public"])
 
-kt_jvm_binary(
+kt_jvm_library(
     name = "main",
     srcs = glob(["src/main/kotlin/**/*.kt"]),
-    main_class = "hs.kr.entrydsm.example.ExampleApplicationKt",
-    plugins = ["//:spring_allopen"],
     deps = MODULE_DEPS,
     javac_opts = "//:javac_options",
     kotlinc_opts = "//:kotlinc_options",
@@ -16,8 +14,7 @@ kt_jvm_binary(
 kt_jvm_test(
     name = "test",
     srcs = glob(["src/test/kotlin/**/*.kt"]),
-    test_class = "hs.kr.entrydsm.example.ExampleApplicationTest",
-    plugins = ["//:spring_allopen"],
+    test_class = "hs.kr.entrydsm.notification.adapterin.NotificationAdapterInModuleTest",
     deps = MODULE_DEPS + TEST_DEPS,
     javac_opts = "//:javac_options",
     kotlinc_opts = "//:kotlinc_options",

--- a/systems/notification/notification-adapter-in/deps.bzl
+++ b/systems/notification/notification-adapter-in/deps.bzl
@@ -1,16 +1,7 @@
-SPRING_DEPS = [
-    "@maven//:org_springframework_boot_spring_boot_starter_web",
-    "@maven//:org_springframework_boot_spring_boot_starter_actuator",
-]
-
-KOTLIN_DEPS = [
-    "@maven//:org_jetbrains_kotlin_kotlin_reflect",
-    "@maven//:com_fasterxml_jackson_module_jackson_module_kotlin",
-]
+KOTLIN_DEPS = []
 
 TEST_DEPS = [
-    "@maven//:org_springframework_boot_spring_boot_starter_test",
     "@maven//:junit_junit",
 ]
 
-MODULE_DEPS = SPRING_DEPS + KOTLIN_DEPS
+MODULE_DEPS = KOTLIN_DEPS

--- a/systems/notification/notification-adapter-in/src/main/kotlin/hs/kr/entrydsm/ExampleApplication.kt
+++ b/systems/notification/notification-adapter-in/src/main/kotlin/hs/kr/entrydsm/ExampleApplication.kt
@@ -1,11 +1,3 @@
-package hs.kr.entrydsm.example
+package hs.kr.entrydsm.notification.adapterin
 
-import org.springframework.boot.autoconfigure.SpringBootApplication
-import org.springframework.boot.runApplication
-
-@SpringBootApplication
-class ExampleApplication
-
-fun main(args: Array<String>) {
-    runApplication<ExampleApplication>(*args)
-}
+class NotificationAdapterInModule

--- a/systems/notification/notification-adapter-in/src/test/kotlin/hs/kr/entrydsm/TestMain.kt
+++ b/systems/notification/notification-adapter-in/src/test/kotlin/hs/kr/entrydsm/TestMain.kt
@@ -1,11 +1,11 @@
-package hs.kr.entrydsm.example
+package hs.kr.entrydsm.notification.adapterin
 
-import org.junit.Assert.assertEquals
+import org.junit.Assert.assertTrue
 import org.junit.Test
 
-class ExampleApplicationTest {
+class NotificationAdapterInModuleTest {
     @Test
-    fun contextLoads() {
-        assertEquals(4, 2 + 2)
+    fun moduleLoads() {
+        assertTrue(true)
     }
 }

--- a/systems/notification/notification-adapter-out/BUILD.bazel
+++ b/systems/notification/notification-adapter-out/BUILD.bazel
@@ -1,13 +1,11 @@
-load("@rules_kotlin//kotlin:jvm.bzl", "kt_jvm_binary", "kt_jvm_test")
-load("//systems/admission/module-a:deps.bzl", "MODULE_DEPS", "TEST_DEPS")
+load("@rules_kotlin//kotlin:jvm.bzl", "kt_jvm_library", "kt_jvm_test")
+load(":deps.bzl", "MODULE_DEPS", "TEST_DEPS")
 
 package(default_visibility = ["//visibility:public"])
 
-kt_jvm_binary(
+kt_jvm_library(
     name = "main",
     srcs = glob(["src/main/kotlin/**/*.kt"]),
-    main_class = "hs.kr.entrydsm.example.ExampleApplicationKt",
-    plugins = ["//:spring_allopen"],
     deps = MODULE_DEPS,
     javac_opts = "//:javac_options",
     kotlinc_opts = "//:kotlinc_options",
@@ -16,8 +14,7 @@ kt_jvm_binary(
 kt_jvm_test(
     name = "test",
     srcs = glob(["src/test/kotlin/**/*.kt"]),
-    test_class = "hs.kr.entrydsm.example.ExampleApplicationTest",
-    plugins = ["//:spring_allopen"],
+    test_class = "hs.kr.entrydsm.notification.adapterout.NotificationAdapterOutModuleTest",
     deps = MODULE_DEPS + TEST_DEPS,
     javac_opts = "//:javac_options",
     kotlinc_opts = "//:kotlinc_options",

--- a/systems/notification/notification-adapter-out/deps.bzl
+++ b/systems/notification/notification-adapter-out/deps.bzl
@@ -1,16 +1,7 @@
-SPRING_DEPS = [
-    "@maven//:org_springframework_boot_spring_boot_starter_web",
-    "@maven//:org_springframework_boot_spring_boot_starter_actuator",
-]
-
-KOTLIN_DEPS = [
-    "@maven//:org_jetbrains_kotlin_kotlin_reflect",
-    "@maven//:com_fasterxml_jackson_module_jackson_module_kotlin",
-]
+KOTLIN_DEPS = []
 
 TEST_DEPS = [
-    "@maven//:org_springframework_boot_spring_boot_starter_test",
     "@maven//:junit_junit",
 ]
 
-MODULE_DEPS = SPRING_DEPS + KOTLIN_DEPS
+MODULE_DEPS = KOTLIN_DEPS

--- a/systems/notification/notification-adapter-out/src/main/kotlin/hs/kr/entrydsm/ExampleApplication.kt
+++ b/systems/notification/notification-adapter-out/src/main/kotlin/hs/kr/entrydsm/ExampleApplication.kt
@@ -1,11 +1,3 @@
-package hs.kr.entrydsm.example
+package hs.kr.entrydsm.notification.adapterout
 
-import org.springframework.boot.autoconfigure.SpringBootApplication
-import org.springframework.boot.runApplication
-
-@SpringBootApplication
-class ExampleApplication
-
-fun main(args: Array<String>) {
-    runApplication<ExampleApplication>(*args)
-}
+class NotificationAdapterOutModule

--- a/systems/notification/notification-adapter-out/src/test/kotlin/hs/kr/entrydsm/TestMain.kt
+++ b/systems/notification/notification-adapter-out/src/test/kotlin/hs/kr/entrydsm/TestMain.kt
@@ -1,11 +1,11 @@
-package hs.kr.entrydsm.example
+package hs.kr.entrydsm.notification.adapterout
 
-import org.junit.Assert.assertEquals
+import org.junit.Assert.assertTrue
 import org.junit.Test
 
-class ExampleApplicationTest {
+class NotificationAdapterOutModuleTest {
     @Test
-    fun contextLoads() {
-        assertEquals(4, 2 + 2)
+    fun moduleLoads() {
+        assertTrue(true)
     }
 }

--- a/systems/notification/notification-application/BUILD.bazel
+++ b/systems/notification/notification-application/BUILD.bazel
@@ -1,13 +1,11 @@
-load("@rules_kotlin//kotlin:jvm.bzl", "kt_jvm_binary", "kt_jvm_test")
-load("//systems/admission/module-a:deps.bzl", "MODULE_DEPS", "TEST_DEPS")
+load("@rules_kotlin//kotlin:jvm.bzl", "kt_jvm_library", "kt_jvm_test")
+load(":deps.bzl", "MODULE_DEPS", "TEST_DEPS")
 
 package(default_visibility = ["//visibility:public"])
 
-kt_jvm_binary(
+kt_jvm_library(
     name = "main",
     srcs = glob(["src/main/kotlin/**/*.kt"]),
-    main_class = "hs.kr.entrydsm.example.ExampleApplicationKt",
-    plugins = ["//:spring_allopen"],
     deps = MODULE_DEPS,
     javac_opts = "//:javac_options",
     kotlinc_opts = "//:kotlinc_options",
@@ -16,8 +14,7 @@ kt_jvm_binary(
 kt_jvm_test(
     name = "test",
     srcs = glob(["src/test/kotlin/**/*.kt"]),
-    test_class = "hs.kr.entrydsm.example.ExampleApplicationTest",
-    plugins = ["//:spring_allopen"],
+    test_class = "hs.kr.entrydsm.notification.application.NotificationApplicationModuleTest",
     deps = MODULE_DEPS + TEST_DEPS,
     javac_opts = "//:javac_options",
     kotlinc_opts = "//:kotlinc_options",

--- a/systems/notification/notification-application/deps.bzl
+++ b/systems/notification/notification-application/deps.bzl
@@ -1,16 +1,7 @@
-SPRING_DEPS = [
-    "@maven//:org_springframework_boot_spring_boot_starter_web",
-    "@maven//:org_springframework_boot_spring_boot_starter_actuator",
-]
-
-KOTLIN_DEPS = [
-    "@maven//:org_jetbrains_kotlin_kotlin_reflect",
-    "@maven//:com_fasterxml_jackson_module_jackson_module_kotlin",
-]
+KOTLIN_DEPS = []
 
 TEST_DEPS = [
-    "@maven//:org_springframework_boot_spring_boot_starter_test",
     "@maven//:junit_junit",
 ]
 
-MODULE_DEPS = SPRING_DEPS + KOTLIN_DEPS
+MODULE_DEPS = KOTLIN_DEPS

--- a/systems/notification/notification-application/src/main/kotlin/hs/kr/entrydsm/ExampleApplication.kt
+++ b/systems/notification/notification-application/src/main/kotlin/hs/kr/entrydsm/ExampleApplication.kt
@@ -1,11 +1,3 @@
-package hs.kr.entrydsm.example
+package hs.kr.entrydsm.notification.application
 
-import org.springframework.boot.autoconfigure.SpringBootApplication
-import org.springframework.boot.runApplication
-
-@SpringBootApplication
-class ExampleApplication
-
-fun main(args: Array<String>) {
-    runApplication<ExampleApplication>(*args)
-}
+class NotificationApplicationModule

--- a/systems/notification/notification-application/src/test/kotlin/hs/kr/entrydsm/TestMain.kt
+++ b/systems/notification/notification-application/src/test/kotlin/hs/kr/entrydsm/TestMain.kt
@@ -1,11 +1,11 @@
-package hs.kr.entrydsm.example
+package hs.kr.entrydsm.notification.application
 
-import org.junit.Assert.assertEquals
+import org.junit.Assert.assertTrue
 import org.junit.Test
 
-class ExampleApplicationTest {
+class NotificationApplicationModuleTest {
     @Test
-    fun contextLoads() {
-        assertEquals(4, 2 + 2)
+    fun moduleLoads() {
+        assertTrue(true)
     }
 }

--- a/systems/notification/notification-bootstrap/BUILD.bazel
+++ b/systems/notification/notification-bootstrap/BUILD.bazel
@@ -1,14 +1,20 @@
 load("@rules_kotlin//kotlin:jvm.bzl", "kt_jvm_binary", "kt_jvm_test")
-load("//systems/admission/module-a:deps.bzl", "MODULE_DEPS", "TEST_DEPS")
+load(":deps.bzl", "MODULE_DEPS", "TEST_DEPS")
 
 package(default_visibility = ["//visibility:public"])
 
 kt_jvm_binary(
     name = "main",
     srcs = glob(["src/main/kotlin/**/*.kt"]),
-    main_class = "hs.kr.entrydsm.example.ExampleApplicationKt",
+    resources = glob(["src/main/resources/**"]),
+    main_class = "hs.kr.entrydsm.notification.NotificationBootstrapApplicationKt",
     plugins = ["//:spring_allopen"],
-    deps = MODULE_DEPS,
+    deps = MODULE_DEPS + [
+        "//systems/notification/notification-adapter-in:main",
+        "//systems/notification/notification-adapter-out:main",
+        "//systems/notification/notification-application:main",
+        "//systems/notification/notification-domain:main",
+    ],
     javac_opts = "//:javac_options",
     kotlinc_opts = "//:kotlinc_options",
 )
@@ -16,7 +22,7 @@ kt_jvm_binary(
 kt_jvm_test(
     name = "test",
     srcs = glob(["src/test/kotlin/**/*.kt"]),
-    test_class = "hs.kr.entrydsm.example.ExampleApplicationTest",
+    test_class = "hs.kr.entrydsm.notification.NotificationBootstrapApplicationTest",
     plugins = ["//:spring_allopen"],
     deps = MODULE_DEPS + TEST_DEPS,
     javac_opts = "//:javac_options",

--- a/systems/notification/notification-bootstrap/src/main/kotlin/hs/kr/entrydsm/ExampleApplication.kt
+++ b/systems/notification/notification-bootstrap/src/main/kotlin/hs/kr/entrydsm/ExampleApplication.kt
@@ -1,11 +1,11 @@
-package hs.kr.entrydsm.example
+package hs.kr.entrydsm.notification
 
 import org.springframework.boot.autoconfigure.SpringBootApplication
 import org.springframework.boot.runApplication
 
 @SpringBootApplication
-class ExampleApplication
+class NotificationBootstrapApplication
 
 fun main(args: Array<String>) {
-    runApplication<ExampleApplication>(*args)
+    runApplication<NotificationBootstrapApplication>(*args)
 }

--- a/systems/notification/notification-bootstrap/src/main/resources/application.yaml
+++ b/systems/notification/notification-bootstrap/src/main/resources/application.yaml
@@ -1,0 +1,21 @@
+spring:
+  application:
+    name: notification
+  profiles:
+    default: local
+  main:
+    lazy-initialization: true
+server:
+  shutdown: graceful
+management:
+  endpoints:
+    web:
+      exposure:
+        include: health,info
+  endpoint:
+    health:
+      probes:
+        enabled: true
+logging:
+  level:
+    root: INFO

--- a/systems/notification/notification-bootstrap/src/test/kotlin/hs/kr/entrydsm/TestMain.kt
+++ b/systems/notification/notification-bootstrap/src/test/kotlin/hs/kr/entrydsm/TestMain.kt
@@ -1,11 +1,11 @@
-package hs.kr.entrydsm.example
+package hs.kr.entrydsm.notification
 
-import org.junit.Assert.assertEquals
+import org.junit.Assert.assertTrue
 import org.junit.Test
 
-class ExampleApplicationTest {
+class NotificationBootstrapApplicationTest {
     @Test
     fun contextLoads() {
-        assertEquals(4, 2 + 2)
+        assertTrue(true)
     }
 }

--- a/systems/notification/notification-domain/BUILD.bazel
+++ b/systems/notification/notification-domain/BUILD.bazel
@@ -1,13 +1,11 @@
-load("@rules_kotlin//kotlin:jvm.bzl", "kt_jvm_binary", "kt_jvm_test")
-load("//systems/admission/module-a:deps.bzl", "MODULE_DEPS", "TEST_DEPS")
+load("@rules_kotlin//kotlin:jvm.bzl", "kt_jvm_library", "kt_jvm_test")
+load(":deps.bzl", "MODULE_DEPS", "TEST_DEPS")
 
 package(default_visibility = ["//visibility:public"])
 
-kt_jvm_binary(
+kt_jvm_library(
     name = "main",
     srcs = glob(["src/main/kotlin/**/*.kt"]),
-    main_class = "hs.kr.entrydsm.example.ExampleApplicationKt",
-    plugins = ["//:spring_allopen"],
     deps = MODULE_DEPS,
     javac_opts = "//:javac_options",
     kotlinc_opts = "//:kotlinc_options",
@@ -16,8 +14,7 @@ kt_jvm_binary(
 kt_jvm_test(
     name = "test",
     srcs = glob(["src/test/kotlin/**/*.kt"]),
-    test_class = "hs.kr.entrydsm.example.ExampleApplicationTest",
-    plugins = ["//:spring_allopen"],
+    test_class = "hs.kr.entrydsm.notification.domain.NotificationDomainModuleTest",
     deps = MODULE_DEPS + TEST_DEPS,
     javac_opts = "//:javac_options",
     kotlinc_opts = "//:kotlinc_options",

--- a/systems/notification/notification-domain/deps.bzl
+++ b/systems/notification/notification-domain/deps.bzl
@@ -1,16 +1,7 @@
-SPRING_DEPS = [
-    "@maven//:org_springframework_boot_spring_boot_starter_web",
-    "@maven//:org_springframework_boot_spring_boot_starter_actuator",
-]
-
-KOTLIN_DEPS = [
-    "@maven//:org_jetbrains_kotlin_kotlin_reflect",
-    "@maven//:com_fasterxml_jackson_module_jackson_module_kotlin",
-]
+KOTLIN_DEPS = []
 
 TEST_DEPS = [
-    "@maven//:org_springframework_boot_spring_boot_starter_test",
     "@maven//:junit_junit",
 ]
 
-MODULE_DEPS = SPRING_DEPS + KOTLIN_DEPS
+MODULE_DEPS = KOTLIN_DEPS

--- a/systems/notification/notification-domain/src/main/kotlin/hs/kr/entrydsm/ExampleApplication.kt
+++ b/systems/notification/notification-domain/src/main/kotlin/hs/kr/entrydsm/ExampleApplication.kt
@@ -1,11 +1,3 @@
-package hs.kr.entrydsm.example
+package hs.kr.entrydsm.notification.domain
 
-import org.springframework.boot.autoconfigure.SpringBootApplication
-import org.springframework.boot.runApplication
-
-@SpringBootApplication
-class ExampleApplication
-
-fun main(args: Array<String>) {
-    runApplication<ExampleApplication>(*args)
-}
+class NotificationDomainModule

--- a/systems/notification/notification-domain/src/test/kotlin/hs/kr/entrydsm/TestMain.kt
+++ b/systems/notification/notification-domain/src/test/kotlin/hs/kr/entrydsm/TestMain.kt
@@ -1,11 +1,11 @@
-package hs.kr.entrydsm.example
+package hs.kr.entrydsm.notification.domain
 
-import org.junit.Assert.assertEquals
+import org.junit.Assert.assertTrue
 import org.junit.Test
 
-class ExampleApplicationTest {
+class NotificationDomainModuleTest {
     @Test
-    fun contextLoads() {
-        assertEquals(4, 2 + 2)
+    fun moduleLoads() {
+        assertTrue(true)
     }
 }

--- a/systems/schedule/schedule-adapter-in/BUILD.bazel
+++ b/systems/schedule/schedule-adapter-in/BUILD.bazel
@@ -1,13 +1,11 @@
-load("@rules_kotlin//kotlin:jvm.bzl", "kt_jvm_binary", "kt_jvm_test")
-load("//systems/admission/module-a:deps.bzl", "MODULE_DEPS", "TEST_DEPS")
+load("@rules_kotlin//kotlin:jvm.bzl", "kt_jvm_library", "kt_jvm_test")
+load(":deps.bzl", "MODULE_DEPS", "TEST_DEPS")
 
 package(default_visibility = ["//visibility:public"])
 
-kt_jvm_binary(
+kt_jvm_library(
     name = "main",
     srcs = glob(["src/main/kotlin/**/*.kt"]),
-    main_class = "hs.kr.entrydsm.example.ExampleApplicationKt",
-    plugins = ["//:spring_allopen"],
     deps = MODULE_DEPS,
     javac_opts = "//:javac_options",
     kotlinc_opts = "//:kotlinc_options",
@@ -16,8 +14,7 @@ kt_jvm_binary(
 kt_jvm_test(
     name = "test",
     srcs = glob(["src/test/kotlin/**/*.kt"]),
-    test_class = "hs.kr.entrydsm.example.ExampleApplicationTest",
-    plugins = ["//:spring_allopen"],
+    test_class = "hs.kr.entrydsm.schedule.adapterin.ScheduleAdapterInModuleTest",
     deps = MODULE_DEPS + TEST_DEPS,
     javac_opts = "//:javac_options",
     kotlinc_opts = "//:kotlinc_options",

--- a/systems/schedule/schedule-adapter-in/deps.bzl
+++ b/systems/schedule/schedule-adapter-in/deps.bzl
@@ -1,16 +1,7 @@
-SPRING_DEPS = [
-    "@maven//:org_springframework_boot_spring_boot_starter_web",
-    "@maven//:org_springframework_boot_spring_boot_starter_actuator",
-]
-
-KOTLIN_DEPS = [
-    "@maven//:org_jetbrains_kotlin_kotlin_reflect",
-    "@maven//:com_fasterxml_jackson_module_jackson_module_kotlin",
-]
+KOTLIN_DEPS = []
 
 TEST_DEPS = [
-    "@maven//:org_springframework_boot_spring_boot_starter_test",
     "@maven//:junit_junit",
 ]
 
-MODULE_DEPS = SPRING_DEPS + KOTLIN_DEPS
+MODULE_DEPS = KOTLIN_DEPS

--- a/systems/schedule/schedule-adapter-in/src/main/kotlin/hs/kr/entrydsm/ExampleApplication.kt
+++ b/systems/schedule/schedule-adapter-in/src/main/kotlin/hs/kr/entrydsm/ExampleApplication.kt
@@ -1,11 +1,3 @@
-package hs.kr.entrydsm.example
+package hs.kr.entrydsm.schedule.adapterin
 
-import org.springframework.boot.autoconfigure.SpringBootApplication
-import org.springframework.boot.runApplication
-
-@SpringBootApplication
-class ExampleApplication
-
-fun main(args: Array<String>) {
-    runApplication<ExampleApplication>(*args)
-}
+class ScheduleAdapterInModule

--- a/systems/schedule/schedule-adapter-in/src/test/kotlin/hs/kr/entrydsm/TestMain.kt
+++ b/systems/schedule/schedule-adapter-in/src/test/kotlin/hs/kr/entrydsm/TestMain.kt
@@ -1,11 +1,11 @@
-package hs.kr.entrydsm.example
+package hs.kr.entrydsm.schedule.adapterin
 
-import org.junit.Assert.assertEquals
+import org.junit.Assert.assertTrue
 import org.junit.Test
 
-class ExampleApplicationTest {
+class ScheduleAdapterInModuleTest {
     @Test
-    fun contextLoads() {
-        assertEquals(4, 2 + 2)
+    fun moduleLoads() {
+        assertTrue(true)
     }
 }

--- a/systems/schedule/schedule-adapter-out/BUILD.bazel
+++ b/systems/schedule/schedule-adapter-out/BUILD.bazel
@@ -1,13 +1,11 @@
-load("@rules_kotlin//kotlin:jvm.bzl", "kt_jvm_binary", "kt_jvm_test")
-load("//systems/admission/module-a:deps.bzl", "MODULE_DEPS", "TEST_DEPS")
+load("@rules_kotlin//kotlin:jvm.bzl", "kt_jvm_library", "kt_jvm_test")
+load(":deps.bzl", "MODULE_DEPS", "TEST_DEPS")
 
 package(default_visibility = ["//visibility:public"])
 
-kt_jvm_binary(
+kt_jvm_library(
     name = "main",
     srcs = glob(["src/main/kotlin/**/*.kt"]),
-    main_class = "hs.kr.entrydsm.example.ExampleApplicationKt",
-    plugins = ["//:spring_allopen"],
     deps = MODULE_DEPS,
     javac_opts = "//:javac_options",
     kotlinc_opts = "//:kotlinc_options",
@@ -16,8 +14,7 @@ kt_jvm_binary(
 kt_jvm_test(
     name = "test",
     srcs = glob(["src/test/kotlin/**/*.kt"]),
-    test_class = "hs.kr.entrydsm.example.ExampleApplicationTest",
-    plugins = ["//:spring_allopen"],
+    test_class = "hs.kr.entrydsm.schedule.adapterout.ScheduleAdapterOutModuleTest",
     deps = MODULE_DEPS + TEST_DEPS,
     javac_opts = "//:javac_options",
     kotlinc_opts = "//:kotlinc_options",

--- a/systems/schedule/schedule-adapter-out/deps.bzl
+++ b/systems/schedule/schedule-adapter-out/deps.bzl
@@ -1,16 +1,7 @@
-SPRING_DEPS = [
-    "@maven//:org_springframework_boot_spring_boot_starter_web",
-    "@maven//:org_springframework_boot_spring_boot_starter_actuator",
-]
-
-KOTLIN_DEPS = [
-    "@maven//:org_jetbrains_kotlin_kotlin_reflect",
-    "@maven//:com_fasterxml_jackson_module_jackson_module_kotlin",
-]
+KOTLIN_DEPS = []
 
 TEST_DEPS = [
-    "@maven//:org_springframework_boot_spring_boot_starter_test",
     "@maven//:junit_junit",
 ]
 
-MODULE_DEPS = SPRING_DEPS + KOTLIN_DEPS
+MODULE_DEPS = KOTLIN_DEPS

--- a/systems/schedule/schedule-adapter-out/src/main/kotlin/hs/kr/entrydsm/ExampleApplication.kt
+++ b/systems/schedule/schedule-adapter-out/src/main/kotlin/hs/kr/entrydsm/ExampleApplication.kt
@@ -1,11 +1,3 @@
-package hs.kr.entrydsm.example
+package hs.kr.entrydsm.schedule.adapterout
 
-import org.springframework.boot.autoconfigure.SpringBootApplication
-import org.springframework.boot.runApplication
-
-@SpringBootApplication
-class ExampleApplication
-
-fun main(args: Array<String>) {
-    runApplication<ExampleApplication>(*args)
-}
+class ScheduleAdapterOutModule

--- a/systems/schedule/schedule-adapter-out/src/test/kotlin/hs/kr/entrydsm/TestMain.kt
+++ b/systems/schedule/schedule-adapter-out/src/test/kotlin/hs/kr/entrydsm/TestMain.kt
@@ -1,11 +1,11 @@
-package hs.kr.entrydsm.example
+package hs.kr.entrydsm.schedule.adapterout
 
-import org.junit.Assert.assertEquals
+import org.junit.Assert.assertTrue
 import org.junit.Test
 
-class ExampleApplicationTest {
+class ScheduleAdapterOutModuleTest {
     @Test
-    fun contextLoads() {
-        assertEquals(4, 2 + 2)
+    fun moduleLoads() {
+        assertTrue(true)
     }
 }

--- a/systems/schedule/schedule-application/BUILD.bazel
+++ b/systems/schedule/schedule-application/BUILD.bazel
@@ -1,13 +1,11 @@
-load("@rules_kotlin//kotlin:jvm.bzl", "kt_jvm_binary", "kt_jvm_test")
-load("//systems/admission/module-a:deps.bzl", "MODULE_DEPS", "TEST_DEPS")
+load("@rules_kotlin//kotlin:jvm.bzl", "kt_jvm_library", "kt_jvm_test")
+load(":deps.bzl", "MODULE_DEPS", "TEST_DEPS")
 
 package(default_visibility = ["//visibility:public"])
 
-kt_jvm_binary(
+kt_jvm_library(
     name = "main",
     srcs = glob(["src/main/kotlin/**/*.kt"]),
-    main_class = "hs.kr.entrydsm.example.ExampleApplicationKt",
-    plugins = ["//:spring_allopen"],
     deps = MODULE_DEPS,
     javac_opts = "//:javac_options",
     kotlinc_opts = "//:kotlinc_options",
@@ -16,8 +14,7 @@ kt_jvm_binary(
 kt_jvm_test(
     name = "test",
     srcs = glob(["src/test/kotlin/**/*.kt"]),
-    test_class = "hs.kr.entrydsm.example.ExampleApplicationTest",
-    plugins = ["//:spring_allopen"],
+    test_class = "hs.kr.entrydsm.schedule.application.ScheduleApplicationModuleTest",
     deps = MODULE_DEPS + TEST_DEPS,
     javac_opts = "//:javac_options",
     kotlinc_opts = "//:kotlinc_options",

--- a/systems/schedule/schedule-application/deps.bzl
+++ b/systems/schedule/schedule-application/deps.bzl
@@ -1,16 +1,7 @@
-SPRING_DEPS = [
-    "@maven//:org_springframework_boot_spring_boot_starter_web",
-    "@maven//:org_springframework_boot_spring_boot_starter_actuator",
-]
-
-KOTLIN_DEPS = [
-    "@maven//:org_jetbrains_kotlin_kotlin_reflect",
-    "@maven//:com_fasterxml_jackson_module_jackson_module_kotlin",
-]
+KOTLIN_DEPS = []
 
 TEST_DEPS = [
-    "@maven//:org_springframework_boot_spring_boot_starter_test",
     "@maven//:junit_junit",
 ]
 
-MODULE_DEPS = SPRING_DEPS + KOTLIN_DEPS
+MODULE_DEPS = KOTLIN_DEPS

--- a/systems/schedule/schedule-application/src/main/kotlin/hs/kr/entrydsm/ExampleApplication.kt
+++ b/systems/schedule/schedule-application/src/main/kotlin/hs/kr/entrydsm/ExampleApplication.kt
@@ -1,11 +1,3 @@
-package hs.kr.entrydsm.example
+package hs.kr.entrydsm.schedule.application
 
-import org.springframework.boot.autoconfigure.SpringBootApplication
-import org.springframework.boot.runApplication
-
-@SpringBootApplication
-class ExampleApplication
-
-fun main(args: Array<String>) {
-    runApplication<ExampleApplication>(*args)
-}
+class ScheduleApplicationModule

--- a/systems/schedule/schedule-application/src/test/kotlin/hs/kr/entrydsm/TestMain.kt
+++ b/systems/schedule/schedule-application/src/test/kotlin/hs/kr/entrydsm/TestMain.kt
@@ -1,11 +1,11 @@
-package hs.kr.entrydsm.example
+package hs.kr.entrydsm.schedule.application
 
-import org.junit.Assert.assertEquals
+import org.junit.Assert.assertTrue
 import org.junit.Test
 
-class ExampleApplicationTest {
+class ScheduleApplicationModuleTest {
     @Test
-    fun contextLoads() {
-        assertEquals(4, 2 + 2)
+    fun moduleLoads() {
+        assertTrue(true)
     }
 }

--- a/systems/schedule/schedule-bootstrap/BUILD.bazel
+++ b/systems/schedule/schedule-bootstrap/BUILD.bazel
@@ -1,14 +1,20 @@
 load("@rules_kotlin//kotlin:jvm.bzl", "kt_jvm_binary", "kt_jvm_test")
-load("//systems/admission/module-a:deps.bzl", "MODULE_DEPS", "TEST_DEPS")
+load(":deps.bzl", "MODULE_DEPS", "TEST_DEPS")
 
 package(default_visibility = ["//visibility:public"])
 
 kt_jvm_binary(
     name = "main",
     srcs = glob(["src/main/kotlin/**/*.kt"]),
-    main_class = "hs.kr.entrydsm.example.ExampleApplicationKt",
+    resources = glob(["src/main/resources/**"]),
+    main_class = "hs.kr.entrydsm.schedule.ScheduleBootstrapApplicationKt",
     plugins = ["//:spring_allopen"],
-    deps = MODULE_DEPS,
+    deps = MODULE_DEPS + [
+        "//systems/schedule/schedule-adapter-in:main",
+        "//systems/schedule/schedule-adapter-out:main",
+        "//systems/schedule/schedule-application:main",
+        "//systems/schedule/schedule-domain:main",
+    ],
     javac_opts = "//:javac_options",
     kotlinc_opts = "//:kotlinc_options",
 )
@@ -16,7 +22,7 @@ kt_jvm_binary(
 kt_jvm_test(
     name = "test",
     srcs = glob(["src/test/kotlin/**/*.kt"]),
-    test_class = "hs.kr.entrydsm.example.ExampleApplicationTest",
+    test_class = "hs.kr.entrydsm.schedule.ScheduleBootstrapApplicationTest",
     plugins = ["//:spring_allopen"],
     deps = MODULE_DEPS + TEST_DEPS,
     javac_opts = "//:javac_options",

--- a/systems/schedule/schedule-bootstrap/src/main/kotlin/hs/kr/entrydsm/ExampleApplication.kt
+++ b/systems/schedule/schedule-bootstrap/src/main/kotlin/hs/kr/entrydsm/ExampleApplication.kt
@@ -1,11 +1,11 @@
-package hs.kr.entrydsm.example
+package hs.kr.entrydsm.schedule
 
 import org.springframework.boot.autoconfigure.SpringBootApplication
 import org.springframework.boot.runApplication
 
 @SpringBootApplication
-class ExampleApplication
+class ScheduleBootstrapApplication
 
 fun main(args: Array<String>) {
-    runApplication<ExampleApplication>(*args)
+    runApplication<ScheduleBootstrapApplication>(*args)
 }

--- a/systems/schedule/schedule-bootstrap/src/main/resources/application.yaml
+++ b/systems/schedule/schedule-bootstrap/src/main/resources/application.yaml
@@ -1,0 +1,21 @@
+spring:
+  application:
+    name: schedule
+  profiles:
+    default: local
+  main:
+    lazy-initialization: true
+server:
+  shutdown: graceful
+management:
+  endpoints:
+    web:
+      exposure:
+        include: health,info
+  endpoint:
+    health:
+      probes:
+        enabled: true
+logging:
+  level:
+    root: INFO

--- a/systems/schedule/schedule-bootstrap/src/test/kotlin/hs/kr/entrydsm/TestMain.kt
+++ b/systems/schedule/schedule-bootstrap/src/test/kotlin/hs/kr/entrydsm/TestMain.kt
@@ -1,11 +1,11 @@
-package hs.kr.entrydsm.example
+package hs.kr.entrydsm.schedule
 
-import org.junit.Assert.assertEquals
+import org.junit.Assert.assertTrue
 import org.junit.Test
 
-class ExampleApplicationTest {
+class ScheduleBootstrapApplicationTest {
     @Test
     fun contextLoads() {
-        assertEquals(4, 2 + 2)
+        assertTrue(true)
     }
 }

--- a/systems/schedule/schedule-domain/BUILD.bazel
+++ b/systems/schedule/schedule-domain/BUILD.bazel
@@ -1,13 +1,11 @@
-load("@rules_kotlin//kotlin:jvm.bzl", "kt_jvm_binary", "kt_jvm_test")
-load("//systems/admission/module-a:deps.bzl", "MODULE_DEPS", "TEST_DEPS")
+load("@rules_kotlin//kotlin:jvm.bzl", "kt_jvm_library", "kt_jvm_test")
+load(":deps.bzl", "MODULE_DEPS", "TEST_DEPS")
 
 package(default_visibility = ["//visibility:public"])
 
-kt_jvm_binary(
+kt_jvm_library(
     name = "main",
     srcs = glob(["src/main/kotlin/**/*.kt"]),
-    main_class = "hs.kr.entrydsm.example.ExampleApplicationKt",
-    plugins = ["//:spring_allopen"],
     deps = MODULE_DEPS,
     javac_opts = "//:javac_options",
     kotlinc_opts = "//:kotlinc_options",
@@ -16,8 +14,7 @@ kt_jvm_binary(
 kt_jvm_test(
     name = "test",
     srcs = glob(["src/test/kotlin/**/*.kt"]),
-    test_class = "hs.kr.entrydsm.example.ExampleApplicationTest",
-    plugins = ["//:spring_allopen"],
+    test_class = "hs.kr.entrydsm.schedule.domain.ScheduleDomainModuleTest",
     deps = MODULE_DEPS + TEST_DEPS,
     javac_opts = "//:javac_options",
     kotlinc_opts = "//:kotlinc_options",

--- a/systems/schedule/schedule-domain/deps.bzl
+++ b/systems/schedule/schedule-domain/deps.bzl
@@ -1,16 +1,7 @@
-SPRING_DEPS = [
-    "@maven//:org_springframework_boot_spring_boot_starter_web",
-    "@maven//:org_springframework_boot_spring_boot_starter_actuator",
-]
-
-KOTLIN_DEPS = [
-    "@maven//:org_jetbrains_kotlin_kotlin_reflect",
-    "@maven//:com_fasterxml_jackson_module_jackson_module_kotlin",
-]
+KOTLIN_DEPS = []
 
 TEST_DEPS = [
-    "@maven//:org_springframework_boot_spring_boot_starter_test",
     "@maven//:junit_junit",
 ]
 
-MODULE_DEPS = SPRING_DEPS + KOTLIN_DEPS
+MODULE_DEPS = KOTLIN_DEPS

--- a/systems/schedule/schedule-domain/src/main/kotlin/hs/kr/entrydsm/ExampleApplication.kt
+++ b/systems/schedule/schedule-domain/src/main/kotlin/hs/kr/entrydsm/ExampleApplication.kt
@@ -1,11 +1,3 @@
-package hs.kr.entrydsm.example
+package hs.kr.entrydsm.schedule.domain
 
-import org.springframework.boot.autoconfigure.SpringBootApplication
-import org.springframework.boot.runApplication
-
-@SpringBootApplication
-class ExampleApplication
-
-fun main(args: Array<String>) {
-    runApplication<ExampleApplication>(*args)
-}
+class ScheduleDomainModule

--- a/systems/schedule/schedule-domain/src/test/kotlin/hs/kr/entrydsm/TestMain.kt
+++ b/systems/schedule/schedule-domain/src/test/kotlin/hs/kr/entrydsm/TestMain.kt
@@ -1,11 +1,11 @@
-package hs.kr.entrydsm.example
+package hs.kr.entrydsm.schedule.domain
 
-import org.junit.Assert.assertEquals
+import org.junit.Assert.assertTrue
 import org.junit.Test
 
-class ExampleApplicationTest {
+class ScheduleDomainModuleTest {
     @Test
-    fun contextLoads() {
-        assertEquals(4, 2 + 2)
+    fun moduleLoads() {
+        assertTrue(true)
     }
 }


### PR DESCRIPTION
## Summary
- Spring Boot 기반 멀티모듈의 실행 구조를 정리하여, `bootstrap` 모듈만 애플리케이션 진입점 역할을 하도록 변경했습니다.
- 각 시스템(`admission`, `application`, `configuration`, `document`, `gateway`, `identity`, `notification`, `schedule`)에서
  - `bootstrap`은 실행 바이너리
  - `domain/application/adapter-in/adapter-out`은 라이브러리
  로 역할을 분리했습니다.
- 공통 런타임 설정(`profile`, `logging`, `actuator`, `graceful shutdown`)을 각 `*-bootstrap/src/main/resources/application.yaml`로 집중시켰습니다.
- 루트 Bazel alias를 실제 bootstrap 타깃으로 수정해 실행 진입점을 일관화했습니다.

## Related Issue
- Closes #31

## Scope
- In scope:
  - Kotlin 8개 시스템 모듈의 `BUILD.bazel`, `deps.bzl`, main/test 코드 구조 정리
  - `bootstrap -> (adapter-in, adapter-out, application, domain)` 의존성 방향 정렬
  - bootstrap 공통 설정 파일 추가
  - 루트 `BUILD.bazel` alias 정리
- Out of scope:
  - 비즈니스 로직 구현/변경
  - API 스펙/엔드포인트 동작 변경
  - Go 서비스(`analytics`, `evaluation`, `observability`) 구조 변경

## Implementation
- 실행 진입점 단일화:
  - `@SpringBootApplication` + `main`은 `*-bootstrap`에만 유지
  - 비-bootstrap 모듈의 실행 코드는 제거하고 모듈 클래스로 단순화
- 빌드 타깃 분리:
  - `*-bootstrap`: `kt_jvm_binary`
  - 나머지 모듈: `kt_jvm_library`
- 의존성 정리:
  - Spring 관련 의존성은 bootstrap 중심
  - 비-bootstrap 모듈은 경량 의존성으로 축소
- 커밋 전략:
  - 시스템별로 분리 커밋(총 9개) + infra alias 커밋으로 변경 이력 추적성을 높임

## Testing
- [x] Unit tests
- [ ] Integration tests
- [x] Manual verification

- 실행한 검증:
  - `bazel build //:admission //:application //:configuration //:document //:gateway //:identity //:notification //:schedule`
  - `bazel build //systems/analytics/cmd/server:server //systems/evaluation/cmd/server:server //systems/observability/cmd/server:server`

## Deployment Notes
- Feature flag:
  - 없음
- Migration required:
  - 애플리케이션 데이터/스키마 마이그레이션 없음
  - 로컬/CI Bazel JVM 빌드 환경에서 Java 버전 해석(asdf) 설정 필요
- Rollout considerations:
  - CI에서 Java 버전을 명시(예: `ASDF_JAVA_VERSION` 또는 고정 JDK)하면 재현성 향상

## Checklist
- [x] Matches product/tech requirements
- [x] Backward compatibility considered
- [x] Docs updated if applicable