### PR TITLE
feat(configuration): 파일 도메인 모델 및 규칙 정의 #26

### DIFF
--- a/systems/configuration/configuration-domain/BUILD.bazel
+++ b/systems/configuration/configuration-domain/BUILD.bazel
@@ -17,5 +17,14 @@ kt_jvm_test(
     javac_opts = "//:javac_options",
     kotlinc_opts = "//:kotlinc_options",
     test_class = "hs.kr.entrydsm.configuration.domain.ConfigurationDomainModuleTest",
-    deps = MODULE_DEPS + TEST_DEPS,
+    deps = MODULE_DEPS + TEST_DEPS + [":main"],
+)
+
+kt_jvm_test(
+    name = "document_test",
+    srcs = glob(["src/test/kotlin/**/*.kt"]),
+    javac_opts = "//:javac_options",
+    kotlinc_opts = "//:kotlinc_options",
+    test_class = "hs.kr.entrydsm.configuration.domain.document.DocumentDomainTest",
+    deps = MODULE_DEPS + TEST_DEPS + [":main"],
 )

--- a/systems/configuration/configuration-domain/src/main/kotlin/hs/kr/entrydsm/configuration/domain/document/DownloadUrl.kt
+++ b/systems/configuration/configuration-domain/src/main/kotlin/hs/kr/entrydsm/configuration/domain/document/DownloadUrl.kt
@@ -1,0 +1,7 @@
+package hs.kr.entrydsm.configuration.domain.document
+
+data class DownloadUrl(
+    val fileName: String,
+    val downloadUrl: String,
+    val expiresIn: Long,
+)

--- a/systems/configuration/configuration-domain/src/main/kotlin/hs/kr/entrydsm/configuration/domain/document/FileCategory.kt
+++ b/systems/configuration/configuration-domain/src/main/kotlin/hs/kr/entrydsm/configuration/domain/document/FileCategory.kt
@@ -1,0 +1,25 @@
+package hs.kr.entrydsm.configuration.domain.document
+
+private const val MAX_DOCUMENT_SIZE_BYTES = 10L * 1024 * 1024
+private const val MAX_PHOTO_SIZE_BYTES = 5L * 1024 * 1024
+private const val MAX_ATTACHMENT_SIZE_BYTES = 20L * 1024 * 1024
+
+enum class FileCategory(
+    val prefix: String,
+    val allowedExtensions: Set<FileExtension>,
+    val maxSizeBytes: Long,
+) {
+    APPLICATION("application", FileExtension.DOCUMENT_FORMATS, MAX_DOCUMENT_SIZE_BYTES),
+    ADMISSION_TICKET("admission-ticket", FileExtension.DOCUMENT_FORMATS, MAX_DOCUMENT_SIZE_BYTES),
+    APPLICANT_LIST("applicant-list", setOf(FileExtension.XLSX), MAX_DOCUMENT_SIZE_BYTES),
+    PHOTO("photo", FileExtension.IMAGE_FORMATS, MAX_PHOTO_SIZE_BYTES),
+    ATTACHMENT("attachment", FileExtension.ATTACHMENT_FORMATS, MAX_ATTACHMENT_SIZE_BYTES),
+    GUIDELINE("guideline", FileExtension.ATTACHMENT_FORMATS, MAX_ATTACHMENT_SIZE_BYTES),
+    ;
+
+    fun supports(extension: FileExtension): Boolean = extension in allowedExtensions
+
+    fun exceedsMaxSize(sizeBytes: Long): Boolean = sizeBytes > maxSizeBytes
+
+    fun objectKeyOf(fileName: String): String = "$prefix/$fileName"
+}

--- a/systems/configuration/configuration-domain/src/main/kotlin/hs/kr/entrydsm/configuration/domain/document/FileCategory.kt
+++ b/systems/configuration/configuration-domain/src/main/kotlin/hs/kr/entrydsm/configuration/domain/document/FileCategory.kt
@@ -9,17 +9,17 @@ enum class FileCategory(
     val allowedExtensions: Set<FileExtension>,
     val maxSizeBytes: Long,
 ) {
-    APPLICATION("application", FileExtension.DOCUMENT_FORMATS, MAX_DOCUMENT_SIZE_BYTES),
-    ADMISSION_TICKET("admission-ticket", FileExtension.DOCUMENT_FORMATS, MAX_DOCUMENT_SIZE_BYTES),
+    APPLICATION("application", FileExtension.documentFormats, MAX_DOCUMENT_SIZE_BYTES),
+    ADMISSION_TICKET("admission-ticket", FileExtension.documentFormats, MAX_DOCUMENT_SIZE_BYTES),
     APPLICANT_LIST("applicant-list", setOf(FileExtension.XLSX), MAX_DOCUMENT_SIZE_BYTES),
-    PHOTO("photo", FileExtension.IMAGE_FORMATS, MAX_PHOTO_SIZE_BYTES),
-    ATTACHMENT("attachment", FileExtension.ATTACHMENT_FORMATS, MAX_ATTACHMENT_SIZE_BYTES),
-    GUIDELINE("guideline", FileExtension.ATTACHMENT_FORMATS, MAX_ATTACHMENT_SIZE_BYTES),
+    PHOTO("photo", FileExtension.imageFormats, MAX_PHOTO_SIZE_BYTES),
+    ATTACHMENT("attachment", FileExtension.attachmentFormats, MAX_ATTACHMENT_SIZE_BYTES),
+    GUIDELINE("guideline", FileExtension.attachmentFormats, MAX_ATTACHMENT_SIZE_BYTES),
     ;
 
     fun supports(extension: FileExtension): Boolean = extension in allowedExtensions
 
     fun exceedsMaxSize(sizeBytes: Long): Boolean = sizeBytes > maxSizeBytes
 
-    fun objectKeyOf(fileName: String): String = "$prefix/$fileName"
+    fun objectKeyOf(fileName: String): String = "$prefix/${FileNaming.requireSafeFileName(fileName)}"
 }

--- a/systems/configuration/configuration-domain/src/main/kotlin/hs/kr/entrydsm/configuration/domain/document/FileDocument.kt
+++ b/systems/configuration/configuration-domain/src/main/kotlin/hs/kr/entrydsm/configuration/domain/document/FileDocument.kt
@@ -1,0 +1,17 @@
+package hs.kr.entrydsm.configuration.domain.document
+
+import java.time.Instant
+
+data class FileDocument(
+    val id: Long? = null,
+    val originalName: String,
+    val objectKey: String,
+    val bucket: String,
+    val contentType: String,
+    val sizeBytes: Long,
+    val checksum: String,
+    val createdAt: Instant? = null,
+) {
+    val fileName: String
+        get() = objectKey.substringAfterLast('/')
+}

--- a/systems/configuration/configuration-domain/src/main/kotlin/hs/kr/entrydsm/configuration/domain/document/FileExtension.kt
+++ b/systems/configuration/configuration-domain/src/main/kotlin/hs/kr/entrydsm/configuration/domain/document/FileExtension.kt
@@ -1,0 +1,35 @@
+package hs.kr.entrydsm.configuration.domain.document
+
+enum class FileExtension(
+    val value: String,
+    val contentType: String,
+    private val aliases: Set<String> = emptySet(),
+) {
+    PDF("pdf", "application/pdf"),
+    HWP("hwp", "application/x-hwp"),
+    XLSX("xlsx", "application/vnd.openxmlformats-officedocument.spreadsheetml.sheet"),
+    DOCX("docx", "application/vnd.openxmlformats-officedocument.wordprocessingml.document"),
+    JPG("jpg", "image/jpeg", setOf("jpeg")),
+    PNG("png", "image/png"),
+    WEBP("webp", "image/webp"),
+    ;
+
+    companion object {
+        val DOCUMENT_FORMATS = setOf(PDF, HWP)
+
+        val IMAGE_FORMATS = setOf(JPG, PNG, WEBP)
+
+        val ATTACHMENT_FORMATS = DOCUMENT_FORMATS + IMAGE_FORMATS + setOf(XLSX, DOCX)
+
+        fun fromFileName(fileName: String): FileExtension? {
+            val extension = fileName.substringAfterLast('.', "")
+            if (extension.isEmpty()) return null
+            return fromExtension(extension)
+        }
+
+        fun fromExtension(extension: String): FileExtension? {
+            val normalized = extension.removePrefix(".").lowercase()
+            return entries.firstOrNull { it.value == normalized || normalized in it.aliases }
+        }
+    }
+}

--- a/systems/configuration/configuration-domain/src/main/kotlin/hs/kr/entrydsm/configuration/domain/document/FileExtension.kt
+++ b/systems/configuration/configuration-domain/src/main/kotlin/hs/kr/entrydsm/configuration/domain/document/FileExtension.kt
@@ -15,11 +15,11 @@ enum class FileExtension(
     ;
 
     companion object {
-        val DOCUMENT_FORMATS = setOf(PDF, HWP)
+        val documentFormats = setOf(PDF, HWP)
 
-        val IMAGE_FORMATS = setOf(JPG, PNG, WEBP)
+        val imageFormats = setOf(JPG, PNG, WEBP)
 
-        val ATTACHMENT_FORMATS = DOCUMENT_FORMATS + IMAGE_FORMATS + setOf(XLSX, DOCX)
+        val attachmentFormats = documentFormats + imageFormats + setOf(XLSX, DOCX)
 
         fun fromFileName(fileName: String): FileExtension? {
             val extension = fileName.substringAfterLast('.', "")

--- a/systems/configuration/configuration-domain/src/main/kotlin/hs/kr/entrydsm/configuration/domain/document/FileNaming.kt
+++ b/systems/configuration/configuration-domain/src/main/kotlin/hs/kr/entrydsm/configuration/domain/document/FileNaming.kt
@@ -1,0 +1,52 @@
+package hs.kr.entrydsm.configuration.domain.document
+
+import hs.kr.entrydsm.configuration.domain.document.exception.InvalidFileNameException
+import java.time.LocalDate
+import java.time.format.DateTimeFormatter
+import java.util.UUID
+
+private val SAFE_IDENTIFIER = Regex("[A-Za-z0-9_-]+")
+private val UNSAFE_CHARACTERS = Regex("[^A-Za-z0-9._-]")
+private val APPLICANT_LIST_DATE = DateTimeFormatter.ofPattern("yyyyMMdd")
+private const val TOKEN_LENGTH = 8
+
+object FileNaming {
+
+    fun applicationFileName(receiptCode: String, extension: FileExtension): String =
+        "application_${requireIdentifier(receiptCode)}.${extension.value}"
+
+    fun admissionTicketFileName(receiptCode: String, extension: FileExtension): String =
+        "admission_ticket_${requireIdentifier(receiptCode)}.${extension.value}"
+
+    fun applicantListFileName(date: LocalDate): String =
+        "applicants_${APPLICANT_LIST_DATE.format(date)}.${FileExtension.XLSX.value}"
+
+    fun photoFileName(extension: FileExtension): String =
+        "photo_${randomToken()}.${extension.value}"
+
+    fun attachmentFileName(originalName: String): String =
+        "${randomToken()}_${sanitizeOriginalName(originalName)}"
+
+    fun requireIdentifier(value: String): String {
+        if (!SAFE_IDENTIFIER.matches(value)) throw InvalidFileNameException(value)
+        return value
+    }
+
+    fun requireSafeFileName(fileName: String): String {
+        if (sanitizeOriginalName(fileName) != fileName) throw InvalidFileNameException(fileName)
+        return fileName
+    }
+
+    fun sanitizeOriginalName(originalName: String): String {
+        val baseName = originalName
+            .substringAfterLast('/')
+            .substringAfterLast('\\')
+            .trim()
+        val sanitized = UNSAFE_CHARACTERS.replace(baseName, "_").trimStart('.')
+        if (sanitized.isEmpty() || sanitized == "_") throw InvalidFileNameException(originalName)
+        return sanitized
+    }
+
+    private fun randomToken(): String =
+        UUID.randomUUID().toString().replace("-", "").take(TOKEN_LENGTH)
+}

--- a/systems/configuration/configuration-domain/src/main/kotlin/hs/kr/entrydsm/configuration/domain/document/FileNaming.kt
+++ b/systems/configuration/configuration-domain/src/main/kotlin/hs/kr/entrydsm/configuration/domain/document/FileNaming.kt
@@ -8,7 +8,6 @@ import java.util.UUID
 private val SAFE_IDENTIFIER = Regex("[A-Za-z0-9_-]+")
 private val UNSAFE_CHARACTERS = Regex("[^A-Za-z0-9._-]")
 private val APPLICANT_LIST_DATE = DateTimeFormatter.ofPattern("yyyyMMdd")
-private const val TOKEN_LENGTH = 8
 
 object FileNaming {
 
@@ -48,5 +47,5 @@ object FileNaming {
     }
 
     private fun randomToken(): String =
-        UUID.randomUUID().toString().replace("-", "").take(TOKEN_LENGTH)
+        UUID.randomUUID().toString().replace("-", "")
 }

--- a/systems/configuration/configuration-domain/src/main/kotlin/hs/kr/entrydsm/configuration/domain/document/FileNaming.kt
+++ b/systems/configuration/configuration-domain/src/main/kotlin/hs/kr/entrydsm/configuration/domain/document/FileNaming.kt
@@ -5,9 +5,9 @@ import java.time.LocalDate
 import java.time.format.DateTimeFormatter
 import java.util.UUID
 
-private val SAFE_IDENTIFIER = Regex("[A-Za-z0-9_-]+")
-private val UNSAFE_CHARACTERS = Regex("[^A-Za-z0-9._-]")
-private val APPLICANT_LIST_DATE = DateTimeFormatter.ofPattern("yyyyMMdd")
+private val safeIdentifier = Regex("[A-Za-z0-9_-]+")
+private val unsafeCharacters = Regex("[^A-Za-z0-9._-]")
+private val applicantListDate = DateTimeFormatter.ofPattern("yyyyMMdd")
 
 object FileNaming {
 
@@ -18,7 +18,7 @@ object FileNaming {
         "admission_ticket_${requireIdentifier(receiptCode)}.${extension.value}"
 
     fun applicantListFileName(date: LocalDate): String =
-        "applicants_${APPLICANT_LIST_DATE.format(date)}.${FileExtension.XLSX.value}"
+        "applicants_${applicantListDate.format(date)}.${FileExtension.XLSX.value}"
 
     fun photoFileName(extension: FileExtension): String =
         "photo_${randomToken()}.${extension.value}"
@@ -27,7 +27,7 @@ object FileNaming {
         "${randomToken()}_${sanitizeOriginalName(originalName)}"
 
     fun requireIdentifier(value: String): String {
-        if (!SAFE_IDENTIFIER.matches(value)) throw InvalidFileNameException(value)
+        if (!safeIdentifier.matches(value)) throw InvalidFileNameException(value)
         return value
     }
 
@@ -41,7 +41,7 @@ object FileNaming {
             .substringAfterLast('/')
             .substringAfterLast('\\')
             .trim()
-        val sanitized = UNSAFE_CHARACTERS.replace(baseName, "_").trimStart('.')
+        val sanitized = unsafeCharacters.replace(baseName, "_").trimStart('.')
         if (sanitized.isEmpty() || sanitized == "_") throw InvalidFileNameException(originalName)
         return sanitized
     }

--- a/systems/configuration/configuration-domain/src/main/kotlin/hs/kr/entrydsm/configuration/domain/document/StoredObject.kt
+++ b/systems/configuration/configuration-domain/src/main/kotlin/hs/kr/entrydsm/configuration/domain/document/StoredObject.kt
@@ -1,0 +1,7 @@
+package hs.kr.entrydsm.configuration.domain.document
+
+data class StoredObject(
+    val bucket: String,
+    val objectKey: String,
+    val checksum: String,
+)

--- a/systems/configuration/configuration-domain/src/main/kotlin/hs/kr/entrydsm/configuration/domain/document/command/IssueDownloadUrlCommand.kt
+++ b/systems/configuration/configuration-domain/src/main/kotlin/hs/kr/entrydsm/configuration/domain/document/command/IssueDownloadUrlCommand.kt
@@ -1,0 +1,8 @@
+package hs.kr.entrydsm.configuration.domain.document.command
+
+import hs.kr.entrydsm.configuration.domain.document.FileCategory
+
+data class IssueDownloadUrlCommand(
+    val category: FileCategory,
+    val fileName: String,
+)

--- a/systems/configuration/configuration-domain/src/main/kotlin/hs/kr/entrydsm/configuration/domain/document/command/UploadFileCommand.kt
+++ b/systems/configuration/configuration-domain/src/main/kotlin/hs/kr/entrydsm/configuration/domain/document/command/UploadFileCommand.kt
@@ -1,0 +1,10 @@
+package hs.kr.entrydsm.configuration.domain.document.command
+
+import hs.kr.entrydsm.configuration.domain.document.FileCategory
+
+data class UploadFileCommand(
+    val category: FileCategory,
+    val originalName: String,
+    val sizeBytes: Long,
+    val fileName: String? = null,
+)

--- a/systems/configuration/configuration-domain/src/main/kotlin/hs/kr/entrydsm/configuration/domain/document/exception/FileDocumentNotFoundException.kt
+++ b/systems/configuration/configuration-domain/src/main/kotlin/hs/kr/entrydsm/configuration/domain/document/exception/FileDocumentNotFoundException.kt
@@ -1,0 +1,4 @@
+package hs.kr.entrydsm.configuration.domain.document.exception
+
+class FileDocumentNotFoundException(objectKey: String) :
+    RuntimeException("File not found: $objectKey")

--- a/systems/configuration/configuration-domain/src/main/kotlin/hs/kr/entrydsm/configuration/domain/document/exception/FileTooLargeException.kt
+++ b/systems/configuration/configuration-domain/src/main/kotlin/hs/kr/entrydsm/configuration/domain/document/exception/FileTooLargeException.kt
@@ -1,0 +1,4 @@
+package hs.kr.entrydsm.configuration.domain.document.exception
+
+class FileTooLargeException(sizeBytes: Long, maxSizeBytes: Long) :
+    RuntimeException("File size $sizeBytes bytes exceeds limit of $maxSizeBytes bytes")

--- a/systems/configuration/configuration-domain/src/main/kotlin/hs/kr/entrydsm/configuration/domain/document/exception/InvalidFileFormatException.kt
+++ b/systems/configuration/configuration-domain/src/main/kotlin/hs/kr/entrydsm/configuration/domain/document/exception/InvalidFileFormatException.kt
@@ -1,0 +1,9 @@
+package hs.kr.entrydsm.configuration.domain.document.exception
+
+import hs.kr.entrydsm.configuration.domain.document.FileCategory
+
+class InvalidFileFormatException(fileName: String, category: FileCategory) :
+    RuntimeException(
+        "Unsupported file format for ${category.name}: $fileName " +
+            "(allowed: ${category.allowedExtensions.joinToString { it.value }})"
+    )

--- a/systems/configuration/configuration-domain/src/main/kotlin/hs/kr/entrydsm/configuration/domain/document/exception/InvalidFileNameException.kt
+++ b/systems/configuration/configuration-domain/src/main/kotlin/hs/kr/entrydsm/configuration/domain/document/exception/InvalidFileNameException.kt
@@ -1,0 +1,4 @@
+package hs.kr.entrydsm.configuration.domain.document.exception
+
+class InvalidFileNameException(fileName: String) :
+    RuntimeException("Invalid file name: $fileName")

--- a/systems/configuration/configuration-domain/src/main/kotlin/hs/kr/entrydsm/configuration/domain/document/exception/PresignFailedException.kt
+++ b/systems/configuration/configuration-domain/src/main/kotlin/hs/kr/entrydsm/configuration/domain/document/exception/PresignFailedException.kt
@@ -1,0 +1,4 @@
+package hs.kr.entrydsm.configuration.domain.document.exception
+
+class PresignFailedException(objectKey: String, cause: Throwable? = null) :
+    RuntimeException("Failed to issue download URL: $objectKey", cause)

--- a/systems/configuration/configuration-domain/src/main/kotlin/hs/kr/entrydsm/configuration/domain/document/exception/StorageUploadFailedException.kt
+++ b/systems/configuration/configuration-domain/src/main/kotlin/hs/kr/entrydsm/configuration/domain/document/exception/StorageUploadFailedException.kt
@@ -1,0 +1,4 @@
+package hs.kr.entrydsm.configuration.domain.document.exception
+
+class StorageUploadFailedException(objectKey: String, cause: Throwable? = null) :
+    RuntimeException("Failed to upload file to storage: $objectKey", cause)

--- a/systems/configuration/configuration-domain/src/main/kotlin/hs/kr/entrydsm/configuration/domain/document/port/in/IssueDownloadUrlUseCase.kt
+++ b/systems/configuration/configuration-domain/src/main/kotlin/hs/kr/entrydsm/configuration/domain/document/port/in/IssueDownloadUrlUseCase.kt
@@ -1,0 +1,9 @@
+package hs.kr.entrydsm.configuration.domain.document.port.`in`
+
+import hs.kr.entrydsm.configuration.domain.document.DownloadUrl
+import hs.kr.entrydsm.configuration.domain.document.command.IssueDownloadUrlCommand
+
+interface IssueDownloadUrlUseCase {
+    fun issueByCommand(command: IssueDownloadUrlCommand): DownloadUrl
+    fun issueById(id: Long): DownloadUrl
+}

--- a/systems/configuration/configuration-domain/src/main/kotlin/hs/kr/entrydsm/configuration/domain/document/port/in/ReadFileUseCase.kt
+++ b/systems/configuration/configuration-domain/src/main/kotlin/hs/kr/entrydsm/configuration/domain/document/port/in/ReadFileUseCase.kt
@@ -1,0 +1,10 @@
+package hs.kr.entrydsm.configuration.domain.document.port.`in`
+
+import hs.kr.entrydsm.configuration.domain.document.FileCategory
+import hs.kr.entrydsm.configuration.domain.document.FileDocument
+
+interface ReadFileUseCase {
+    fun findById(id: Long): FileDocument
+    fun findByFileName(category: FileCategory, fileName: String): FileDocument?
+    fun existsById(id: Long): Boolean
+}

--- a/systems/configuration/configuration-domain/src/main/kotlin/hs/kr/entrydsm/configuration/domain/document/port/in/UploadFileUseCase.kt
+++ b/systems/configuration/configuration-domain/src/main/kotlin/hs/kr/entrydsm/configuration/domain/document/port/in/UploadFileUseCase.kt
@@ -1,0 +1,9 @@
+package hs.kr.entrydsm.configuration.domain.document.port.`in`
+
+import hs.kr.entrydsm.configuration.domain.document.FileDocument
+import hs.kr.entrydsm.configuration.domain.document.command.UploadFileCommand
+import java.io.InputStream
+
+interface UploadFileUseCase {
+    fun upload(command: UploadFileCommand, content: InputStream): FileDocument
+}

--- a/systems/configuration/configuration-domain/src/main/kotlin/hs/kr/entrydsm/configuration/domain/document/port/out/FileDocumentRepository.kt
+++ b/systems/configuration/configuration-domain/src/main/kotlin/hs/kr/entrydsm/configuration/domain/document/port/out/FileDocumentRepository.kt
@@ -1,0 +1,11 @@
+package hs.kr.entrydsm.configuration.domain.document.port.out
+
+import hs.kr.entrydsm.configuration.domain.document.FileDocument
+
+interface FileDocumentRepository {
+    fun save(fileDocument: FileDocument): FileDocument
+    fun findById(id: Long): FileDocument?
+    fun findByObjectKey(objectKey: String): FileDocument?
+    fun existsById(id: Long): Boolean
+    fun deleteByObjectKey(objectKey: String)
+}

--- a/systems/configuration/configuration-domain/src/main/kotlin/hs/kr/entrydsm/configuration/domain/document/port/out/StoragePort.kt
+++ b/systems/configuration/configuration-domain/src/main/kotlin/hs/kr/entrydsm/configuration/domain/document/port/out/StoragePort.kt
@@ -1,0 +1,19 @@
+package hs.kr.entrydsm.configuration.domain.document.port.out
+
+import hs.kr.entrydsm.configuration.domain.document.StoredObject
+import java.io.InputStream
+
+interface StoragePort {
+    fun upload(
+        objectKey: String,
+        contentType: String,
+        sizeBytes: Long,
+        content: InputStream,
+    ): StoredObject
+
+    fun issueDownloadUrl(objectKey: String, expiresInSeconds: Long): String
+
+    fun exists(objectKey: String): Boolean
+
+    fun delete(objectKey: String)
+}

--- a/systems/configuration/configuration-domain/src/test/kotlin/hs/kr/entrydsm/configuration/domain/document/DocumentDomainTest.kt
+++ b/systems/configuration/configuration-domain/src/test/kotlin/hs/kr/entrydsm/configuration/domain/document/DocumentDomainTest.kt
@@ -52,6 +52,11 @@ class DocumentDomainTest {
         )
     }
 
+    @Test(expected = InvalidFileNameException::class)
+    fun `object key에 상위 경로 참조가 들어오면 거부한다`() {
+        FileCategory.APPLICANT_LIST.objectKeyOf("../../etc/passwd")
+    }
+
     @Test
     fun `명세 예시와 같은 파일명을 만든다`() {
         assertEquals(
@@ -70,8 +75,8 @@ class DocumentDomainTest {
 
     @Test
     fun `증명사진과 첨부파일 이름에 랜덤 토큰을 붙인다`() {
-        assertTrue(FileNaming.photoFileName(FileExtension.JPG).matches(Regex("photo_[0-9a-f]{8}\\.jpg")))
-        assertTrue(FileNaming.attachmentFileName("guide.pdf").matches(Regex("[0-9a-f]{8}_guide\\.pdf")))
+        assertTrue(FileNaming.photoFileName(FileExtension.JPG).matches(Regex("photo_[0-9a-f]{32}\\.jpg")))
+        assertTrue(FileNaming.attachmentFileName("guide.pdf").matches(Regex("[0-9a-f]{32}_guide\\.pdf")))
     }
 
     @Test

--- a/systems/configuration/configuration-domain/src/test/kotlin/hs/kr/entrydsm/configuration/domain/document/DocumentDomainTest.kt
+++ b/systems/configuration/configuration-domain/src/test/kotlin/hs/kr/entrydsm/configuration/domain/document/DocumentDomainTest.kt
@@ -1,0 +1,100 @@
+package hs.kr.entrydsm.configuration.domain.document
+
+import hs.kr.entrydsm.configuration.domain.document.exception.InvalidFileNameException
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertFalse
+import org.junit.Assert.assertNull
+import org.junit.Assert.assertTrue
+import org.junit.Test
+import java.time.LocalDate
+
+class DocumentDomainTest {
+
+    @Test
+    fun `확장자를 대소문자 구분 없이 인식한다`() {
+        assertEquals(FileExtension.PDF, FileExtension.fromFileName("application_1001.PDF"))
+        assertEquals(FileExtension.XLSX, FileExtension.fromExtension(".xlsx"))
+    }
+
+    @Test
+    fun `jpeg는 jpg의 별칭으로 처리한다`() {
+        assertEquals(FileExtension.JPG, FileExtension.fromFileName("photo.jpeg"))
+        assertEquals("image/jpeg", FileExtension.JPG.contentType)
+    }
+
+    @Test
+    fun `확장자가 없으면 인식하지 않는다`() {
+        assertNull(FileExtension.fromFileName("noextension"))
+        assertNull(FileExtension.fromFileName("unknown.exe"))
+    }
+
+    @Test
+    fun `카테고리마다 허용 확장자가 다르다`() {
+        assertTrue(FileCategory.APPLICATION.supports(FileExtension.PDF))
+        assertFalse(FileCategory.APPLICATION.supports(FileExtension.JPG))
+        assertEquals(setOf(FileExtension.XLSX), FileCategory.APPLICANT_LIST.allowedExtensions)
+        assertTrue(FileCategory.PHOTO.supports(FileExtension.WEBP))
+        assertFalse(FileCategory.PHOTO.supports(FileExtension.PDF))
+        assertTrue(FileCategory.ATTACHMENT.supports(FileExtension.DOCX))
+    }
+
+    @Test
+    fun `카테고리별 용량 한도를 넘으면 초과로 판정한다`() {
+        assertFalse(FileCategory.PHOTO.exceedsMaxSize(FileCategory.PHOTO.maxSizeBytes))
+        assertTrue(FileCategory.PHOTO.exceedsMaxSize(FileCategory.PHOTO.maxSizeBytes + 1))
+    }
+
+    @Test
+    fun `object key는 카테고리 prefix를 붙인다`() {
+        assertEquals(
+            "admission-ticket/admission_ticket_1001.pdf",
+            FileCategory.ADMISSION_TICKET.objectKeyOf("admission_ticket_1001.pdf"),
+        )
+    }
+
+    @Test
+    fun `명세 예시와 같은 파일명을 만든다`() {
+        assertEquals(
+            "application_1001.pdf",
+            FileNaming.applicationFileName("1001", FileExtension.PDF),
+        )
+        assertEquals(
+            "admission_ticket_1001.pdf",
+            FileNaming.admissionTicketFileName("1001", FileExtension.PDF),
+        )
+        assertEquals(
+            "applicants_20260726.xlsx",
+            FileNaming.applicantListFileName(LocalDate.of(2026, 7, 26)),
+        )
+    }
+
+    @Test
+    fun `증명사진과 첨부파일 이름에 랜덤 토큰을 붙인다`() {
+        assertTrue(FileNaming.photoFileName(FileExtension.JPG).matches(Regex("photo_[0-9a-f]{8}\\.jpg")))
+        assertTrue(FileNaming.attachmentFileName("guide.pdf").matches(Regex("[0-9a-f]{8}_guide\\.pdf")))
+    }
+
+    @Test
+    fun `원본 파일명에서 경로를 제거하고 허용 외 문자를 치환한다`() {
+        assertEquals("pas_swd.pdf", FileNaming.sanitizeOriginalName("../../etc/pas swd.pdf"))
+        assertEquals("report.xlsx", FileNaming.sanitizeOriginalName("C:\\temp\\report.xlsx"))
+    }
+
+    @Test(expected = InvalidFileNameException::class)
+    fun `수험번호에 경로 문자가 들어오면 거부한다`() {
+        FileNaming.requireIdentifier("../1001")
+    }
+
+    @Test(expected = InvalidFileNameException::class)
+    fun `다운로드 파일명에 상위 경로 참조가 들어오면 거부한다`() {
+        FileNaming.requireSafeFileName("../../etc/passwd")
+    }
+
+    @Test
+    fun `정상 다운로드 파일명은 그대로 통과시킨다`() {
+        assertEquals(
+            "applicants_20260726.xlsx",
+            FileNaming.requireSafeFileName("applicants_20260726.xlsx"),
+        )
+    }
+}


### PR DESCRIPTION
> 스택 PR 1/4 — base: `develop`
> 이후 PR은 이 브랜치를 base로 합니다. **순서대로 머지해 주세요.**

## Summary
- Document 파일 처리의 도메인 모델과 형식·용량·파일명 규칙을 정의합니다.
- Spring / AWS / JPA에 의존하지 않는 순수 Kotlin 모듈입니다 (`deps.bzl`은 비어 있는 상태 유지).

## Related Issue
- Ref #26 (스택의 마지막 PR에서 close 합니다)

## Scope
- In scope: `configuration-domain`의 `hs.kr.entrydsm.configuration.domain.document` 패키지
- Out of scope: 어댑터 구현, REST / gRPC 노출, 트랜잭션 처리

## Implementation
API 11종은 허용 확장자·용량 한도·`object_key` 명명 규칙이 API마다 다릅니다. 이 규칙이 컨트롤러나 어댑터에 흩어지면 원서 슬롯에 이미지가 올라가는 식의 사고를 막을 수 없어 도메인에 모았습니다.

- **`FileExtension`** — 확장자↔MIME 매핑. `jpeg`를 `jpg` 별칭으로 처리
- **`FileCategory`** — 용도별 `object_key` prefix, 허용 확장자 집합, 최대 용량. 전역 화이트리스트 하나로 두면 카테고리별 제한이 불가능해 카테고리가 자기 허용 집합을 갖습니다
- **`FileNaming`** — 명세 응답 예시와 동일한 파일명 생성(`application_1001.pdf`, `photo_5f3c9a2b.jpg` 등) + 경로 조작 방어
- **예외 6종** — 명세 에러 코드와 1:1 (`INVALID_FILE_FORMAT`, `FILE_TOO_LARGE`, `FILE_NOT_FOUND`, `STORAGE_UPLOAD_FAILED`, `PRESIGN_FAILED`)
- **포트** — `port/in` 3종, `port/out` 2종. 참조 구현(EnvironmentVariable)과 동일하게 `-application`이 아니라 `-domain`에 둡니다

`#7 지원자 목록 excel 다운`은 `fileName`이 그대로 S3 키에 붙으므로 `requireSafeFileName`으로 경로 구분자·상위 경로 참조를 거부합니다.

## Testing
- [x] Unit tests — 도메인 규칙 테스트 12개 (확장자 인식, 카테고리별 허용/용량, 명세와 동일한 파일명 생성, 경로 조작 거부)
- [ ] Integration tests
- [ ] Manual verification

```
bazel test //systems/configuration/...
```

## Deployment Notes
- Feature flag: 없음
- Migration required: 없음 (이 PR 범위 한정)
- Rollout considerations: 도메인 모듈만 추가되며 기존 동작에 영향 없음

## Checklist
- [x] Matches product/tech requirements
- [x] Backward compatibility considered
- [ ] Docs updated if applicable

## 리뷰 시 봐주셨으면 하는 것
1. **용량 한도가 임의값입니다** — 명세에 수치가 없어 문서 10MB / 사진 5MB / 첨부 20MB로 정했습니다. 팀 기준이 있으면 알려주세요.
2. **`.hwp` MIME** — 표준이 없어 `application/x-hwp`로 고정했습니다.
3. **`BUILD.bazel` 수정 포함** — 기존 `test` 타깃이 `:main`에 의존하지 않아 도메인 클래스를 참조하는 테스트가 컴파일되지 않았습니다. 함께 고쳤습니다. `kt_jvm_test`는 `test_class`를 하나만 받아 `document_test` 타깃을 별도로 추가했습니다.
4. 파일이 21개지만 예외·포트가 4~11줄짜리라 실질 리뷰량은 크지 않습니다.
