### PR TITLE
feat(configuration): 환경변수 DB 저장 기능 구현 (#36)

### DIFF
--- a/MODULE.bazel
+++ b/MODULE.bazel
@@ -7,6 +7,8 @@ bazel_dep(name = "rules_kotlin", version = "2.1.0")
 bazel_dep(name = "rules_jvm_external", version = "6.7")
 bazel_dep(name = "rules_go", version = "0.59.0")
 bazel_dep(name = "gazelle", version = "0.47.0")
+bazel_dep(name = "rules_proto", version = "7.0.2")
+bazel_dep(name = "grpc-java", version = "1.70.0")
 
 include("//:kotlin.MODULE.bazel")
 include("//:go.MODULE.bazel")

--- a/contracts/BUILD.bazel
+++ b/contracts/BUILD.bazel
@@ -1,0 +1,21 @@
+load("@rules_proto//proto:defs.bzl", "proto_library")
+load("@grpc-java//:java_grpc_library.bzl", "java_grpc_library")
+load("@rules_java//java:defs.bzl", "java_proto_library")
+
+package(default_visibility = ["//visibility:public"])
+
+proto_library(
+    name = "configuration_proto",
+    srcs = ["proto/configuration.proto"],
+)
+
+java_proto_library(
+    name = "configuration_java_proto",
+    deps = [":configuration_proto"],
+)
+
+java_grpc_library(
+    name = "configuration_grpc_java",
+    srcs = [":configuration_proto"],
+    deps = [":configuration_java_proto"],
+)

--- a/contracts/proto/configuration.proto
+++ b/contracts/proto/configuration.proto
@@ -1,0 +1,52 @@
+syntax = "proto3";
+
+package entrydsm.configuration.v1;
+
+option java_package = "hs.kr.entrydsm.configuration.grpc";
+option java_multiple_files = true;
+option java_outer_classname = "ConfigurationProto";
+
+service ConfigurationService {
+    rpc CreateEnvironmentVariable(CreateEnvironmentVariableRequest) returns (EnvironmentVariableResponse);
+    rpc GetEnvironmentVariable(GetEnvironmentVariableRequest) returns (EnvironmentVariableResponse);
+    rpc GetAllEnvironmentVariables(GetAllEnvironmentVariablesRequest) returns (GetAllEnvironmentVariablesResponse);
+    rpc UpdateEnvironmentVariable(UpdateEnvironmentVariableRequest) returns (EnvironmentVariableResponse);
+    rpc DeleteEnvironmentVariable(DeleteEnvironmentVariableRequest) returns (DeleteEnvironmentVariableResponse);
+}
+
+message CreateEnvironmentVariableRequest {
+    string key = 1;
+    string value = 2;
+    optional string description = 3;
+}
+
+message GetEnvironmentVariableRequest {
+    string key = 1;
+}
+
+message GetAllEnvironmentVariablesRequest {}
+
+message UpdateEnvironmentVariableRequest {
+    string key = 1;
+    string value = 2;
+    optional string description = 3;
+}
+
+message DeleteEnvironmentVariableRequest {
+    string key = 1;
+}
+
+message EnvironmentVariableResponse {
+    int64 id = 1;
+    string key = 2;
+    string value = 3;
+    optional string description = 4;
+}
+
+message GetAllEnvironmentVariablesResponse {
+    repeated EnvironmentVariableResponse items = 1;
+}
+
+message DeleteEnvironmentVariableResponse {
+    bool success = 1;
+}

--- a/kotlin.MODULE.bazel
+++ b/kotlin.MODULE.bazel
@@ -9,4 +9,18 @@ maven.artifact(artifact = "kotlin-reflect", group = "org.jetbrains.kotlin", vers
 maven.artifact(artifact = "kotlin-allopen-compiler-plugin", group = "org.jetbrains.kotlin", version = "2.1.0")
 maven.artifact(artifact = "jackson-module-kotlin", group = "com.fasterxml.jackson.module", version = "2.18.2")
 
+# JPA / DB
+maven.artifact(artifact = "spring-boot-starter-data-jpa", group = "org.springframework.boot", version = "4.0.1")
+maven.artifact(artifact = "spring-boot-starter", group = "org.springframework.boot", version = "4.0.1")
+maven.artifact(artifact = "mysql-connector-j", group = "com.mysql", version = "9.3.0")
+
+# gRPC
+maven.artifact(artifact = "grpc-netty-shaded", group = "io.grpc", version = "1.70.0")
+maven.artifact(artifact = "grpc-protobuf", group = "io.grpc", version = "1.70.0")
+maven.artifact(artifact = "grpc-stub", group = "io.grpc", version = "1.70.0")
+maven.artifact(artifact = "grpc-kotlin-stub", group = "io.grpc", version = "1.4.1")
+maven.artifact(artifact = "protobuf-java", group = "com.google.protobuf", version = "4.30.2")
+maven.artifact(artifact = "protobuf-kotlin", group = "com.google.protobuf", version = "4.30.2")
+maven.artifact(artifact = "javax.annotation-api", group = "javax.annotation", version = "1.3.2")
+
 use_repo(maven, "maven")

--- a/systems/configuration/configuration-adapter-in/deps.bzl
+++ b/systems/configuration/configuration-adapter-in/deps.bzl
@@ -1,4 +1,16 @@
-KOTLIN_DEPS = []
+KOTLIN_DEPS = [
+    "@maven//:io_grpc_grpc_netty_shaded",
+    "@maven//:io_grpc_grpc_protobuf",
+    "@maven//:io_grpc_grpc_stub",
+    "@maven//:io_grpc_grpc_kotlin_stub",
+    "@maven//:com_google_protobuf_protobuf_java",
+    "@maven//:com_google_protobuf_protobuf_kotlin",
+    "@maven//:javax_annotation_javax_annotation_api",
+    "@maven//:org_springframework_boot_spring_boot_starter",
+    "//contracts:configuration_grpc_java",
+    "//contracts:configuration_java_proto",
+    "//systems/configuration/configuration-domain:main",
+]
 
 TEST_DEPS = [
     "@maven//:junit_junit",

--- a/systems/configuration/configuration-adapter-in/src/main/kotlin/hs/kr/entrydsm/configuration/adapterin/grpc/ConfigurationGrpcServer.kt
+++ b/systems/configuration/configuration-adapter-in/src/main/kotlin/hs/kr/entrydsm/configuration/adapterin/grpc/ConfigurationGrpcServer.kt
@@ -1,0 +1,33 @@
+package hs.kr.entrydsm.configuration.adapterin.grpc
+
+import io.grpc.Server
+import io.grpc.ServerBuilder
+import org.springframework.beans.factory.annotation.Value
+import org.springframework.context.SmartLifecycle
+import org.springframework.stereotype.Component
+import java.util.concurrent.TimeUnit
+
+@Component
+class ConfigurationGrpcServer(
+    @Value("\${grpc.port:9090}") private val port: Int,
+    private val configurationGrpcService: ConfigurationGrpcService,
+) : SmartLifecycle {
+
+    private var server: Server? = null
+    private var running = false
+
+    override fun start() {
+        server = ServerBuilder.forPort(port)
+            .addService(configurationGrpcService)
+            .build()
+            .start()
+        running = true
+    }
+
+    override fun stop() {
+        server?.shutdown()?.awaitTermination(30, TimeUnit.SECONDS)
+        running = false
+    }
+
+    override fun isRunning(): Boolean = running
+}

--- a/systems/configuration/configuration-adapter-in/src/main/kotlin/hs/kr/entrydsm/configuration/adapterin/grpc/ConfigurationGrpcService.kt
+++ b/systems/configuration/configuration-adapter-in/src/main/kotlin/hs/kr/entrydsm/configuration/adapterin/grpc/ConfigurationGrpcService.kt
@@ -1,0 +1,102 @@
+package hs.kr.entrydsm.configuration.adapterin.grpc
+
+import hs.kr.entrydsm.configuration.domain.command.CreateEnvironmentVariableCommand
+import hs.kr.entrydsm.configuration.domain.command.UpdateEnvironmentVariableCommand
+import hs.kr.entrydsm.configuration.domain.port.`in`.CreateEnvironmentVariableUseCase
+import hs.kr.entrydsm.configuration.domain.port.`in`.DeleteEnvironmentVariableUseCase
+import hs.kr.entrydsm.configuration.domain.port.`in`.ReadEnvironmentVariableUseCase
+import hs.kr.entrydsm.configuration.domain.port.`in`.UpdateEnvironmentVariableUseCase
+import hs.kr.entrydsm.configuration.grpc.ConfigurationServiceGrpc
+import hs.kr.entrydsm.configuration.grpc.CreateEnvironmentVariableRequest
+import hs.kr.entrydsm.configuration.grpc.DeleteEnvironmentVariableRequest
+import hs.kr.entrydsm.configuration.grpc.DeleteEnvironmentVariableResponse
+import hs.kr.entrydsm.configuration.grpc.EnvironmentVariableResponse
+import hs.kr.entrydsm.configuration.grpc.GetAllEnvironmentVariablesRequest
+import hs.kr.entrydsm.configuration.grpc.GetAllEnvironmentVariablesResponse
+import hs.kr.entrydsm.configuration.grpc.GetEnvironmentVariableRequest
+import hs.kr.entrydsm.configuration.grpc.UpdateEnvironmentVariableRequest
+import io.grpc.stub.StreamObserver
+import org.springframework.stereotype.Component
+
+@Component
+class ConfigurationGrpcService(
+    private val createUseCase: CreateEnvironmentVariableUseCase,
+    private val readUseCase: ReadEnvironmentVariableUseCase,
+    private val updateUseCase: UpdateEnvironmentVariableUseCase,
+    private val deleteUseCase: DeleteEnvironmentVariableUseCase,
+) : ConfigurationServiceGrpc.ConfigurationServiceImplBase() {
+
+    override fun createEnvironmentVariable(
+        request: CreateEnvironmentVariableRequest,
+        responseObserver: StreamObserver<EnvironmentVariableResponse>,
+    ) {
+        val result = createUseCase.create(
+            CreateEnvironmentVariableCommand(
+                key = request.key,
+                value = request.value,
+                description = if (request.hasDescription()) request.description else null,
+            )
+        )
+        responseObserver.onNext(result.toResponse())
+        responseObserver.onCompleted()
+    }
+
+    override fun getEnvironmentVariable(
+        request: GetEnvironmentVariableRequest,
+        responseObserver: StreamObserver<EnvironmentVariableResponse>,
+    ) {
+        val result = readUseCase.findByKey(request.key)
+        responseObserver.onNext(result.toResponse())
+        responseObserver.onCompleted()
+    }
+
+    override fun getAllEnvironmentVariables(
+        request: GetAllEnvironmentVariablesRequest,
+        responseObserver: StreamObserver<GetAllEnvironmentVariablesResponse>,
+    ) {
+        val items = readUseCase.findAll().map { it.toResponse() }
+        responseObserver.onNext(
+            GetAllEnvironmentVariablesResponse.newBuilder()
+                .addAllItems(items)
+                .build()
+        )
+        responseObserver.onCompleted()
+    }
+
+    override fun updateEnvironmentVariable(
+        request: UpdateEnvironmentVariableRequest,
+        responseObserver: StreamObserver<EnvironmentVariableResponse>,
+    ) {
+        val result = updateUseCase.update(
+            UpdateEnvironmentVariableCommand(
+                key = request.key,
+                value = request.value,
+                description = if (request.hasDescription()) request.description else null,
+            )
+        )
+        responseObserver.onNext(result.toResponse())
+        responseObserver.onCompleted()
+    }
+
+    override fun deleteEnvironmentVariable(
+        request: DeleteEnvironmentVariableRequest,
+        responseObserver: StreamObserver<DeleteEnvironmentVariableResponse>,
+    ) {
+        deleteUseCase.delete(request.key)
+        responseObserver.onNext(
+            DeleteEnvironmentVariableResponse.newBuilder()
+                .setSuccess(true)
+                .build()
+        )
+        responseObserver.onCompleted()
+    }
+
+    private fun hs.kr.entrydsm.configuration.domain.EnvironmentVariable.toResponse(): EnvironmentVariableResponse {
+        val builder = EnvironmentVariableResponse.newBuilder()
+            .setId(id ?: 0L)
+            .setKey(key)
+            .setValue(value)
+        description?.let { builder.setDescription(it) }
+        return builder.build()
+    }
+}

--- a/systems/configuration/configuration-adapter-out/deps.bzl
+++ b/systems/configuration/configuration-adapter-out/deps.bzl
@@ -1,4 +1,8 @@
-KOTLIN_DEPS = []
+KOTLIN_DEPS = [
+    "@maven//:org_springframework_boot_spring_boot_starter_data_jpa",
+    "@maven//:com_mysql_mysql_connector_j",
+    "//systems/configuration/configuration-domain:main",
+]
 
 TEST_DEPS = [
     "@maven//:junit_junit",

--- a/systems/configuration/configuration-adapter-out/src/main/kotlin/hs/kr/entrydsm/configuration/adapterout/EnvironmentVariablePersistenceAdapter.kt
+++ b/systems/configuration/configuration-adapter-out/src/main/kotlin/hs/kr/entrydsm/configuration/adapterout/EnvironmentVariablePersistenceAdapter.kt
@@ -1,0 +1,30 @@
+package hs.kr.entrydsm.configuration.adapterout
+
+import hs.kr.entrydsm.configuration.adapterout.entity.EnvironmentVariableJpaEntity
+import hs.kr.entrydsm.configuration.adapterout.repository.EnvironmentVariableJpaRepository
+import hs.kr.entrydsm.configuration.domain.EnvironmentVariable
+import hs.kr.entrydsm.configuration.domain.port.out.EnvironmentVariableRepository
+import org.springframework.stereotype.Component
+
+@Component
+class EnvironmentVariablePersistenceAdapter(
+    private val environmentVariableJpaRepository: EnvironmentVariableJpaRepository,
+) : EnvironmentVariableRepository {
+
+    override fun save(environmentVariable: EnvironmentVariable): EnvironmentVariable =
+        environmentVariableJpaRepository.save(
+            EnvironmentVariableJpaEntity.from(environmentVariable)
+        ).toDomain()
+
+    override fun findByKey(key: String): EnvironmentVariable? =
+        environmentVariableJpaRepository.findByKey(key)?.toDomain()
+
+    override fun findAll(): List<EnvironmentVariable> =
+        environmentVariableJpaRepository.findAll().map { it.toDomain() }
+
+    override fun deleteByKey(key: String) =
+        environmentVariableJpaRepository.deleteByKey(key)
+
+    override fun existsByKey(key: String): Boolean =
+        environmentVariableJpaRepository.existsByKey(key)
+}

--- a/systems/configuration/configuration-adapter-out/src/main/kotlin/hs/kr/entrydsm/configuration/adapterout/entity/EnvironmentVariableJpaEntity.kt
+++ b/systems/configuration/configuration-adapter-out/src/main/kotlin/hs/kr/entrydsm/configuration/adapterout/entity/EnvironmentVariableJpaEntity.kt
@@ -1,0 +1,42 @@
+package hs.kr.entrydsm.configuration.adapterout.entity
+
+import hs.kr.entrydsm.configuration.domain.EnvironmentVariable
+import jakarta.persistence.Column
+import jakarta.persistence.Entity
+import jakarta.persistence.GeneratedValue
+import jakarta.persistence.GenerationType
+import jakarta.persistence.Id
+import jakarta.persistence.Table
+
+@Entity
+@Table(name = "environment_variable")
+class EnvironmentVariableJpaEntity(
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    val id: Long? = null,
+
+    @Column(name = "env_key", unique = true, nullable = false, length = 255)
+    val key: String,
+
+    @Column(name = "env_value", nullable = false, columnDefinition = "TEXT")
+    val value: String,
+
+    @Column(name = "description", columnDefinition = "TEXT")
+    val description: String? = null,
+) {
+    fun toDomain() = EnvironmentVariable(
+        id = id,
+        key = key,
+        value = value,
+        description = description,
+    )
+
+    companion object {
+        fun from(domain: EnvironmentVariable) = EnvironmentVariableJpaEntity(
+            id = domain.id,
+            key = domain.key,
+            value = domain.value,
+            description = domain.description,
+        )
+    }
+}

--- a/systems/configuration/configuration-adapter-out/src/main/kotlin/hs/kr/entrydsm/configuration/adapterout/repository/EnvironmentVariableJpaRepository.kt
+++ b/systems/configuration/configuration-adapter-out/src/main/kotlin/hs/kr/entrydsm/configuration/adapterout/repository/EnvironmentVariableJpaRepository.kt
@@ -1,0 +1,10 @@
+package hs.kr.entrydsm.configuration.adapterout.repository
+
+import hs.kr.entrydsm.configuration.adapterout.entity.EnvironmentVariableJpaEntity
+import org.springframework.data.jpa.repository.JpaRepository
+
+interface EnvironmentVariableJpaRepository : JpaRepository<EnvironmentVariableJpaEntity, Long> {
+    fun findByKey(key: String): EnvironmentVariableJpaEntity?
+    fun deleteByKey(key: String)
+    fun existsByKey(key: String): Boolean
+}

--- a/systems/configuration/configuration-application/deps.bzl
+++ b/systems/configuration/configuration-application/deps.bzl
@@ -1,4 +1,7 @@
-KOTLIN_DEPS = []
+KOTLIN_DEPS = [
+    "@maven//:org_springframework_boot_spring_boot_starter",
+    "//systems/configuration/configuration-domain:main",
+]
 
 TEST_DEPS = [
     "@maven//:junit_junit",

--- a/systems/configuration/configuration-application/src/main/kotlin/hs/kr/entrydsm/configuration/application/EnvironmentVariableService.kt
+++ b/systems/configuration/configuration-application/src/main/kotlin/hs/kr/entrydsm/configuration/application/EnvironmentVariableService.kt
@@ -1,0 +1,65 @@
+package hs.kr.entrydsm.configuration.application
+
+import hs.kr.entrydsm.configuration.domain.EnvironmentVariable
+import hs.kr.entrydsm.configuration.domain.command.CreateEnvironmentVariableCommand
+import hs.kr.entrydsm.configuration.domain.command.UpdateEnvironmentVariableCommand
+import hs.kr.entrydsm.configuration.domain.exception.EnvironmentVariableAlreadyExistsException
+import hs.kr.entrydsm.configuration.domain.exception.EnvironmentVariableNotFoundException
+import hs.kr.entrydsm.configuration.domain.port.`in`.CreateEnvironmentVariableUseCase
+import hs.kr.entrydsm.configuration.domain.port.`in`.DeleteEnvironmentVariableUseCase
+import hs.kr.entrydsm.configuration.domain.port.`in`.ReadEnvironmentVariableUseCase
+import hs.kr.entrydsm.configuration.domain.port.`in`.UpdateEnvironmentVariableUseCase
+import hs.kr.entrydsm.configuration.domain.port.out.EnvironmentVariableRepository
+import org.springframework.stereotype.Service
+import org.springframework.transaction.annotation.Transactional
+
+@Service
+@Transactional(readOnly = true)
+class EnvironmentVariableService(
+    private val environmentVariableRepository: EnvironmentVariableRepository,
+) : CreateEnvironmentVariableUseCase,
+    ReadEnvironmentVariableUseCase,
+    UpdateEnvironmentVariableUseCase,
+    DeleteEnvironmentVariableUseCase {
+
+    @Transactional
+    override fun create(command: CreateEnvironmentVariableCommand): EnvironmentVariable {
+        if (environmentVariableRepository.existsByKey(command.key)) {
+            throw EnvironmentVariableAlreadyExistsException(command.key)
+        }
+        return environmentVariableRepository.save(
+            EnvironmentVariable(
+                key = command.key,
+                value = command.value,
+                description = command.description,
+            )
+        )
+    }
+
+    override fun findByKey(key: String): EnvironmentVariable =
+        environmentVariableRepository.findByKey(key)
+            ?: throw EnvironmentVariableNotFoundException(key)
+
+    override fun findAll(): List<EnvironmentVariable> =
+        environmentVariableRepository.findAll()
+
+    @Transactional
+    override fun update(command: UpdateEnvironmentVariableCommand): EnvironmentVariable {
+        val existing = environmentVariableRepository.findByKey(command.key)
+            ?: throw EnvironmentVariableNotFoundException(command.key)
+        return environmentVariableRepository.save(
+            existing.copy(
+                value = command.value,
+                description = command.description,
+            )
+        )
+    }
+
+    @Transactional
+    override fun delete(key: String) {
+        if (!environmentVariableRepository.existsByKey(key)) {
+            throw EnvironmentVariableNotFoundException(key)
+        }
+        environmentVariableRepository.deleteByKey(key)
+    }
+}

--- a/systems/configuration/configuration-bootstrap/deps.bzl
+++ b/systems/configuration/configuration-bootstrap/deps.bzl
@@ -1,11 +1,13 @@
 SPRING_DEPS = [
     "@maven//:org_springframework_boot_spring_boot_starter_web",
     "@maven//:org_springframework_boot_spring_boot_starter_actuator",
+    "@maven//:org_springframework_boot_spring_boot_starter_data_jpa",
 ]
 
 KOTLIN_DEPS = [
     "@maven//:org_jetbrains_kotlin_kotlin_reflect",
     "@maven//:com_fasterxml_jackson_module_jackson_module_kotlin",
+    "@maven//:com_mysql_mysql_connector_j",
 ]
 
 TEST_DEPS = [

--- a/systems/configuration/configuration-bootstrap/src/main/resources/application.yaml
+++ b/systems/configuration/configuration-bootstrap/src/main/resources/application.yaml
@@ -5,8 +5,25 @@ spring:
     default: local
   main:
     lazy-initialization: true
+  datasource:
+    url: jdbc:mysql://localhost:3306/configuration_db?useSSL=false&serverTimezone=UTC&allowPublicKeyRetrieval=true
+    username: ${DB_USERNAME:root}
+    password: ${DB_PASSWORD:password}
+    driver-class-name: com.mysql.cj.jdbc.Driver
+  jpa:
+    hibernate:
+      ddl-auto: validate
+    show-sql: false
+    properties:
+      hibernate:
+        dialect: org.hibernate.dialect.MySQLDialect
+
 server:
   shutdown: graceful
+
+grpc:
+  port: ${GRPC_PORT:9090}
+
 management:
   endpoints:
     web:
@@ -16,6 +33,7 @@ management:
     health:
       probes:
         enabled: true
+
 logging:
   level:
     root: INFO

--- a/systems/configuration/configuration-domain/src/main/kotlin/hs/kr/entrydsm/configuration/domain/EnvironmentVariable.kt
+++ b/systems/configuration/configuration-domain/src/main/kotlin/hs/kr/entrydsm/configuration/domain/EnvironmentVariable.kt
@@ -1,0 +1,8 @@
+package hs.kr.entrydsm.configuration.domain
+
+data class EnvironmentVariable(
+    val id: Long? = null,
+    val key: String,
+    val value: String,
+    val description: String? = null,
+)

--- a/systems/configuration/configuration-domain/src/main/kotlin/hs/kr/entrydsm/configuration/domain/command/CreateEnvironmentVariableCommand.kt
+++ b/systems/configuration/configuration-domain/src/main/kotlin/hs/kr/entrydsm/configuration/domain/command/CreateEnvironmentVariableCommand.kt
@@ -1,0 +1,7 @@
+package hs.kr.entrydsm.configuration.domain.command
+
+data class CreateEnvironmentVariableCommand(
+    val key: String,
+    val value: String,
+    val description: String? = null,
+)

--- a/systems/configuration/configuration-domain/src/main/kotlin/hs/kr/entrydsm/configuration/domain/command/UpdateEnvironmentVariableCommand.kt
+++ b/systems/configuration/configuration-domain/src/main/kotlin/hs/kr/entrydsm/configuration/domain/command/UpdateEnvironmentVariableCommand.kt
@@ -1,0 +1,7 @@
+package hs.kr.entrydsm.configuration.domain.command
+
+data class UpdateEnvironmentVariableCommand(
+    val key: String,
+    val value: String,
+    val description: String? = null,
+)

--- a/systems/configuration/configuration-domain/src/main/kotlin/hs/kr/entrydsm/configuration/domain/exception/EnvironmentVariableAlreadyExistsException.kt
+++ b/systems/configuration/configuration-domain/src/main/kotlin/hs/kr/entrydsm/configuration/domain/exception/EnvironmentVariableAlreadyExistsException.kt
@@ -1,0 +1,4 @@
+package hs.kr.entrydsm.configuration.domain.exception
+
+class EnvironmentVariableAlreadyExistsException(key: String) :
+    RuntimeException("Environment variable already exists: $key")

--- a/systems/configuration/configuration-domain/src/main/kotlin/hs/kr/entrydsm/configuration/domain/exception/EnvironmentVariableNotFoundException.kt
+++ b/systems/configuration/configuration-domain/src/main/kotlin/hs/kr/entrydsm/configuration/domain/exception/EnvironmentVariableNotFoundException.kt
@@ -1,0 +1,4 @@
+package hs.kr.entrydsm.configuration.domain.exception
+
+class EnvironmentVariableNotFoundException(key: String) :
+    RuntimeException("Environment variable not found: $key")

--- a/systems/configuration/configuration-domain/src/main/kotlin/hs/kr/entrydsm/configuration/domain/port/in/CreateEnvironmentVariableUseCase.kt
+++ b/systems/configuration/configuration-domain/src/main/kotlin/hs/kr/entrydsm/configuration/domain/port/in/CreateEnvironmentVariableUseCase.kt
@@ -1,0 +1,8 @@
+package hs.kr.entrydsm.configuration.domain.port.`in`
+
+import hs.kr.entrydsm.configuration.domain.EnvironmentVariable
+import hs.kr.entrydsm.configuration.domain.command.CreateEnvironmentVariableCommand
+
+interface CreateEnvironmentVariableUseCase {
+    fun create(command: CreateEnvironmentVariableCommand): EnvironmentVariable
+}

--- a/systems/configuration/configuration-domain/src/main/kotlin/hs/kr/entrydsm/configuration/domain/port/in/DeleteEnvironmentVariableUseCase.kt
+++ b/systems/configuration/configuration-domain/src/main/kotlin/hs/kr/entrydsm/configuration/domain/port/in/DeleteEnvironmentVariableUseCase.kt
@@ -1,0 +1,5 @@
+package hs.kr.entrydsm.configuration.domain.port.`in`
+
+interface DeleteEnvironmentVariableUseCase {
+    fun delete(key: String)
+}

--- a/systems/configuration/configuration-domain/src/main/kotlin/hs/kr/entrydsm/configuration/domain/port/in/ReadEnvironmentVariableUseCase.kt
+++ b/systems/configuration/configuration-domain/src/main/kotlin/hs/kr/entrydsm/configuration/domain/port/in/ReadEnvironmentVariableUseCase.kt
@@ -1,0 +1,8 @@
+package hs.kr.entrydsm.configuration.domain.port.`in`
+
+import hs.kr.entrydsm.configuration.domain.EnvironmentVariable
+
+interface ReadEnvironmentVariableUseCase {
+    fun findByKey(key: String): EnvironmentVariable
+    fun findAll(): List<EnvironmentVariable>
+}

--- a/systems/configuration/configuration-domain/src/main/kotlin/hs/kr/entrydsm/configuration/domain/port/in/UpdateEnvironmentVariableUseCase.kt
+++ b/systems/configuration/configuration-domain/src/main/kotlin/hs/kr/entrydsm/configuration/domain/port/in/UpdateEnvironmentVariableUseCase.kt
@@ -1,0 +1,8 @@
+package hs.kr.entrydsm.configuration.domain.port.`in`
+
+import hs.kr.entrydsm.configuration.domain.EnvironmentVariable
+import hs.kr.entrydsm.configuration.domain.command.UpdateEnvironmentVariableCommand
+
+interface UpdateEnvironmentVariableUseCase {
+    fun update(command: UpdateEnvironmentVariableCommand): EnvironmentVariable
+}

--- a/systems/configuration/configuration-domain/src/main/kotlin/hs/kr/entrydsm/configuration/domain/port/out/EnvironmentVariableRepository.kt
+++ b/systems/configuration/configuration-domain/src/main/kotlin/hs/kr/entrydsm/configuration/domain/port/out/EnvironmentVariableRepository.kt
@@ -1,0 +1,11 @@
+package hs.kr.entrydsm.configuration.domain.port.out
+
+import hs.kr.entrydsm.configuration.domain.EnvironmentVariable
+
+interface EnvironmentVariableRepository {
+    fun save(environmentVariable: EnvironmentVariable): EnvironmentVariable
+    fun findByKey(key: String): EnvironmentVariable?
+    fun findAll(): List<EnvironmentVariable>
+    fun deleteByKey(key: String)
+    fun existsByKey(key: String): Boolean
+}


### PR DESCRIPTION
## Summary
- 환경변수를 MySQL DB에 저장하고 중앙에서 관리하는 Configuration 서비스 구현
- 헥사고날 아키텍처(Domain / Application / Adapter-in / Adapter-out) 패턴 적용
- 다른 MSA 서비스가 gRPC를 통해 환경변수를 조회할 수 있는 엔드포인트 노출

## Related Issue
- Closes #36

## Change Type
- [x] New feature

## Changes
| 레이어 | 파일 | 설명 |
|--------|------|------|
| contracts | `configuration.proto` | gRPC 서비스/메시지 정의 |
| domain | `EnvironmentVariable.kt`, Port interfaces, Commands, Exceptions | 도메인 모델 및 포트 |
| application | `EnvironmentVariableService.kt` | CRUD 유즈케이스 구현 |
| adapter-out | `EnvironmentVariableJpaEntity`, `JpaRepository`, `PersistenceAdapter` | MySQL JPA 영속성 |
| adapter-in | `ConfigurationGrpcService`, `ConfigurationGrpcServer` | gRPC 서버 (5개 RPC) |
| bootstrap | `application.yaml` | MySQL/gRPC 포트 설정 |

## gRPC API
| RPC | 설명 |
|-----|------|
| `CreateEnvironmentVariable` | 새 환경변수 등록 |
| `GetEnvironmentVariable` | key로 단건 조회 |
| `GetAllEnvironmentVariables` | 전체 조회 |
| `UpdateEnvironmentVariable` | 기존 환경변수 수정 |
| `DeleteEnvironmentVariable` | 환경변수 삭제 |

## Follow-up Tasks
> 이 PR 머지 후 아래 후속 작업이 필요합니다.

- [ ] **DB 테이블 생성**: `configuration_db` 스키마 및 `environment_variable` 테이블 생성 (현재 `ddl-auto: validate` 설정으로 앱 실행 전 수동 생성 필요)
  ```sql
  CREATE DATABASE IF NOT EXISTS configuration_db;
  USE configuration_db;
  CREATE TABLE environment_variable (
      id BIGINT AUTO_INCREMENT PRIMARY KEY,
      env_key VARCHAR(255) NOT NULL UNIQUE,
      env_value TEXT NOT NULL,
      description TEXT
  );
  ```
- [ ] **환경변수 주입 설정**: `DB_USERNAME`, `DB_PASSWORD`, `GRPC_PORT` 환경변수 인프라 설정
- [ ] **다른 서비스 연동**: 타 MSA 서비스에서 gRPC 클라이언트 스텁 연결

## Review Focus
- 헥사고날 아키텍처 레이어 경계 준수 여부
- gRPC 서버 SmartLifecycle 기반 생명주기 관리 방식
- 트랜잭션 경계 (Application 레이어에서 관리)

## Checklist
- [x] 기존 아키텍처 패턴(헥사고날) 준수
- [x] 기존 Bazel 빌드 컨벤션 준수
- [x] 커밋 컨벤션 준수
- [ ] DB 테이블 생성 (후속 작업)
- [ ] 인프라 환경변수 설정 (후속 작업)