### PR TITLE
chore(infra): IntelliJ Bazel sync가 --package_path 미적용으로 실패하는 문제 수정 #49

### DIFF
--- a/.bazelrc
+++ b/.bazelrc
@@ -1,4 +1,4 @@
-build --package_path=%workspace%
+common --package_path=%workspace%
 
 sync --enable_workspace
 

--- a/MODULE.bazel.lock
+++ b/MODULE.bazel.lock
@@ -283,6 +283,132 @@
   },
   "selectedYankedVersions": {},
   "moduleExtensions": {
+    "@@bazel_jar_jar+//internal:non_module_deps.bzl%non_module_deps": {
+      "general": {
+        "bzlTransitiveDigest": "yG7TQVxSnN0cNQ0ERHiH4s5bonmA2kkddNp1CBisbE0=",
+        "usagesDigest": "yPUJRbCRF7ZBu5lCj2Y0tKOlweQexKh04B+dgm99R3U=",
+        "recordedFileInputs": {},
+        "recordedDirentsInputs": {},
+        "envVariables": {},
+        "generatedRepoSpecs": {
+          "jvm__jarjar_abrams_assembly": {
+            "repoRuleId": "@@bazel_tools//tools/build_defs/repo:http.bzl%http_jar",
+            "attributes": {
+              "urls": [
+                "https://repo1.maven.org/maven2/com/eed3si9n/jarjarabrams/jarjar-abrams-assembly_2.12/1.15.0/jarjar-abrams-assembly_2.12-1.15.0.jar"
+              ],
+              "sha256": "cc896901e66bc65aeab164e914040aacea16e8a4108b385142b2c68207d5881b"
+            }
+          },
+          "jvm__com_twitter__scalding_args": {
+            "repoRuleId": "@@bazel_tools//tools/build_defs/repo:http.bzl%http_jar",
+            "attributes": {
+              "urls": [
+                "https://repo1.maven.org/maven2/com/twitter/scalding-args_2.12/0.17.4/scalding-args_2.12-0.17.4.jar"
+              ],
+              "sha256": "e0de2ad8ef344bb11a2854275b5b85a1adb17f0e0ed9740177d940a602cd977b"
+            }
+          }
+        },
+        "recordedRepoMappingEntries": [
+          [
+            "bazel_features+",
+            "bazel_features_globals",
+            "bazel_features++version_extension+bazel_features_globals"
+          ],
+          [
+            "bazel_features+",
+            "bazel_features_version",
+            "bazel_features++version_extension+bazel_features_version"
+          ],
+          [
+            "bazel_jar_jar+",
+            "bazel_tools",
+            "bazel_tools"
+          ],
+          [
+            "bazel_jar_jar+",
+            "rules_java",
+            "rules_java+"
+          ],
+          [
+            "bazel_tools",
+            "rules_java",
+            "rules_java+"
+          ],
+          [
+            "protobuf+",
+            "proto_bazel_features",
+            "bazel_features+"
+          ],
+          [
+            "rules_cc+",
+            "bazel_skylib",
+            "bazel_skylib+"
+          ],
+          [
+            "rules_cc+",
+            "bazel_tools",
+            "bazel_tools"
+          ],
+          [
+            "rules_cc+",
+            "cc_compatibility_proxy",
+            "rules_cc++compatibility_proxy+cc_compatibility_proxy"
+          ],
+          [
+            "rules_cc+",
+            "platforms",
+            "platforms"
+          ],
+          [
+            "rules_cc+",
+            "rules_cc",
+            "rules_cc+"
+          ],
+          [
+            "rules_cc++compatibility_proxy+cc_compatibility_proxy",
+            "rules_cc",
+            "rules_cc+"
+          ],
+          [
+            "rules_java+",
+            "bazel_features",
+            "bazel_features+"
+          ],
+          [
+            "rules_java+",
+            "bazel_skylib",
+            "bazel_skylib+"
+          ],
+          [
+            "rules_java+",
+            "bazel_tools",
+            "bazel_tools"
+          ],
+          [
+            "rules_java+",
+            "com_google_protobuf",
+            "protobuf+"
+          ],
+          [
+            "rules_java+",
+            "compatibility_proxy",
+            "rules_java++compatibility_proxy+compatibility_proxy"
+          ],
+          [
+            "rules_java+",
+            "rules_cc",
+            "rules_cc+"
+          ],
+          [
+            "rules_java++compatibility_proxy+compatibility_proxy",
+            "rules_java",
+            "rules_java+"
+          ]
+        ]
+      }
+    },
     "@@protobuf+//python/dist:system_python.bzl%system_python_extension": {
       "general": {
         "bzlTransitiveDigest": "pmsA+awieucfllLc2n7k8xEoPp0i5LF9Hw6mGX0cqSQ=",


### PR DESCRIPTION
## Summary
- `.bazelrc`에서 `--package_path=%workspace%` 옵션을 `build`에서 `common`으로 이동하여, IntelliJ Bazel(bazelbsp) sync 시 호출되는 mod/query 명령에도 package_path가 적용되도록 함
- 이로써 `//:kotlin.MODULE.bazel` 로드 실패로 인한 IntelliJ sync 오류 해결

## Related Issue
- Closes #49

## Scope
- Affected components: `.bazelrc` (빌드/IDE 설정)
- 런타임 코드 변경 없음

## Change Type
- [ ] Refactor
- [ ] Dependency update
- [x] Config / infra change
- [x] Tooling / CI

## Risk
- 런타임 동작에 영향 없음. `common`은 `build`를 포함한 모든 Bazel 명령에 옵션을 적용하므로, 기존 `bazel build` 동작은 그대로 유지됨
- 오히려 IntelliJ 사용자(특히 Windows) 전반의 sync 안정성이 개선됨

## Checklist
- [x] No functional changes
- [x] CI / build verified (터미널 `bazel build` 및 IntelliJ sync 모두 정상 확인)