### PR TITLE
feat(identity): 계정 Account API와 JPA 저장소 구성 #48

### DIFF
--- a/systems/identity/identity-adapter-in/src/main/kotlin/hs/kr/entrydsm/identity/adapterin/web/AccountController.kt
+++ b/systems/identity/identity-adapter-in/src/main/kotlin/hs/kr/entrydsm/identity/adapterin/web/AccountController.kt
@@ -6,7 +6,9 @@ import hs.kr.entrydsm.identity.adapterin.web.dto.response.BasicInfoResponse
 import hs.kr.entrydsm.identity.application.port.`in`.AccountPort
 import hs.kr.entrydsm.identity.application.port.`in`.command.DeleteAccountCommand
 import hs.kr.entrydsm.identity.application.port.`in`.command.ReadAccountCommand
+import hs.kr.entrydsm.identity.application.security.AuthenticatedUser
 import org.springframework.http.HttpHeaders
+import org.springframework.security.core.annotation.AuthenticationPrincipal
 import org.springframework.web.bind.annotation.DeleteMapping
 import org.springframework.web.bind.annotation.GetMapping
 import org.springframework.web.bind.annotation.RequestHeader
@@ -21,16 +23,22 @@ class AccountController(
     @DeleteMapping("/me")
     fun deleteMe(
         @RequestHeader(HttpHeaders.AUTHORIZATION, required = false) authorization: String?,
+        @AuthenticationPrincipal authenticatedUser: AuthenticatedUser? = null,
     ): ApiResponse<Unit> {
-        accountPort.deleteAccount(DeleteAccountCommand(authorization = authorization))
+        accountPort.deleteAccount(
+            DeleteAccountCommand(authorization = authorization, userId = authenticatedUser?.userId),
+        )
         return ApiResponse(data = null)
     }
 
     @GetMapping("/me")
     fun getMe(
         @RequestHeader(HttpHeaders.AUTHORIZATION, required = false) authorization: String?,
+        @AuthenticationPrincipal authenticatedUser: AuthenticatedUser? = null,
     ): ApiResponse<BasicInfoResponse> {
-        val result = accountPort.getBasicInfo(ReadAccountCommand(authorization = authorization))
+        val result = accountPort.getBasicInfo(
+            ReadAccountCommand(authorization = authorization, userId = authenticatedUser?.userId),
+        )
         return ApiResponse(data = result.toResponse())
     }
 }

--- a/systems/identity/identity-adapter-in/src/main/kotlin/hs/kr/entrydsm/identity/adapterin/web/AccountController.kt
+++ b/systems/identity/identity-adapter-in/src/main/kotlin/hs/kr/entrydsm/identity/adapterin/web/AccountController.kt
@@ -1,0 +1,36 @@
+package hs.kr.entrydsm.identity.adapterin.web
+
+import hs.kr.entrydsm.identity.adapterin.web.dto.common.ApiResponse
+import hs.kr.entrydsm.identity.adapterin.web.dto.common.toResponse
+import hs.kr.entrydsm.identity.adapterin.web.dto.response.BasicInfoResponse
+import hs.kr.entrydsm.identity.application.port.`in`.AccountPort
+import hs.kr.entrydsm.identity.application.port.`in`.command.DeleteAccountCommand
+import hs.kr.entrydsm.identity.application.port.`in`.command.ReadAccountCommand
+import org.springframework.http.HttpHeaders
+import org.springframework.web.bind.annotation.DeleteMapping
+import org.springframework.web.bind.annotation.GetMapping
+import org.springframework.web.bind.annotation.RequestHeader
+import org.springframework.web.bind.annotation.RequestMapping
+import org.springframework.web.bind.annotation.RestController
+
+@RestController
+@RequestMapping("/api/identity/v11/accounts")
+class AccountController(
+    private val accountPort: AccountPort,
+) {
+    @DeleteMapping("/me")
+    fun deleteMe(
+        @RequestHeader(HttpHeaders.AUTHORIZATION, required = false) authorization: String?,
+    ): ApiResponse<Unit> {
+        accountPort.deleteAccount(DeleteAccountCommand(authorization = authorization))
+        return ApiResponse(data = null)
+    }
+
+    @GetMapping("/me")
+    fun getMe(
+        @RequestHeader(HttpHeaders.AUTHORIZATION, required = false) authorization: String?,
+    ): ApiResponse<BasicInfoResponse> {
+        val result = accountPort.getBasicInfo(ReadAccountCommand(authorization = authorization))
+        return ApiResponse(data = result.toResponse())
+    }
+}

--- a/systems/identity/identity-adapter-in/src/test/kotlin/hs/kr/entrydsm/TestMain.kt
+++ b/systems/identity/identity-adapter-in/src/test/kotlin/hs/kr/entrydsm/TestMain.kt
@@ -1,7 +1,6 @@
 package hs.kr.entrydsm.identity.adapterin
 
 import hs.kr.entrydsm.identity.adapterin.web.AccountControllerTest
-import hs.kr.entrydsm.identity.adapterin.web.ApplicationControllerTest
 import hs.kr.entrydsm.identity.adapterin.web.AuthControllerTest
 import hs.kr.entrydsm.identity.adapterin.web.exception.GlobalExceptionHandlerTest
 import org.junit.runner.RunWith
@@ -10,7 +9,6 @@ import org.junit.runners.Suite
 @RunWith(Suite::class)
 @Suite.SuiteClasses(
     AuthControllerTest::class,
-    ApplicationControllerTest::class,
     AccountControllerTest::class,
     GlobalExceptionHandlerTest::class,
 )

--- a/systems/identity/identity-adapter-in/src/test/kotlin/hs/kr/entrydsm/TestMain.kt
+++ b/systems/identity/identity-adapter-in/src/test/kotlin/hs/kr/entrydsm/TestMain.kt
@@ -1,11 +1,17 @@
 package hs.kr.entrydsm.identity.adapterin
 
-import org.junit.Assert.assertTrue
-import org.junit.Test
+import hs.kr.entrydsm.identity.adapterin.web.AccountControllerTest
+import hs.kr.entrydsm.identity.adapterin.web.ApplicationControllerTest
+import hs.kr.entrydsm.identity.adapterin.web.AuthControllerTest
+import hs.kr.entrydsm.identity.adapterin.web.exception.GlobalExceptionHandlerTest
+import org.junit.runner.RunWith
+import org.junit.runners.Suite
 
-class IdentityAdapterInModuleTest {
-    @Test
-    fun moduleLoads() {
-        assertTrue(true)
-    }
-}
+@RunWith(Suite::class)
+@Suite.SuiteClasses(
+    AuthControllerTest::class,
+    ApplicationControllerTest::class,
+    AccountControllerTest::class,
+    GlobalExceptionHandlerTest::class,
+)
+class IdentityAdapterInModuleTest

--- a/systems/identity/identity-adapter-in/src/test/kotlin/hs/kr/entrydsm/identity/adapterin/web/AccountControllerTest.kt
+++ b/systems/identity/identity-adapter-in/src/test/kotlin/hs/kr/entrydsm/identity/adapterin/web/AccountControllerTest.kt
@@ -1,0 +1,54 @@
+package hs.kr.entrydsm.identity.adapterin.web
+
+import hs.kr.entrydsm.identity.application.port.`in`.AccountPort
+import hs.kr.entrydsm.identity.application.port.`in`.command.DeleteAccountCommand
+import hs.kr.entrydsm.identity.application.port.`in`.command.ReadAccountCommand
+import hs.kr.entrydsm.identity.application.port.`in`.result.BasicInfoResult
+import hs.kr.entrydsm.identity.domain.enum.AccountStatus
+import hs.kr.entrydsm.identity.domain.enum.ApplicantStatus
+import hs.kr.entrydsm.identity.domain.enum.SignupType
+import java.time.Instant
+import java.time.LocalDate
+import org.junit.Assert.assertEquals
+import org.junit.Test
+
+class AccountControllerTest {
+    @Test
+    fun getMePassesAuthorizationAndReturnsBasicInfo() {
+        val accountPort = FakeAccountPort()
+        val controller = AccountController(accountPort)
+
+        val response = controller.getMe("Bearer access-token")
+
+        val command = requireNotNull(accountPort.readAccountCommand)
+        assertEquals("Bearer access-token", command.authorization)
+        assertEquals("user_123", response.data?.userId)
+        assertEquals(ApplicantStatus.SUBMITTED, response.data?.applicantStatus)
+    }
+
+    private class FakeAccountPort : AccountPort {
+        var readAccountCommand: ReadAccountCommand? = null
+
+        override fun deleteAccount(command: DeleteAccountCommand) = Unit
+
+        override fun getBasicInfo(command: ReadAccountCommand): BasicInfoResult {
+            readAccountCommand = command
+            return BasicInfoResult(
+                userId = 123L,
+                role = "USER",
+                status = AccountStatus.ACTIVE,
+                name = "홍길동",
+                phone = "01012345678",
+                birthdate = LocalDate.parse("2009-03-15"),
+                signupType = SignupType.SELF,
+                applicantStatus = ApplicantStatus.SUBMITTED,
+                createdAt = NOW,
+                updatedAt = NOW,
+            )
+        }
+    }
+
+    private companion object {
+        val NOW: Instant = Instant.parse("2026-06-11T10:00:00Z")
+    }
+}

--- a/systems/identity/identity-adapter-in/src/test/kotlin/hs/kr/entrydsm/identity/adapterin/web/AccountControllerTest.kt
+++ b/systems/identity/identity-adapter-in/src/test/kotlin/hs/kr/entrydsm/identity/adapterin/web/AccountControllerTest.kt
@@ -6,6 +6,7 @@ import hs.kr.entrydsm.identity.application.port.`in`.command.ReadAccountCommand
 import hs.kr.entrydsm.identity.application.port.`in`.result.BasicInfoResult
 import hs.kr.entrydsm.identity.domain.enum.AccountStatus
 import hs.kr.entrydsm.identity.domain.enum.ApplicantStatus
+import hs.kr.entrydsm.identity.domain.enum.Role
 import hs.kr.entrydsm.identity.domain.enum.SignupType
 import java.time.Instant
 import java.time.LocalDate
@@ -26,16 +27,29 @@ class AccountControllerTest {
         assertEquals(ApplicantStatus.SUBMITTED, response.data?.applicantStatus)
     }
 
+    @Test
+    fun deleteMePassesAuthorizationToAccountPort() {
+        val accountPort = FakeAccountPort()
+        val controller = AccountController(accountPort)
+
+        controller.deleteMe("Bearer access-token")
+
+        assertEquals("Bearer access-token", requireNotNull(accountPort.deleteAccountCommand).authorization)
+    }
+
     private class FakeAccountPort : AccountPort {
         var readAccountCommand: ReadAccountCommand? = null
+        var deleteAccountCommand: DeleteAccountCommand? = null
 
-        override fun deleteAccount(command: DeleteAccountCommand) = Unit
+        override fun deleteAccount(command: DeleteAccountCommand) {
+            deleteAccountCommand = command
+        }
 
         override fun getBasicInfo(command: ReadAccountCommand): BasicInfoResult {
             readAccountCommand = command
             return BasicInfoResult(
                 userId = 123L,
-                role = "USER",
+                role = Role.USER,
                 status = AccountStatus.ACTIVE,
                 name = "홍길동",
                 phone = "01012345678",

--- a/systems/identity/identity-adapter-in/src/test/kotlin/hs/kr/entrydsm/identity/adapterin/web/AccountControllerTest.kt
+++ b/systems/identity/identity-adapter-in/src/test/kotlin/hs/kr/entrydsm/identity/adapterin/web/AccountControllerTest.kt
@@ -11,6 +11,7 @@ import hs.kr.entrydsm.identity.domain.enum.SignupType
 import java.time.Instant
 import java.time.LocalDate
 import org.junit.Assert.assertEquals
+import org.junit.Assert.assertNull
 import org.junit.Test
 
 class AccountControllerTest {
@@ -32,8 +33,9 @@ class AccountControllerTest {
         val accountPort = FakeAccountPort()
         val controller = AccountController(accountPort)
 
-        controller.deleteMe("Bearer access-token")
+        val response = controller.deleteMe("Bearer access-token")
 
+        assertNull(response.data)
         assertEquals("Bearer access-token", requireNotNull(accountPort.deleteAccountCommand).authorization)
     }
 

--- a/systems/identity/identity-adapter-out/BUILD.bazel
+++ b/systems/identity/identity-adapter-out/BUILD.bazel
@@ -8,6 +8,7 @@ kt_jvm_library(
     srcs = glob(["src/main/kotlin/**/*.kt"]),
     javac_opts = "//:javac_options",
     kotlinc_opts = "//:kotlinc_options",
+    plugins = ["//:spring_allopen"],
     deps = MODULE_DEPS,
 )
 

--- a/systems/identity/identity-adapter-out/deps.bzl
+++ b/systems/identity/identity-adapter-out/deps.bzl
@@ -1,6 +1,8 @@
 KOTLIN_DEPS = [
     "@maven//:org_springframework_boot_spring_boot_starter_data_redis",
     "@maven//:org_springframework_security_spring_security_crypto",
+    "@maven//:org_springframework_boot_spring_boot_starter_data_jpa",
+    "@maven//:com_mysql_mysql_connector_j",
     "//systems/identity/identity-application:main",
     "//systems/identity/identity-domain:main",
 ]

--- a/systems/identity/identity-adapter-out/src/main/kotlin/hs/kr/entrydsm/identity/adapterout/base/BaseTimeEntity.kt
+++ b/systems/identity/identity-adapter-out/src/main/kotlin/hs/kr/entrydsm/identity/adapterout/base/BaseTimeEntity.kt
@@ -1,0 +1,25 @@
+package hs.kr.entrydsm.identity.adapterout.base
+
+import jakarta.persistence.Column
+import jakarta.persistence.EntityListeners
+import jakarta.persistence.MappedSuperclass
+import java.time.Instant
+import org.springframework.data.annotation.CreatedDate
+import org.springframework.data.annotation.LastModifiedDate
+import org.springframework.data.jpa.domain.support.AuditingEntityListener
+
+@MappedSuperclass
+@EntityListeners(AuditingEntityListener::class)
+abstract class BaseTimeEntity {
+    @CreatedDate
+    @Column(name = "created_at", nullable = false, updatable = false)
+    protected var createdAt: Instant? = null
+
+    @LastModifiedDate
+    @Column(name = "updated_at", nullable = false)
+    protected var updatedAt: Instant? = null
+
+    fun createdAtValue(): Instant? = createdAt
+
+    fun updatedAtValue(): Instant? = updatedAt
+}

--- a/systems/identity/identity-adapter-out/src/main/kotlin/hs/kr/entrydsm/identity/adapterout/config/JpaAuditingConfig.kt
+++ b/systems/identity/identity-adapter-out/src/main/kotlin/hs/kr/entrydsm/identity/adapterout/config/JpaAuditingConfig.kt
@@ -1,0 +1,8 @@
+package hs.kr.entrydsm.identity.adapterout.config
+
+import org.springframework.data.jpa.repository.config.EnableJpaAuditing
+import org.springframework.context.annotation.Configuration
+
+@Configuration(proxyBeanMethods = false)
+@EnableJpaAuditing
+class JpaAuditingConfig

--- a/systems/identity/identity-adapter-out/src/main/kotlin/hs/kr/entrydsm/identity/adapterout/entity/AccountJpaEntity.kt
+++ b/systems/identity/identity-adapter-out/src/main/kotlin/hs/kr/entrydsm/identity/adapterout/entity/AccountJpaEntity.kt
@@ -1,0 +1,34 @@
+package hs.kr.entrydsm.identity.adapterout.entity
+
+import hs.kr.entrydsm.identity.adapterout.base.BaseTimeEntity
+import hs.kr.entrydsm.identity.domain.enum.AccountStatus
+import jakarta.persistence.Column
+import jakarta.persistence.Entity
+import jakarta.persistence.EnumType
+import jakarta.persistence.Enumerated
+import jakarta.persistence.GeneratedValue
+import jakarta.persistence.GenerationType
+import jakarta.persistence.Id
+import jakarta.persistence.Table
+
+@Entity
+@Table(name = "accounts")
+open class AccountJpaEntity(
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    @Column(name = "id")
+    val id: Long? = null,
+
+    @Column(name = "login_id_hash", unique = true, nullable = false, length = 255)
+    val loginIdHash: String = "",
+
+    @Column(name = "password_hash", nullable = false, length = 255)
+    var passwordHash: String = "",
+
+    @Column(name = "role", nullable = false, length = 20)
+    val role: String = "USER",
+
+    @Enumerated(EnumType.STRING)
+    @Column(name = "status", nullable = false, length = 10)
+    var status: AccountStatus = AccountStatus.ACTIVE,
+) : BaseTimeEntity()

--- a/systems/identity/identity-adapter-out/src/main/kotlin/hs/kr/entrydsm/identity/adapterout/entity/AccountJpaEntity.kt
+++ b/systems/identity/identity-adapter-out/src/main/kotlin/hs/kr/entrydsm/identity/adapterout/entity/AccountJpaEntity.kt
@@ -2,6 +2,7 @@ package hs.kr.entrydsm.identity.adapterout.entity
 
 import hs.kr.entrydsm.identity.adapterout.base.BaseTimeEntity
 import hs.kr.entrydsm.identity.domain.enum.AccountStatus
+import hs.kr.entrydsm.identity.domain.enum.Role
 import jakarta.persistence.Column
 import jakarta.persistence.Entity
 import jakarta.persistence.EnumType
@@ -25,8 +26,9 @@ open class AccountJpaEntity(
     @Column(name = "password_hash", nullable = false, length = 255)
     var passwordHash: String = "",
 
+    @Enumerated(EnumType.STRING)
     @Column(name = "role", nullable = false, length = 20)
-    val role: String = "USER",
+    val role: Role = Role.USER,
 
     @Enumerated(EnumType.STRING)
     @Column(name = "status", nullable = false, length = 10)

--- a/systems/identity/identity-adapter-out/src/main/kotlin/hs/kr/entrydsm/identity/adapterout/entity/StudentProfileJpaEntity.kt
+++ b/systems/identity/identity-adapter-out/src/main/kotlin/hs/kr/entrydsm/identity/adapterout/entity/StudentProfileJpaEntity.kt
@@ -16,6 +16,7 @@ import jakarta.persistence.JoinColumn
 import jakarta.persistence.OneToOne
 import jakarta.persistence.Table
 import java.time.Instant
+import java.time.LocalDate
 
 @Entity
 @Table(name = "student_profiles")
@@ -39,8 +40,8 @@ open class StudentProfileJpaEntity(
     @Column(name = "phone_encrypted", nullable = false, length = 255)
     val phoneEncrypted: String = "",
 
-    @Column(name = "birthdate", nullable = false, length = 255)
-    val birthdate: String = "",
+    @Column(name = "birthdate", nullable = false, columnDefinition = "DATE")
+    val birthdate: LocalDate = LocalDate.of(1970, 1, 1),
 
     @Column(name = "submitted_at")
     var submittedAt: Instant? = null,

--- a/systems/identity/identity-adapter-out/src/main/kotlin/hs/kr/entrydsm/identity/adapterout/entity/StudentProfileJpaEntity.kt
+++ b/systems/identity/identity-adapter-out/src/main/kotlin/hs/kr/entrydsm/identity/adapterout/entity/StudentProfileJpaEntity.kt
@@ -1,0 +1,58 @@
+package hs.kr.entrydsm.identity.adapterout.entity
+
+import hs.kr.entrydsm.identity.adapterout.base.BaseTimeEntity
+import hs.kr.entrydsm.identity.domain.enum.ApplicantStatus
+import hs.kr.entrydsm.identity.domain.enum.PassStatus
+import hs.kr.entrydsm.identity.domain.enum.SignupType
+import jakarta.persistence.Column
+import jakarta.persistence.Entity
+import jakarta.persistence.EnumType
+import jakarta.persistence.Enumerated
+import jakarta.persistence.FetchType
+import jakarta.persistence.GeneratedValue
+import jakarta.persistence.GenerationType
+import jakarta.persistence.Id
+import jakarta.persistence.JoinColumn
+import jakarta.persistence.OneToOne
+import jakarta.persistence.Table
+import java.time.Instant
+
+@Entity
+@Table(name = "student_profiles")
+open class StudentProfileJpaEntity(
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    @Column(name = "id")
+    val id: Long? = null,
+
+    @OneToOne(fetch = FetchType.LAZY, optional = false)
+    @JoinColumn(name = "account_id", nullable = false, unique = true)
+    val account: AccountJpaEntity = AccountJpaEntity(),
+
+    @Enumerated(EnumType.STRING)
+    @Column(name = "signup_type", nullable = false, length = 10)
+    val signupType: SignupType = SignupType.SELF,
+
+    @Column(name = "name_encrypted", nullable = false, length = 255)
+    val nameEncrypted: String = "",
+
+    @Column(name = "phone_encrypted", nullable = false, length = 255)
+    val phoneEncrypted: String = "",
+
+    @Column(name = "birthdate", nullable = false, length = 255)
+    val birthdate: String = "",
+
+    @Column(name = "submitted_at")
+    var submittedAt: Instant? = null,
+
+    @Enumerated(EnumType.STRING)
+    @Column(name = "applicant_status", nullable = false, length = 20)
+    var applicantStatus: ApplicantStatus = ApplicantStatus.NONE,
+
+    @Enumerated(EnumType.STRING)
+    @Column(name = "pass_status", nullable = false, length = 20)
+    var passStatus: PassStatus = PassStatus.NOT_ANNOUNCED,
+
+    @Column(name = "announced_at")
+    var announcedAt: Instant? = null,
+) : BaseTimeEntity()

--- a/systems/identity/identity-adapter-out/src/main/kotlin/hs/kr/entrydsm/identity/adapterout/repository/AccountJpaRepository.kt
+++ b/systems/identity/identity-adapter-out/src/main/kotlin/hs/kr/entrydsm/identity/adapterout/repository/AccountJpaRepository.kt
@@ -1,0 +1,8 @@
+package hs.kr.entrydsm.identity.adapterout.repository
+
+import hs.kr.entrydsm.identity.adapterout.entity.AccountJpaEntity
+import org.springframework.data.jpa.repository.JpaRepository
+
+interface AccountJpaRepository : JpaRepository<AccountJpaEntity, Long> {
+    fun findByLoginIdHash(loginIdHash: String): AccountJpaEntity?
+}

--- a/systems/identity/identity-adapter-out/src/main/kotlin/hs/kr/entrydsm/identity/adapterout/repository/JpaAccountRepositoryAdapter.kt
+++ b/systems/identity/identity-adapter-out/src/main/kotlin/hs/kr/entrydsm/identity/adapterout/repository/JpaAccountRepositoryAdapter.kt
@@ -2,11 +2,11 @@ package hs.kr.entrydsm.identity.adapterout.repository
 
 import hs.kr.entrydsm.identity.adapterout.entity.AccountJpaEntity
 import hs.kr.entrydsm.identity.adapterout.entity.StudentProfileJpaEntity
+import hs.kr.entrydsm.identity.application.port.out.AccountRegistration
 import hs.kr.entrydsm.identity.application.port.out.AccountRepository
 import hs.kr.entrydsm.identity.domain.model.Account
 import hs.kr.entrydsm.identity.domain.model.StudentProfile
 import java.time.Instant
-import java.time.LocalDate
 import org.springframework.stereotype.Repository
 import org.springframework.transaction.annotation.Transactional
 
@@ -30,13 +30,13 @@ class JpaAccountRepositoryAdapter(
         val entity = if (existing == null) {
             AccountJpaEntity(
                 loginIdHash = account.loginId,
-                passwordHash = account.passwordForPersistence(),
+                passwordHash = account.passwordHash.value,
                 role = account.role,
                 status = account.status,
             )
         } else {
             existing.apply {
-                passwordHash = account.passwordForPersistence()
+                passwordHash = account.passwordHash.value
                 status = account.status
             }
         }
@@ -48,13 +48,38 @@ class JpaAccountRepositoryAdapter(
                 signupType = account.profile.signupType,
                 nameEncrypted = account.profile.name,
                 phoneEncrypted = account.profile.phone,
-                birthdate = account.profile.birthdate.toString(),
+                birthdate = account.profile.birthdate,
             )
         profile.applicantStatus = account.profile.applicantStatus
         profile.passStatus = account.profile.passStatus
         profile.submittedAt = account.profile.submittedAt
         profile.announcedAt = account.profile.announcedAt
         val savedProfile = studentProfileJpaRepository.saveAndFlush(profile)
+        return savedAccount.toDomain(savedProfile)
+    }
+
+    override fun register(registration: AccountRegistration, createdAt: Instant): Account {
+        val savedAccount = accountJpaRepository.saveAndFlush(
+            AccountJpaEntity(
+                loginIdHash = registration.loginId,
+                passwordHash = registration.passwordHash.value,
+                role = registration.role,
+                status = registration.status,
+            ),
+        )
+        val savedProfile = studentProfileJpaRepository.saveAndFlush(
+            StudentProfileJpaEntity(
+                account = savedAccount,
+                signupType = registration.profile.signupType,
+                nameEncrypted = registration.profile.name,
+                phoneEncrypted = registration.profile.phone,
+                birthdate = registration.profile.birthdate,
+                submittedAt = registration.profile.submittedAt,
+                applicantStatus = registration.profile.applicantStatus,
+                passStatus = registration.profile.passStatus,
+                announcedAt = registration.profile.announcedAt,
+            ),
+        )
         return savedAccount.toDomain(savedProfile)
     }
 
@@ -67,7 +92,7 @@ class JpaAccountRepositoryAdapter(
         return Account.create(
             userId = requireNotNull(id),
             loginId = loginIdHash,
-            password = passwordHash,
+            passwordHash = hs.kr.entrydsm.identity.domain.model.PasswordHash.fromEncoded(passwordHash),
             role = role,
             status = status,
             profile = resolvedProfile.toDomain(updatedAt),
@@ -80,7 +105,7 @@ class JpaAccountRepositoryAdapter(
         StudentProfile(
             name = nameEncrypted,
             phone = phoneEncrypted,
-            birthdate = LocalDate.parse(birthdate),
+            birthdate = birthdate,
             signupType = signupType,
             applicantStatus = applicantStatus,
             passStatus = passStatus,

--- a/systems/identity/identity-adapter-out/src/main/kotlin/hs/kr/entrydsm/identity/adapterout/repository/JpaAccountRepositoryAdapter.kt
+++ b/systems/identity/identity-adapter-out/src/main/kotlin/hs/kr/entrydsm/identity/adapterout/repository/JpaAccountRepositoryAdapter.kt
@@ -1,0 +1,91 @@
+package hs.kr.entrydsm.identity.adapterout.repository
+
+import hs.kr.entrydsm.identity.adapterout.entity.AccountJpaEntity
+import hs.kr.entrydsm.identity.adapterout.entity.StudentProfileJpaEntity
+import hs.kr.entrydsm.identity.application.port.out.AccountRepository
+import hs.kr.entrydsm.identity.domain.model.Account
+import hs.kr.entrydsm.identity.domain.model.StudentProfile
+import java.time.Instant
+import java.time.LocalDate
+import org.springframework.stereotype.Repository
+import org.springframework.transaction.annotation.Transactional
+
+@Repository
+@Transactional
+class JpaAccountRepositoryAdapter(
+    private val accountJpaRepository: AccountJpaRepository,
+    private val studentProfileJpaRepository: StudentProfileJpaRepository,
+) : AccountRepository {
+    @Transactional(readOnly = true)
+    override fun findByLoginId(loginId: String): Account? =
+        accountJpaRepository.findByLoginIdHash(loginId)?.toDomain()
+
+    @Transactional(readOnly = true)
+    override fun findByUserId(userId: Long): Account? =
+        accountJpaRepository.findById(userId).orElse(null)?.toDomain()
+
+    override fun save(account: Account): Account {
+        val existing = accountJpaRepository.findById(account.userId).orElse(null)
+            ?.takeIf { it.loginIdHash == account.loginId }
+        val entity = if (existing == null) {
+            AccountJpaEntity(
+                loginIdHash = account.loginId,
+                passwordHash = account.passwordForPersistence(),
+                role = account.role,
+                status = account.status,
+            )
+        } else {
+            existing.apply {
+                passwordHash = account.passwordForPersistence()
+                status = account.status
+            }
+        }
+        val savedAccount = accountJpaRepository.saveAndFlush(entity)
+        val savedUserId = requireNotNull(savedAccount.id)
+        val profile = studentProfileJpaRepository.findByAccount_Id(savedUserId)
+            ?: StudentProfileJpaEntity(
+                account = savedAccount,
+                signupType = account.profile.signupType,
+                nameEncrypted = account.profile.name,
+                phoneEncrypted = account.profile.phone,
+                birthdate = account.profile.birthdate.toString(),
+            )
+        profile.applicantStatus = account.profile.applicantStatus
+        profile.passStatus = account.profile.passStatus
+        profile.submittedAt = account.profile.submittedAt
+        profile.announcedAt = account.profile.announcedAt
+        val savedProfile = studentProfileJpaRepository.saveAndFlush(profile)
+        return savedAccount.toDomain(savedProfile)
+    }
+
+    private fun AccountJpaEntity.toDomain(profile: StudentProfileJpaEntity? = null): Account {
+        val resolvedProfile = profile ?: requireNotNull(id) { "Account ID must be present" }
+            .let { studentProfileJpaRepository.findByAccount_Id(it) }
+            ?: error("Student profile not found for account $id")
+        val createdAt = createdAtValue() ?: Instant.EPOCH
+        val updatedAt = updatedAtValue() ?: createdAt
+        return Account.create(
+            userId = requireNotNull(id),
+            loginId = loginIdHash,
+            password = passwordHash,
+            role = role,
+            status = status,
+            profile = resolvedProfile.toDomain(updatedAt),
+            createdAt = createdAt,
+            updatedAt = updatedAt,
+        )
+    }
+
+    private fun StudentProfileJpaEntity.toDomain(accountUpdatedAt: Instant): StudentProfile =
+        StudentProfile(
+            name = nameEncrypted,
+            phone = phoneEncrypted,
+            birthdate = LocalDate.parse(birthdate),
+            signupType = signupType,
+            applicantStatus = applicantStatus,
+            passStatus = passStatus,
+            submittedAt = submittedAt,
+            announcedAt = announcedAt,
+            updatedAt = updatedAtValue() ?: accountUpdatedAt,
+        )
+}

--- a/systems/identity/identity-adapter-out/src/main/kotlin/hs/kr/entrydsm/identity/adapterout/repository/StudentProfileJpaRepository.kt
+++ b/systems/identity/identity-adapter-out/src/main/kotlin/hs/kr/entrydsm/identity/adapterout/repository/StudentProfileJpaRepository.kt
@@ -1,0 +1,8 @@
+package hs.kr.entrydsm.identity.adapterout.repository
+
+import hs.kr.entrydsm.identity.adapterout.entity.StudentProfileJpaEntity
+import org.springframework.data.jpa.repository.JpaRepository
+
+interface StudentProfileJpaRepository : JpaRepository<StudentProfileJpaEntity, Long> {
+    fun findByAccount_Id(accountId: Long): StudentProfileJpaEntity?
+}

--- a/systems/identity/identity-adapter-out/src/test/kotlin/hs/kr/entrydsm/TestMain.kt
+++ b/systems/identity/identity-adapter-out/src/test/kotlin/hs/kr/entrydsm/TestMain.kt
@@ -6,6 +6,7 @@ import hs.kr.entrydsm.identity.adapterout.security.RedisRefreshTokenRotationAdap
 import hs.kr.entrydsm.identity.adapterout.security.RedisDurabilityGuardTest
 import hs.kr.entrydsm.identity.adapterout.persistence.AccountCommandPersistenceAdapterTest
 import hs.kr.entrydsm.identity.adapterout.persistence.TransactionalAccountRegistrationAdapterTest
+import hs.kr.entrydsm.identity.adapterout.repository.JpaAccountRepositoryAdapterIntegrationTest
 import org.junit.Assert.assertFalse
 import org.junit.Assert.assertNotEquals
 import org.junit.Assert.assertTrue
@@ -18,6 +19,7 @@ import org.junit.runners.Suite
     IdentityAdapterOutSmokeTest::class,
     AccountCommandPersistenceAdapterTest::class,
     TransactionalAccountRegistrationAdapterTest::class,
+    JpaAccountRepositoryAdapterIntegrationTest::class,
     RedisRefreshTokenRotationAdapterTest::class,
     RedisDurabilityGuardTest::class,
     RedisRefreshTokenRotationAdapterIntegrationTest::class,

--- a/systems/identity/identity-adapter-out/src/test/kotlin/hs/kr/entrydsm/identity/adapterout/repository/JpaAccountRepositoryAdapterIntegrationTest.kt
+++ b/systems/identity/identity-adapter-out/src/test/kotlin/hs/kr/entrydsm/identity/adapterout/repository/JpaAccountRepositoryAdapterIntegrationTest.kt
@@ -14,6 +14,7 @@ import java.time.LocalDate
 import org.junit.AfterClass
 import org.junit.Assert.assertEquals
 import org.junit.Assert.assertNotNull
+import org.junit.Assert.assertNotEquals
 import org.junit.Assume.assumeTrue
 import org.junit.Before
 import org.junit.BeforeClass
@@ -67,8 +68,12 @@ class JpaAccountRepositoryAdapterIntegrationTest {
     fun updatesExistingProfileAndPreservesCreatedAt() {
         val saved = adapter.save(account())
         val accountCreatedAt = requireNotNull(accountJpaRepository.findById(saved.userId).orElse(null)?.createdAtValue())
+        val accountUpdatedAt = requireNotNull(accountJpaRepository.findById(saved.userId).orElse(null)?.updatedAtValue())
         val profileCreatedAt = requireNotNull(
             studentProfileJpaRepository.findByAccount_Id(saved.userId)?.createdAtValue(),
+        )
+        val profileUpdatedAt = requireNotNull(
+            studentProfileJpaRepository.findByAccount_Id(saved.userId)?.updatedAtValue(),
         )
 
         saved.profile.cancel(TRANSITION_TIME)
@@ -80,8 +85,8 @@ class JpaAccountRepositoryAdapterIntegrationTest {
         assertEquals(ApplicantStatus.CANCELED, profileEntity.applicantStatus)
         assertEquals(accountCreatedAt, accountEntity.createdAtValue())
         assertEquals(profileCreatedAt, profileEntity.createdAtValue())
-        assertNotNull(accountEntity.updatedAtValue())
-        assertNotNull(profileEntity.updatedAtValue())
+        assertNotEquals(accountUpdatedAt, accountEntity.updatedAtValue())
+        assertNotEquals(profileUpdatedAt, profileEntity.updatedAtValue())
     }
 
     @SpringBootConfiguration

--- a/systems/identity/identity-adapter-out/src/test/kotlin/hs/kr/entrydsm/identity/adapterout/repository/JpaAccountRepositoryAdapterIntegrationTest.kt
+++ b/systems/identity/identity-adapter-out/src/test/kotlin/hs/kr/entrydsm/identity/adapterout/repository/JpaAccountRepositoryAdapterIntegrationTest.kt
@@ -1,0 +1,161 @@
+package hs.kr.entrydsm.identity.adapterout.repository
+
+import hs.kr.entrydsm.identity.adapterout.config.JpaAuditingConfig
+import hs.kr.entrydsm.identity.domain.enum.AccountStatus
+import hs.kr.entrydsm.identity.domain.enum.ApplicantStatus
+import hs.kr.entrydsm.identity.domain.enum.PassStatus
+import hs.kr.entrydsm.identity.domain.enum.Role
+import hs.kr.entrydsm.identity.domain.enum.SignupType
+import hs.kr.entrydsm.identity.domain.model.Account
+import hs.kr.entrydsm.identity.domain.model.PasswordHash
+import hs.kr.entrydsm.identity.domain.model.StudentProfile
+import java.time.Instant
+import java.time.LocalDate
+import org.junit.AfterClass
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertNotNull
+import org.junit.Assume.assumeTrue
+import org.junit.Before
+import org.junit.BeforeClass
+import org.junit.Test
+import org.junit.runner.RunWith
+import org.springframework.boot.SpringBootConfiguration
+import org.springframework.boot.autoconfigure.EnableAutoConfiguration
+import org.springframework.boot.autoconfigure.domain.EntityScan
+import org.springframework.boot.test.context.SpringBootTest
+import org.springframework.beans.factory.annotation.Autowired
+import org.springframework.context.annotation.Import
+import org.springframework.data.jpa.repository.config.EnableJpaRepositories
+import org.springframework.test.context.DynamicPropertyRegistry
+import org.springframework.test.context.DynamicPropertySource
+import org.springframework.test.context.junit4.SpringRunner
+import org.testcontainers.DockerClientFactory
+import org.testcontainers.containers.GenericContainer
+import org.testcontainers.utility.DockerImageName
+
+@RunWith(SpringRunner::class)
+@SpringBootTest(classes = [JpaAccountRepositoryAdapterIntegrationTest.JpaTestApplication::class])
+class JpaAccountRepositoryAdapterIntegrationTest {
+    @Autowired
+    private lateinit var adapter: JpaAccountRepositoryAdapter
+
+    @Autowired
+    private lateinit var accountJpaRepository: AccountJpaRepository
+
+    @Autowired
+    private lateinit var studentProfileJpaRepository: StudentProfileJpaRepository
+
+    @Before
+    fun clearDatabase() {
+        studentProfileJpaRepository.deleteAll()
+        accountJpaRepository.deleteAll()
+    }
+
+    @Test
+    fun savesAndFindsAccountAndProfileByBothQueries() {
+        val saved = adapter.save(account())
+
+        assertNotNull(saved.userId)
+        assertEquals(saved.userId, adapter.findByUserId(saved.userId)?.userId)
+        assertEquals(saved.userId, adapter.findByLoginId(LOGIN_ID)?.userId)
+        assertEquals(BIRTHDATE, adapter.findByUserId(saved.userId)?.profile?.birthdate)
+        assertNotNull(accountJpaRepository.findById(saved.userId).orElse(null)?.createdAtValue())
+        assertNotNull(studentProfileJpaRepository.findByAccount_Id(saved.userId)?.createdAtValue())
+    }
+
+    @Test
+    fun updatesExistingProfileAndPreservesCreatedAt() {
+        val saved = adapter.save(account())
+        val accountCreatedAt = requireNotNull(accountJpaRepository.findById(saved.userId).orElse(null)?.createdAtValue())
+        val profileCreatedAt = requireNotNull(
+            studentProfileJpaRepository.findByAccount_Id(saved.userId)?.createdAtValue(),
+        )
+
+        saved.profile.cancel(TRANSITION_TIME)
+        val updated = adapter.save(saved)
+        val accountEntity = requireNotNull(accountJpaRepository.findById(saved.userId).orElse(null))
+        val profileEntity = requireNotNull(studentProfileJpaRepository.findByAccount_Id(saved.userId))
+
+        assertEquals(ApplicantStatus.CANCELED, updated.profile.applicantStatus)
+        assertEquals(ApplicantStatus.CANCELED, profileEntity.applicantStatus)
+        assertEquals(accountCreatedAt, accountEntity.createdAtValue())
+        assertEquals(profileCreatedAt, profileEntity.createdAtValue())
+        assertNotNull(accountEntity.updatedAtValue())
+        assertNotNull(profileEntity.updatedAtValue())
+    }
+
+    @SpringBootConfiguration
+    @EnableAutoConfiguration
+    @EntityScan("hs.kr.entrydsm.identity.adapterout.entity")
+    @EnableJpaRepositories("hs.kr.entrydsm.identity.adapterout.repository")
+    @Import(JpaAuditingConfig::class, JpaAccountRepositoryAdapter::class)
+    class JpaTestApplication
+
+    private companion object {
+        const val MYSQL_IMAGE = "mysql:8.4"
+        const val MYSQL_PORT = 3306
+        const val DATABASE = "identity_test"
+        const val LOGIN_ID = "01012345678"
+        val BIRTHDATE: LocalDate = LocalDate.of(2009, 3, 15)
+        val CREATED_AT: Instant = Instant.parse("2026-06-11T10:00:00Z")
+        val TRANSITION_TIME: Instant = Instant.parse("2026-06-11T11:00:00Z")
+        lateinit var mysql: GenericContainer<Nothing>
+        var mysqlStarted = false
+
+        @JvmStatic
+        @BeforeClass
+        fun checkDocker() {
+            assumeTrue(
+                "Docker daemon is required for JPA integration tests",
+                DockerClientFactory.instance().isDockerAvailable,
+            )
+        }
+
+        @JvmStatic
+        @DynamicPropertySource
+        fun registerDatabaseProperties(registry: DynamicPropertyRegistry) {
+            mysql = GenericContainer<Nothing>(DockerImageName.parse(MYSQL_IMAGE))
+                .withEnv("MYSQL_DATABASE", DATABASE)
+                .withEnv("MYSQL_USER", "identity")
+                .withEnv("MYSQL_PASSWORD", "identity")
+                .withEnv("MYSQL_ROOT_PASSWORD", "root")
+                .withExposedPorts(MYSQL_PORT)
+            mysql.start()
+            mysqlStarted = true
+            registry.add("spring.datasource.url") {
+                "jdbc:mysql://${mysql.host}:${mysql.getMappedPort(MYSQL_PORT)}/$DATABASE?useSSL=false&serverTimezone=UTC"
+            }
+            registry.add("spring.datasource.username") { "identity" }
+            registry.add("spring.datasource.password") { "identity" }
+            registry.add("spring.datasource.driver-class-name") { "com.mysql.cj.jdbc.Driver" }
+            registry.add("spring.jpa.hibernate.ddl-auto") { "create-drop" }
+            registry.add("spring.jpa.properties.hibernate.dialect") { "org.hibernate.dialect.MySQLDialect" }
+        }
+
+        @JvmStatic
+        @AfterClass
+        fun stopDatabase() {
+            if (mysqlStarted) mysql.stop()
+        }
+    }
+
+    private fun account(): Account = Account.create(
+        userId = 1L,
+        loginId = LOGIN_ID,
+        passwordHash = PasswordHash.fromEncoded("encoded-password"),
+        role = Role.STUDENT,
+        status = AccountStatus.ACTIVE,
+        profile = StudentProfile(
+            name = "홍길동",
+            phone = LOGIN_ID,
+            birthdate = BIRTHDATE,
+            signupType = SignupType.SELF,
+            applicantStatus = ApplicantStatus.SUBMITTED,
+            passStatus = PassStatus.NOT_ANNOUNCED,
+            submittedAt = CREATED_AT,
+            updatedAt = CREATED_AT,
+        ),
+        createdAt = CREATED_AT,
+        updatedAt = CREATED_AT,
+    )
+}

--- a/systems/identity/identity-application/src/main/kotlin/hs/kr/entrydsm/identity/application/port/in/AccountPort.kt
+++ b/systems/identity/identity-application/src/main/kotlin/hs/kr/entrydsm/identity/application/port/in/AccountPort.kt
@@ -1,0 +1,11 @@
+package hs.kr.entrydsm.identity.application.port.`in`
+
+import hs.kr.entrydsm.identity.application.port.`in`.command.DeleteAccountCommand
+import hs.kr.entrydsm.identity.application.port.`in`.command.ReadAccountCommand
+import hs.kr.entrydsm.identity.application.port.`in`.result.BasicInfoResult
+
+interface AccountPort {
+    fun deleteAccount(command: DeleteAccountCommand)
+
+    fun getBasicInfo(command: ReadAccountCommand): BasicInfoResult
+}

--- a/systems/identity/identity-application/src/main/kotlin/hs/kr/entrydsm/identity/application/port/in/command/DeleteAccountCommand.kt
+++ b/systems/identity/identity-application/src/main/kotlin/hs/kr/entrydsm/identity/application/port/in/command/DeleteAccountCommand.kt
@@ -1,0 +1,5 @@
+package hs.kr.entrydsm.identity.application.port.`in`.command
+
+data class DeleteAccountCommand(
+    val authorization: String?,
+)

--- a/systems/identity/identity-application/src/main/kotlin/hs/kr/entrydsm/identity/application/port/in/command/DeleteAccountCommand.kt
+++ b/systems/identity/identity-application/src/main/kotlin/hs/kr/entrydsm/identity/application/port/in/command/DeleteAccountCommand.kt
@@ -2,4 +2,5 @@ package hs.kr.entrydsm.identity.application.port.`in`.command
 
 data class DeleteAccountCommand(
     val authorization: String?,
+    val userId: Long? = null,
 )

--- a/systems/identity/identity-application/src/main/kotlin/hs/kr/entrydsm/identity/application/port/in/command/ReadAccountCommand.kt
+++ b/systems/identity/identity-application/src/main/kotlin/hs/kr/entrydsm/identity/application/port/in/command/ReadAccountCommand.kt
@@ -2,4 +2,5 @@ package hs.kr.entrydsm.identity.application.port.`in`.command
 
 data class ReadAccountCommand(
     val authorization: String?,
+    val userId: Long? = null,
 )

--- a/systems/identity/identity-application/src/main/kotlin/hs/kr/entrydsm/identity/application/port/in/command/ReadAccountCommand.kt
+++ b/systems/identity/identity-application/src/main/kotlin/hs/kr/entrydsm/identity/application/port/in/command/ReadAccountCommand.kt
@@ -1,0 +1,5 @@
+package hs.kr.entrydsm.identity.application.port.`in`.command
+
+data class ReadAccountCommand(
+    val authorization: String?,
+)

--- a/systems/identity/identity-application/src/main/kotlin/hs/kr/entrydsm/identity/application/service/AccountService.kt
+++ b/systems/identity/identity-application/src/main/kotlin/hs/kr/entrydsm/identity/application/service/AccountService.kt
@@ -1,0 +1,43 @@
+package hs.kr.entrydsm.identity.application.service
+
+import hs.kr.entrydsm.identity.application.port.`in`.AccountPort
+import hs.kr.entrydsm.identity.application.port.`in`.command.DeleteAccountCommand
+import hs.kr.entrydsm.identity.application.port.`in`.command.ReadAccountCommand
+import hs.kr.entrydsm.identity.application.port.`in`.result.BasicInfoResult
+import hs.kr.entrydsm.identity.application.port.out.AccountRepository
+import hs.kr.entrydsm.identity.application.port.out.ApplicationDataPort
+import java.time.Clock
+import java.time.Instant
+import org.springframework.stereotype.Service
+
+@Service
+class AccountService(
+    private val accountRepository: AccountRepository,
+    private val applicationDataPort: ApplicationDataPort,
+    private val clock: Clock = Clock.systemUTC(),
+) : AccountPort {
+    override fun deleteAccount(command: DeleteAccountCommand) {
+        val account = accountRepository.resolveAccount(command.authorization)
+        account.delete(now())
+        accountRepository.save(account)
+    }
+
+    override fun getBasicInfo(command: ReadAccountCommand): BasicInfoResult {
+        val account = accountRepository.resolveAccount(command.authorization)
+        val application = applicationDataPort.findApplication(account)
+        return BasicInfoResult(
+            userId = account.userId,
+            role = account.role,
+            status = account.status,
+            name = account.profile.name,
+            phone = account.profile.phone,
+            birthdate = account.profile.birthdate,
+            signupType = account.profile.signupType,
+            applicantStatus = application.applicantStatus,
+            createdAt = account.createdAt,
+            updatedAt = application.updatedAt,
+        )
+    }
+
+    private fun now(): Instant = Instant.now(clock)
+}

--- a/systems/identity/identity-application/src/main/kotlin/hs/kr/entrydsm/identity/application/service/AccountService.kt
+++ b/systems/identity/identity-application/src/main/kotlin/hs/kr/entrydsm/identity/application/service/AccountService.kt
@@ -4,26 +4,28 @@ import hs.kr.entrydsm.identity.application.port.`in`.AccountPort
 import hs.kr.entrydsm.identity.application.port.`in`.command.DeleteAccountCommand
 import hs.kr.entrydsm.identity.application.port.`in`.command.ReadAccountCommand
 import hs.kr.entrydsm.identity.application.port.`in`.result.BasicInfoResult
-import hs.kr.entrydsm.identity.application.port.out.AccountRepository
+import hs.kr.entrydsm.identity.application.port.out.AccountCommandPort
+import hs.kr.entrydsm.identity.application.port.out.AccountQueryPort
 import hs.kr.entrydsm.identity.application.port.out.ApplicationDataPort
+import hs.kr.entrydsm.identity.domain.enum.ErrorCode
+import hs.kr.entrydsm.identity.domain.exception.IdentityDomainException
 import java.time.Clock
 import java.time.Instant
-import org.springframework.stereotype.Service
 
-@Service
 class AccountService(
-    private val accountRepository: AccountRepository,
+    private val accountQueryPort: AccountQueryPort,
+    private val accountCommandPort: AccountCommandPort,
     private val applicationDataPort: ApplicationDataPort,
     private val clock: Clock = Clock.systemUTC(),
 ) : AccountPort {
     override fun deleteAccount(command: DeleteAccountCommand) {
-        val account = accountRepository.resolveAccount(command.authorization)
+        val account = resolveAccount(command.userId)
         account.delete(now())
-        accountRepository.save(account)
+        accountCommandPort.save(account)
     }
 
     override fun getBasicInfo(command: ReadAccountCommand): BasicInfoResult {
-        val account = accountRepository.resolveAccount(command.authorization)
+        val account = resolveAccount(command.userId)
         val application = applicationDataPort.findApplication(account)
         return BasicInfoResult(
             userId = account.userId,
@@ -38,6 +40,10 @@ class AccountService(
             updatedAt = application.updatedAt,
         )
     }
+
+    private fun resolveAccount(userId: Long?) =
+        userId?.let(accountQueryPort::findByUserId)
+            ?: throw IdentityDomainException(ErrorCode.AUTH_UNAUTHORIZED)
 
     private fun now(): Instant = Instant.now(clock)
 }

--- a/systems/identity/identity-application/src/test/kotlin/hs/kr/entrydsm/TestMain.kt
+++ b/systems/identity/identity-application/src/test/kotlin/hs/kr/entrydsm/TestMain.kt
@@ -1,11 +1,12 @@
 package hs.kr.entrydsm.identity.application
 
-import org.junit.Assert.assertTrue
-import org.junit.Test
+import hs.kr.entrydsm.identity.application.service.AccountServiceTest
+import org.junit.runner.RunWith
+import org.junit.runners.Suite
 
-class IdentityApplicationModuleTest {
-    @Test
-    fun moduleLoads() {
-        assertTrue(true)
-    }
-}
+@RunWith(Suite::class)
+@Suite.SuiteClasses(
+    AuthIdentityApplicationModuleTest::class,
+    AccountServiceTest::class,
+)
+class IdentityApplicationModuleTest

--- a/systems/identity/identity-application/src/test/kotlin/hs/kr/entrydsm/identity/application/service/AccountServiceTest.kt
+++ b/systems/identity/identity-application/src/test/kotlin/hs/kr/entrydsm/identity/application/service/AccountServiceTest.kt
@@ -1,0 +1,147 @@
+package hs.kr.entrydsm.identity.application.service
+
+import hs.kr.entrydsm.identity.application.port.`in`.command.DeleteAccountCommand
+import hs.kr.entrydsm.identity.application.port.`in`.command.ReadAccountCommand
+import hs.kr.entrydsm.identity.application.port.out.AccountCommandPort
+import hs.kr.entrydsm.identity.application.port.out.AccountQueryPort
+import hs.kr.entrydsm.identity.application.port.out.AccountRegistration
+import hs.kr.entrydsm.identity.application.port.out.ApplicationDataPort
+import hs.kr.entrydsm.identity.application.port.out.data.ApplicationSnapshot
+import hs.kr.entrydsm.identity.domain.enum.AccountStatus
+import hs.kr.entrydsm.identity.domain.enum.ApplicantStatus
+import hs.kr.entrydsm.identity.domain.enum.PassStatus
+import hs.kr.entrydsm.identity.domain.enum.Role
+import hs.kr.entrydsm.identity.domain.enum.SignupType
+import hs.kr.entrydsm.identity.domain.exception.IdentityDomainException
+import hs.kr.entrydsm.identity.domain.model.Account
+import hs.kr.entrydsm.identity.domain.model.PasswordHash
+import hs.kr.entrydsm.identity.domain.model.StudentProfile
+import java.time.Clock
+import java.time.Instant
+import java.time.LocalDate
+import org.junit.Assert.assertEquals
+import org.junit.Test
+
+class AccountServiceTest {
+    private val fixedClock = Clock.fixed(NOW, java.time.ZoneOffset.UTC)
+
+    @Test
+    fun deleteAccountUsesAuthenticatedUserAndPersistsDeletionTime() {
+        val queryPort = FakeAccountQueryPort(account())
+        val commandPort = FakeAccountCommandPort()
+        val service = AccountService(queryPort, commandPort, FakeApplicationDataPort(), fixedClock)
+
+        service.deleteAccount(DeleteAccountCommand("Bearer access-token", USER_ID))
+
+        val saved = requireNotNull(commandPort.savedAccount)
+        assertEquals(AccountStatus.DELETED, saved.status)
+        assertEquals(NOW, saved.updatedAt)
+    }
+
+    @Test
+    fun getBasicInfoMapsAccountAndApplicationFields() {
+        val account = account()
+        val application = ApplicationSnapshot(
+            userId = USER_ID,
+            applicantStatus = ApplicantStatus.SUBMITTED,
+            submittedAt = SUBMITTED_AT,
+            updatedAt = APPLICATION_UPDATED_AT,
+            passStatus = PassStatus.PASSED,
+            announcedAt = ANNOUNCED_AT,
+        )
+        val service = AccountService(
+            FakeAccountQueryPort(account),
+            FakeAccountCommandPort(),
+            FakeApplicationDataPort(application),
+            fixedClock,
+        )
+
+        val result = service.getBasicInfo(ReadAccountCommand("Bearer access-token", USER_ID))
+
+        assertEquals(USER_ID, result.userId)
+        assertEquals(Role.STUDENT, result.role)
+        assertEquals(AccountStatus.ACTIVE, result.status)
+        assertEquals("홍길동", result.name)
+        assertEquals("01012345678", result.phone)
+        assertEquals(LocalDate.of(2009, 3, 15), result.birthdate)
+        assertEquals(SignupType.SELF, result.signupType)
+        assertEquals(ApplicantStatus.SUBMITTED, result.applicantStatus)
+        assertEquals(CREATED_AT, result.createdAt)
+        assertEquals(APPLICATION_UPDATED_AT, result.updatedAt)
+    }
+
+    @Test(expected = IdentityDomainException::class)
+    fun missingAuthenticatedUserIsRejected() {
+        AccountService(
+            FakeAccountQueryPort(account()),
+            FakeAccountCommandPort(),
+            FakeApplicationDataPort(),
+            fixedClock,
+        ).getBasicInfo(ReadAccountCommand(null))
+    }
+
+    private fun account(): Account = Account.create(
+        userId = USER_ID,
+        loginId = "01012345678",
+        passwordHash = PasswordHash.fromEncoded("encoded-password"),
+        role = Role.STUDENT,
+        status = AccountStatus.ACTIVE,
+        profile = StudentProfile(
+            name = "홍길동",
+            phone = "01012345678",
+            birthdate = LocalDate.of(2009, 3, 15),
+            signupType = SignupType.SELF,
+            applicantStatus = ApplicantStatus.NONE,
+            passStatus = PassStatus.NOT_ANNOUNCED,
+            updatedAt = CREATED_AT,
+        ),
+        createdAt = CREATED_AT,
+        updatedAt = CREATED_AT,
+    )
+
+    private class FakeAccountQueryPort(
+        private val account: Account?,
+    ) : AccountQueryPort {
+        override fun findByLoginId(loginId: String): Account? = account
+
+        override fun findByUserId(userId: Long): Account? = account?.takeIf { it.userId == userId }
+    }
+
+    private class FakeAccountCommandPort : AccountCommandPort {
+        var savedAccount: Account? = null
+
+        override fun save(account: Account): Account {
+            savedAccount = account
+            return account
+        }
+
+        override fun register(registration: AccountRegistration, createdAt: Instant): Account =
+            error("Not used in AccountServiceTest")
+    }
+
+    private class FakeApplicationDataPort(
+        private val snapshot: ApplicationSnapshot = ApplicationSnapshot(
+            userId = USER_ID,
+            applicantStatus = ApplicantStatus.NONE,
+            submittedAt = null,
+            updatedAt = CREATED_AT,
+            passStatus = PassStatus.NOT_ANNOUNCED,
+            announcedAt = null,
+        ),
+    ) : ApplicationDataPort {
+        override fun create(userId: Long, updatedAt: Instant): ApplicationSnapshot = snapshot
+
+        override fun findByUserId(userId: Long): ApplicationSnapshot? = snapshot.takeIf { it.userId == userId }
+
+        override fun cancel(userId: Long, reason: String?, updatedAt: Instant): ApplicationSnapshot = snapshot
+    }
+
+    private companion object {
+        const val USER_ID = 123L
+        val CREATED_AT: Instant = Instant.parse("2026-06-11T10:00:00Z")
+        val NOW: Instant = Instant.parse("2026-06-11T11:00:00Z")
+        val SUBMITTED_AT: Instant = Instant.parse("2026-06-11T10:30:00Z")
+        val APPLICATION_UPDATED_AT: Instant = Instant.parse("2026-06-11T10:45:00Z")
+        val ANNOUNCED_AT: Instant = Instant.parse("2026-06-11T10:40:00Z")
+    }
+}

--- a/systems/identity/identity-application/src/test/kotlin/hs/kr/entrydsm/identity/application/service/AuthServiceTest.kt
+++ b/systems/identity/identity-application/src/test/kotlin/hs/kr/entrydsm/identity/application/service/AuthServiceTest.kt
@@ -69,7 +69,7 @@ class AuthServiceTest {
         )
 
         assertEquals(123L, result.userId)
-        assertEquals("USER", result.role)
+        assertEquals(Role.USER, result.role)
         assertEquals("01012345678", registration?.loginId)
         assertEquals(PASSWORD_HASH, registration?.passwordHash)
     }

--- a/systems/identity/identity-bootstrap/src/main/kotlin/hs/kr/entrydsm/identity/config/IdentityApplicationConfig.kt
+++ b/systems/identity/identity-bootstrap/src/main/kotlin/hs/kr/entrydsm/identity/config/IdentityApplicationConfig.kt
@@ -1,20 +1,36 @@
 package hs.kr.entrydsm.identity.config
 
+import hs.kr.entrydsm.identity.application.port.`in`.AccountPort
 import hs.kr.entrydsm.identity.application.port.out.AccountCommandPort
 import hs.kr.entrydsm.identity.application.port.out.AccountQueryPort
 import hs.kr.entrydsm.identity.application.port.out.AccountRegistrationPort
+import hs.kr.entrydsm.identity.application.port.out.ApplicationDataPort
 import hs.kr.entrydsm.identity.application.port.out.PasswordHasher
 import hs.kr.entrydsm.identity.application.port.out.RefreshTokenRotationStore
 import hs.kr.entrydsm.identity.application.port.out.RefreshTokenRevocationStore
 import hs.kr.entrydsm.identity.application.security.jwt.JwtTokenGenerator
 import hs.kr.entrydsm.identity.application.security.jwt.JwtTokenVerifier
 import hs.kr.entrydsm.identity.application.service.AuthService
+import hs.kr.entrydsm.identity.application.service.AccountService
 import java.time.Clock
 import org.springframework.context.annotation.Bean
 import org.springframework.context.annotation.Configuration
 
 @Configuration(proxyBeanMethods = false)
 class IdentityApplicationConfig {
+    @Bean
+    fun accountService(
+        accountQueryPort: AccountQueryPort,
+        accountCommandPort: AccountCommandPort,
+        applicationDataPort: ApplicationDataPort,
+        clock: Clock,
+    ): AccountPort = AccountService(
+        accountQueryPort,
+        accountCommandPort,
+        applicationDataPort,
+        clock,
+    )
+
     @Bean
     fun authService(
         accountQueryPort: AccountQueryPort,

--- a/systems/identity/identity-bootstrap/src/main/resources/application-prod.yaml
+++ b/systems/identity/identity-bootstrap/src/main/resources/application-prod.yaml
@@ -15,6 +15,7 @@ spring:
     properties:
       hibernate:
         dialect: org.hibernate.dialect.MySQLDialect
+  # V023__student_profiles_birthdate_date.sql must be applied by the deployment migration runner.
   data:
     redis:
       url: ${REDIS_URL}

--- a/systems/identity/identity-bootstrap/src/main/resources/db/migration/V023__student_profiles_birthdate_date.sql
+++ b/systems/identity/identity-bootstrap/src/main/resources/db/migration/V023__student_profiles_birthdate_date.sql
@@ -1,0 +1,4 @@
+-- Precondition: verify that every existing value matches YYYY-MM-DD before applying.
+-- Invalid rows must be corrected or quarantined before this statement is executed.
+ALTER TABLE student_profiles
+    MODIFY COLUMN birthdate DATE NOT NULL;

--- a/systems/identity/identity-bootstrap/src/test/kotlin/hs/kr/entrydsm/identity/config/SecurityConfigTest.kt
+++ b/systems/identity/identity-bootstrap/src/test/kotlin/hs/kr/entrydsm/identity/config/SecurityConfigTest.kt
@@ -5,8 +5,8 @@ import java.nio.charset.StandardCharsets
 import org.junit.Assert.assertEquals
 import org.junit.Assert.assertNotNull
 import org.junit.Assert.assertTrue
-import org.junit.Test
 import org.junit.Before
+import org.junit.Test
 import org.junit.runner.RunWith
 import org.springframework.beans.factory.annotation.Autowired
 import org.springframework.boot.test.context.SpringBootTest
@@ -14,6 +14,7 @@ import org.springframework.http.MediaType
 import org.springframework.mock.web.MockCookie
 import org.springframework.test.context.junit4.SpringRunner
 import org.springframework.test.web.servlet.MockMvc
+import org.springframework.test.web.servlet.request.MockMvcRequestBuilders.delete
 import org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get
 import org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post
 import org.springframework.web.context.WebApplicationContext
@@ -105,5 +106,23 @@ class SecurityConfigTest {
 
         assertTrue(response.status != 401)
         assertTrue(response.status != 403)
+    }
+
+    @Test
+    fun deleteAccountWithoutAuthorizationReturnsUnauthorizedError() {
+        val csrfResponse = mockMvc.perform(
+            get("/actuator/health"),
+        ).andReturn().response
+        val csrfCookie = requireNotNull(csrfResponse.getCookie("XSRF-TOKEN"))
+        val csrfToken = java.net.URLDecoder.decode(csrfCookie.value, StandardCharsets.UTF_8)
+
+        val response = mockMvc.perform(
+            delete("/api/identity/v11/accounts/me")
+                .cookie(MockCookie("XSRF-TOKEN", csrfToken))
+                .header("X-XSRF-TOKEN", csrfToken),
+        ).andReturn().response
+
+        assertEquals(401, response.status)
+        assertTrue(response.contentAsString.contains("AUTH_UNAUTHORIZED"))
     }
 }

--- a/systems/identity/identity-domain/src/test/kotlin/hs/kr/entrydsm/TestMain.kt
+++ b/systems/identity/identity-domain/src/test/kotlin/hs/kr/entrydsm/TestMain.kt
@@ -1,11 +1,11 @@
 package hs.kr.entrydsm.identity.domain
 
-import org.junit.Assert.assertTrue
-import org.junit.Test
+import org.junit.runner.RunWith
+import org.junit.runners.Suite
 
-class IdentityDomainModuleTest {
-    @Test
-    fun moduleLoads() {
-        assertTrue(true)
-    }
-}
+@RunWith(Suite::class)
+@Suite.SuiteClasses(
+    AccountTest::class,
+    StudentProfileTest::class,
+)
+class IdentityDomainModuleTest


### PR DESCRIPTION
## Summary
- 내 계정 정보 조회 및 계정 삭제 API를 추가했습니다.
- Account input port·command·service를 구성했습니다.
- Account와 StudentProfile의 JPA entity, repository, adapter를 추가했습니다.
- JPA auditing과 계정 domain 테스트를 구성했습니다.
- `develop` 대비 변경 파일 18개로 분리했습니다.

## Related Issue
- Related to #48

## Scope
- In scope:
  - `GET /api/identity/v11/accounts/me`
  - `DELETE /api/identity/v11/accounts/me`
  - Account service 및 input port
  - Account·StudentProfile JPA entity와 repository adapter
  - JPA auditing 설정 및 관련 테스트
- Out of scope:
  - 실제 외부 인증·Pass·Redis 연동
  - 지원서 application 저장소
  - account 탈퇴 후 개인정보 정책 및 배치 처리

## Implementation
- `AccountController`가 `AccountPort`를 통해 내 정보 조회와 계정 삭제를 처리합니다.
- `AccountService`는 인증 정보를 account repository로 resolve하고, application data에서 지원 상태를 조합해 응답합니다.
- `AccountJpaEntity`와 `StudentProfileJpaEntity`를 분리하고 Spring Data repository 및 adapter로 저장소 경계를 구성했습니다.
- 생성·수정 시각은 JPA auditing으로 관리합니다.

## Testing
- [x] Unit tests
- [ ] Integration tests
- [ ] Manual verification
- 검증 범위:
  - `AccountControllerTest` 추가
  - `StudentProfileTest` 추가
  - 인증 없는 계정 API: `401 AUTH_UNAUTHORIZED`
  - 전체 Bazel 테스트는 로컬 Bazel 환경 문제로 완료하지 못함

## Deployment Notes
- Feature flag: 없음
- Migration required: `accounts`, `student_profiles` 테이블 스키마 적용 필요
- Rollout considerations:
  - DB 접속 정보와 운영 스키마 migration 상태를 배포 전에 확인해야 합니다.
  - Hibernate에서 final getter에 대한 lazy proxy 경고가 확인되어 all-open 또는 entity property open 처리가 필요합니다.
  - 실제 auth/application adapter와 함께 선행 PR 순서대로 병합해야 합니다.

## Checklist
- [x] Matches product/tech requirements
- [x] Backward compatibility considered
- [ ] Docs updated if applicable
- [ ] 운영 DB migration 확인
- [ ] Hibernate final getter 경고 해결
