### PR TITLE
feat(configuration): 파일 REST API 11종 구현 #26

### DIFF
--- a/systems/configuration/configuration-adapter-in/BUILD.bazel
+++ b/systems/configuration/configuration-adapter-in/BUILD.bazel
@@ -28,3 +28,12 @@ kt_jvm_test(
     test_class = "hs.kr.entrydsm.configuration.adapterin.common.DocumentApiContractTest",
     deps = MODULE_DEPS + TEST_DEPS + [":main"],
 )
+
+kt_jvm_test(
+    name = "document_controller_test",
+    srcs = glob(["src/test/kotlin/**/*.kt"]),
+    javac_opts = "//:javac_options",
+    kotlinc_opts = "//:kotlinc_options",
+    test_class = "hs.kr.entrydsm.configuration.adapterin.document.DocumentControllerTest",
+    deps = MODULE_DEPS + TEST_DEPS + [":main"],
+)

--- a/systems/configuration/configuration-adapter-in/src/main/kotlin/hs/kr/entrydsm/configuration/adapterin/document/AdmissionTicketController.kt
+++ b/systems/configuration/configuration-adapter-in/src/main/kotlin/hs/kr/entrydsm/configuration/adapterin/document/AdmissionTicketController.kt
@@ -1,0 +1,54 @@
+package hs.kr.entrydsm.configuration.adapterin.document
+
+import hs.kr.entrydsm.configuration.adapterin.common.ApiResponse
+import hs.kr.entrydsm.configuration.adapterin.document.dto.DownloadUrlResponse
+import hs.kr.entrydsm.configuration.adapterin.document.dto.UploadFileResponse
+import hs.kr.entrydsm.configuration.domain.document.FileCategory
+import hs.kr.entrydsm.configuration.domain.document.FileExtension
+import hs.kr.entrydsm.configuration.domain.document.FileNaming
+import hs.kr.entrydsm.configuration.domain.document.command.IssueDownloadUrlCommand
+import hs.kr.entrydsm.configuration.domain.document.port.`in`.IssueDownloadUrlUseCase
+import hs.kr.entrydsm.configuration.domain.document.port.`in`.UploadFileUseCase
+import org.springframework.web.bind.annotation.GetMapping
+import org.springframework.web.bind.annotation.PostMapping
+import org.springframework.web.bind.annotation.RequestMapping
+import org.springframework.web.bind.annotation.RequestParam
+import org.springframework.web.bind.annotation.RestController
+import org.springframework.web.multipart.MultipartFile
+
+private val CATEGORY = FileCategory.ADMISSION_TICKET
+
+@RestController
+@RequestMapping("/api/document/v11/admission-ticket")
+class AdmissionTicketController(
+    private val uploadFileUseCase: UploadFileUseCase,
+    private val issueDownloadUrlUseCase: IssueDownloadUrlUseCase,
+) {
+
+    @PostMapping
+    fun save(
+        @RequestParam("file") file: MultipartFile,
+        @RequestParam("receiptCode") receiptCode: String,
+    ): ApiResponse<UploadFileResponse> {
+        val fileName = FileNaming.admissionTicketFileName(receiptCode, file.requireExtension(CATEGORY))
+        val saved = file.inputStream.use {
+            uploadFileUseCase.upload(file.toUploadCommand(CATEGORY, fileName), it)
+        }
+        return ApiResponse.success(UploadFileResponse.from(saved))
+    }
+
+    @GetMapping("/download")
+    fun download(
+        @RequestParam("receiptCode") receiptCode: String,
+        @RequestParam("format", defaultValue = "pdf") format: String,
+    ): ApiResponse<DownloadUrlResponse> {
+        val extension = FileExtension.fromExtension(format)?.takeIf(CATEGORY::supports)
+            ?: throw IllegalArgumentException("Unsupported format: $format")
+        val fileName = FileNaming.admissionTicketFileName(receiptCode, extension)
+        return ApiResponse.success(
+            DownloadUrlResponse.from(
+                issueDownloadUrlUseCase.issueByCommand(IssueDownloadUrlCommand(CATEGORY, fileName))
+            )
+        )
+    }
+}

--- a/systems/configuration/configuration-adapter-in/src/main/kotlin/hs/kr/entrydsm/configuration/adapterin/document/AdmissionTicketController.kt
+++ b/systems/configuration/configuration-adapter-in/src/main/kotlin/hs/kr/entrydsm/configuration/adapterin/document/AdmissionTicketController.kt
@@ -7,6 +7,7 @@ import hs.kr.entrydsm.configuration.domain.document.FileCategory
 import hs.kr.entrydsm.configuration.domain.document.FileExtension
 import hs.kr.entrydsm.configuration.domain.document.FileNaming
 import hs.kr.entrydsm.configuration.domain.document.command.IssueDownloadUrlCommand
+import hs.kr.entrydsm.configuration.domain.document.exception.InvalidFileFormatException
 import hs.kr.entrydsm.configuration.domain.document.port.`in`.IssueDownloadUrlUseCase
 import hs.kr.entrydsm.configuration.domain.document.port.`in`.UploadFileUseCase
 import org.springframework.web.bind.annotation.GetMapping
@@ -43,7 +44,7 @@ class AdmissionTicketController(
         @RequestParam("format", defaultValue = "pdf") format: String,
     ): ApiResponse<DownloadUrlResponse> {
         val extension = FileExtension.fromExtension(format)?.takeIf(CATEGORY::supports)
-            ?: throw IllegalArgumentException("Unsupported format: $format")
+            ?: throw InvalidFileFormatException(format, CATEGORY)
         val fileName = FileNaming.admissionTicketFileName(receiptCode, extension)
         return ApiResponse.success(
             DownloadUrlResponse.from(

--- a/systems/configuration/configuration-adapter-in/src/main/kotlin/hs/kr/entrydsm/configuration/adapterin/document/ApplicantListController.kt
+++ b/systems/configuration/configuration-adapter-in/src/main/kotlin/hs/kr/entrydsm/configuration/adapterin/document/ApplicantListController.kt
@@ -7,6 +7,7 @@ import hs.kr.entrydsm.configuration.domain.document.FileCategory
 import hs.kr.entrydsm.configuration.domain.document.FileExtension
 import hs.kr.entrydsm.configuration.domain.document.FileNaming
 import hs.kr.entrydsm.configuration.domain.document.command.IssueDownloadUrlCommand
+import hs.kr.entrydsm.configuration.domain.document.exception.InvalidFileFormatException
 import hs.kr.entrydsm.configuration.domain.document.port.`in`.IssueDownloadUrlUseCase
 import hs.kr.entrydsm.configuration.domain.document.port.`in`.UploadFileUseCase
 import org.springframework.web.bind.annotation.GetMapping
@@ -50,7 +51,7 @@ class ApplicantListController(
 
     private fun requireXlsx(fileName: String) {
         if (FileExtension.fromFileName(fileName) != FileExtension.XLSX) {
-            throw IllegalArgumentException("fileName must end with .xlsx: $fileName")
+            throw InvalidFileFormatException(fileName, CATEGORY)
         }
     }
 }

--- a/systems/configuration/configuration-adapter-in/src/main/kotlin/hs/kr/entrydsm/configuration/adapterin/document/ApplicantListController.kt
+++ b/systems/configuration/configuration-adapter-in/src/main/kotlin/hs/kr/entrydsm/configuration/adapterin/document/ApplicantListController.kt
@@ -1,0 +1,56 @@
+package hs.kr.entrydsm.configuration.adapterin.document
+
+import hs.kr.entrydsm.configuration.adapterin.common.ApiResponse
+import hs.kr.entrydsm.configuration.adapterin.document.dto.DownloadUrlResponse
+import hs.kr.entrydsm.configuration.adapterin.document.dto.UploadFileResponse
+import hs.kr.entrydsm.configuration.domain.document.FileCategory
+import hs.kr.entrydsm.configuration.domain.document.FileExtension
+import hs.kr.entrydsm.configuration.domain.document.FileNaming
+import hs.kr.entrydsm.configuration.domain.document.command.IssueDownloadUrlCommand
+import hs.kr.entrydsm.configuration.domain.document.port.`in`.IssueDownloadUrlUseCase
+import hs.kr.entrydsm.configuration.domain.document.port.`in`.UploadFileUseCase
+import org.springframework.web.bind.annotation.GetMapping
+import org.springframework.web.bind.annotation.PostMapping
+import org.springframework.web.bind.annotation.RequestMapping
+import org.springframework.web.bind.annotation.RequestParam
+import org.springframework.web.bind.annotation.RestController
+import org.springframework.web.multipart.MultipartFile
+import java.time.LocalDate
+
+private val CATEGORY = FileCategory.APPLICANT_LIST
+
+@RestController
+@RequestMapping("/api/document/v11/applicant-list")
+class ApplicantListController(
+    private val uploadFileUseCase: UploadFileUseCase,
+    private val issueDownloadUrlUseCase: IssueDownloadUrlUseCase,
+) {
+
+    @PostMapping
+    fun save(
+        @RequestParam("file") file: MultipartFile,
+        @RequestParam("fileName", required = false) fileName: String?,
+    ): ApiResponse<UploadFileResponse> {
+        file.requireExtension(CATEGORY)
+        val targetFileName = fileName?.also(::requireXlsx)
+            ?: FileNaming.applicantListFileName(LocalDate.now())
+        val saved = file.inputStream.use {
+            uploadFileUseCase.upload(file.toUploadCommand(CATEGORY, targetFileName), it)
+        }
+        return ApiResponse.success(UploadFileResponse.from(saved))
+    }
+
+    @GetMapping("/download")
+    fun download(@RequestParam("fileName") fileName: String): ApiResponse<DownloadUrlResponse> =
+        ApiResponse.success(
+            DownloadUrlResponse.from(
+                issueDownloadUrlUseCase.issueByCommand(IssueDownloadUrlCommand(CATEGORY, fileName))
+            )
+        )
+
+    private fun requireXlsx(fileName: String) {
+        if (FileExtension.fromFileName(fileName) != FileExtension.XLSX) {
+            throw IllegalArgumentException("fileName must end with .xlsx: $fileName")
+        }
+    }
+}

--- a/systems/configuration/configuration-adapter-in/src/main/kotlin/hs/kr/entrydsm/configuration/adapterin/document/ApplicationFileController.kt
+++ b/systems/configuration/configuration-adapter-in/src/main/kotlin/hs/kr/entrydsm/configuration/adapterin/document/ApplicationFileController.kt
@@ -1,0 +1,77 @@
+package hs.kr.entrydsm.configuration.adapterin.document
+
+import hs.kr.entrydsm.configuration.adapterin.common.ApiResponse
+import hs.kr.entrydsm.configuration.adapterin.document.dto.DownloadUrlResponse
+import hs.kr.entrydsm.configuration.adapterin.document.dto.FileMetadataResponse
+import hs.kr.entrydsm.configuration.adapterin.document.dto.UploadFileResponse
+import hs.kr.entrydsm.configuration.domain.document.FileCategory
+import hs.kr.entrydsm.configuration.domain.document.FileExtension
+import hs.kr.entrydsm.configuration.domain.document.FileNaming
+import hs.kr.entrydsm.configuration.domain.document.command.IssueDownloadUrlCommand
+import hs.kr.entrydsm.configuration.domain.document.port.`in`.IssueDownloadUrlUseCase
+import hs.kr.entrydsm.configuration.domain.document.port.`in`.ReadFileUseCase
+import hs.kr.entrydsm.configuration.domain.document.port.`in`.UploadFileUseCase
+import org.springframework.web.bind.annotation.GetMapping
+import org.springframework.web.bind.annotation.PostMapping
+import org.springframework.web.bind.annotation.RequestMapping
+import org.springframework.web.bind.annotation.RequestParam
+import org.springframework.web.bind.annotation.RestController
+import org.springframework.web.multipart.MultipartFile
+
+private val CATEGORY = FileCategory.APPLICATION
+
+@RestController
+@RequestMapping("/api/document/v11/application")
+class ApplicationFileController(
+    private val uploadFileUseCase: UploadFileUseCase,
+    private val issueDownloadUrlUseCase: IssueDownloadUrlUseCase,
+    private val readFileUseCase: ReadFileUseCase,
+) {
+
+    @PostMapping
+    fun save(
+        @RequestParam("file") file: MultipartFile,
+        @RequestParam("receiptCode") receiptCode: String,
+    ): ApiResponse<UploadFileResponse> {
+        val fileName = FileNaming.applicationFileName(receiptCode, file.requireExtension(CATEGORY))
+        val saved = file.inputStream.use {
+            uploadFileUseCase.upload(file.toUploadCommand(CATEGORY, fileName), it)
+        }
+        return ApiResponse.success(UploadFileResponse.from(saved))
+    }
+
+    @GetMapping
+    fun find(@RequestParam("receiptCode") receiptCode: String): ApiResponse<FileMetadataResponse> {
+        val stored = FileExtension.DOCUMENT_FORMATS.firstNotNullOfOrNull { extension ->
+            readFileUseCase.findByFileName(CATEGORY, FileNaming.applicationFileName(receiptCode, extension))
+        }
+        if (stored != null) {
+            return ApiResponse.success(
+                FileMetadataResponse(key = stored.objectKey, fileName = stored.fileName, exists = true)
+            )
+        }
+        val defaultFileName = FileNaming.applicationFileName(receiptCode, FileExtension.PDF)
+        return ApiResponse.success(
+            FileMetadataResponse(
+                key = CATEGORY.objectKeyOf(defaultFileName),
+                fileName = defaultFileName,
+                exists = false,
+            )
+        )
+    }
+
+    @GetMapping("/download")
+    fun download(
+        @RequestParam("receiptCode") receiptCode: String,
+        @RequestParam("format", defaultValue = "pdf") format: String,
+    ): ApiResponse<DownloadUrlResponse> {
+        val extension = FileExtension.fromExtension(format)?.takeIf(CATEGORY::supports)
+            ?: throw IllegalArgumentException("Unsupported format: $format")
+        val fileName = FileNaming.applicationFileName(receiptCode, extension)
+        return ApiResponse.success(
+            DownloadUrlResponse.from(
+                issueDownloadUrlUseCase.issueByCommand(IssueDownloadUrlCommand(CATEGORY, fileName))
+            )
+        )
+    }
+}

--- a/systems/configuration/configuration-adapter-in/src/main/kotlin/hs/kr/entrydsm/configuration/adapterin/document/ApplicationFileController.kt
+++ b/systems/configuration/configuration-adapter-in/src/main/kotlin/hs/kr/entrydsm/configuration/adapterin/document/ApplicationFileController.kt
@@ -8,6 +8,7 @@ import hs.kr.entrydsm.configuration.domain.document.FileCategory
 import hs.kr.entrydsm.configuration.domain.document.FileExtension
 import hs.kr.entrydsm.configuration.domain.document.FileNaming
 import hs.kr.entrydsm.configuration.domain.document.command.IssueDownloadUrlCommand
+import hs.kr.entrydsm.configuration.domain.document.exception.InvalidFileFormatException
 import hs.kr.entrydsm.configuration.domain.document.port.`in`.IssueDownloadUrlUseCase
 import hs.kr.entrydsm.configuration.domain.document.port.`in`.ReadFileUseCase
 import hs.kr.entrydsm.configuration.domain.document.port.`in`.UploadFileUseCase
@@ -17,6 +18,7 @@ import org.springframework.web.bind.annotation.RequestMapping
 import org.springframework.web.bind.annotation.RequestParam
 import org.springframework.web.bind.annotation.RestController
 import org.springframework.web.multipart.MultipartFile
+import java.time.Instant
 
 private val CATEGORY = FileCategory.APPLICATION
 
@@ -42,9 +44,11 @@ class ApplicationFileController(
 
     @GetMapping
     fun find(@RequestParam("receiptCode") receiptCode: String): ApiResponse<FileMetadataResponse> {
-        val stored = FileExtension.DOCUMENT_FORMATS.firstNotNullOfOrNull { extension ->
-            readFileUseCase.findByFileName(CATEGORY, FileNaming.applicationFileName(receiptCode, extension))
-        }
+        val stored = FileExtension.documentFormats
+            .mapNotNull { extension ->
+                readFileUseCase.findByFileName(CATEGORY, FileNaming.applicationFileName(receiptCode, extension))
+            }
+            .maxByOrNull { it.createdAt ?: Instant.EPOCH }
         if (stored != null) {
             return ApiResponse.success(
                 FileMetadataResponse(key = stored.objectKey, fileName = stored.fileName, exists = true)
@@ -66,7 +70,7 @@ class ApplicationFileController(
         @RequestParam("format", defaultValue = "pdf") format: String,
     ): ApiResponse<DownloadUrlResponse> {
         val extension = FileExtension.fromExtension(format)?.takeIf(CATEGORY::supports)
-            ?: throw IllegalArgumentException("Unsupported format: $format")
+            ?: throw InvalidFileFormatException(format, CATEGORY)
         val fileName = FileNaming.applicationFileName(receiptCode, extension)
         return ApiResponse.success(
             DownloadUrlResponse.from(

--- a/systems/configuration/configuration-adapter-in/src/main/kotlin/hs/kr/entrydsm/configuration/adapterin/document/AttachmentController.kt
+++ b/systems/configuration/configuration-adapter-in/src/main/kotlin/hs/kr/entrydsm/configuration/adapterin/document/AttachmentController.kt
@@ -1,0 +1,50 @@
+package hs.kr.entrydsm.configuration.adapterin.document
+
+import hs.kr.entrydsm.configuration.adapterin.common.ApiResponse
+import hs.kr.entrydsm.configuration.adapterin.document.dto.DownloadUrlResponse
+import hs.kr.entrydsm.configuration.adapterin.document.dto.UploadAttachmentResponse
+import hs.kr.entrydsm.configuration.domain.document.FileCategory
+import hs.kr.entrydsm.configuration.domain.document.FileNaming
+import hs.kr.entrydsm.configuration.domain.document.port.`in`.IssueDownloadUrlUseCase
+import hs.kr.entrydsm.configuration.domain.document.port.`in`.UploadFileUseCase
+import org.springframework.web.bind.annotation.GetMapping
+import org.springframework.web.bind.annotation.PostMapping
+import org.springframework.web.bind.annotation.RequestMapping
+import org.springframework.web.bind.annotation.RequestParam
+import org.springframework.web.bind.annotation.RestController
+import org.springframework.web.multipart.MultipartFile
+
+private val CATEGORY = FileCategory.ATTACHMENT
+
+@RestController
+@RequestMapping("/api/document/v11/attachment")
+class AttachmentController(
+    private val uploadFileUseCase: UploadFileUseCase,
+    private val issueDownloadUrlUseCase: IssueDownloadUrlUseCase,
+) {
+
+    @PostMapping
+    fun save(@RequestParam("file") file: MultipartFile): ApiResponse<UploadAttachmentResponse> {
+        file.requireExtension(CATEGORY)
+        val fileName = FileNaming.attachmentFileName(file.originalFilename.orEmpty())
+        val saved = file.inputStream.use {
+            uploadFileUseCase.upload(file.toUploadCommand(CATEGORY, fileName), it)
+        }
+        return ApiResponse.success(
+            UploadAttachmentResponse(
+                attachmentId = FileReferenceId.of(CATEGORY, requireNotNull(saved.id)),
+                key = saved.objectKey,
+                fileName = saved.originalName,
+                size = saved.sizeBytes,
+            )
+        )
+    }
+
+    @GetMapping("/download")
+    fun download(@RequestParam("attachmentId") attachmentId: String): ApiResponse<DownloadUrlResponse> =
+        ApiResponse.success(
+            DownloadUrlResponse.from(
+                issueDownloadUrlUseCase.issueById(FileReferenceId.parse(CATEGORY, attachmentId))
+            )
+        )
+}

--- a/systems/configuration/configuration-adapter-in/src/main/kotlin/hs/kr/entrydsm/configuration/adapterin/document/GuidelineController.kt
+++ b/systems/configuration/configuration-adapter-in/src/main/kotlin/hs/kr/entrydsm/configuration/adapterin/document/GuidelineController.kt
@@ -1,0 +1,27 @@
+package hs.kr.entrydsm.configuration.adapterin.document
+
+import hs.kr.entrydsm.configuration.adapterin.common.ApiResponse
+import hs.kr.entrydsm.configuration.adapterin.document.dto.DownloadUrlResponse
+import hs.kr.entrydsm.configuration.domain.document.FileCategory
+import hs.kr.entrydsm.configuration.domain.document.port.`in`.IssueDownloadUrlUseCase
+import org.springframework.web.bind.annotation.GetMapping
+import org.springframework.web.bind.annotation.RequestMapping
+import org.springframework.web.bind.annotation.RequestParam
+import org.springframework.web.bind.annotation.RestController
+
+private val CATEGORY = FileCategory.GUIDELINE
+
+@RestController
+@RequestMapping("/api/document/v11/guideline")
+class GuidelineController(
+    private val issueDownloadUrlUseCase: IssueDownloadUrlUseCase,
+) {
+
+    @GetMapping("/download")
+    fun download(@RequestParam("guidelineId") guidelineId: String): ApiResponse<DownloadUrlResponse> =
+        ApiResponse.success(
+            DownloadUrlResponse.from(
+                issueDownloadUrlUseCase.issueById(FileReferenceId.parse(CATEGORY, guidelineId))
+            )
+        )
+}

--- a/systems/configuration/configuration-adapter-in/src/main/kotlin/hs/kr/entrydsm/configuration/adapterin/document/MultipartFileExtensions.kt
+++ b/systems/configuration/configuration-adapter-in/src/main/kotlin/hs/kr/entrydsm/configuration/adapterin/document/MultipartFileExtensions.kt
@@ -7,7 +7,7 @@ import hs.kr.entrydsm.configuration.domain.document.exception.InvalidFileFormatE
 import org.springframework.web.multipart.MultipartFile
 
 fun MultipartFile.requireExtension(category: FileCategory): FileExtension =
-    FileExtension.fromFileName(originalName())
+    FileExtension.fromFileName(originalName())?.takeIf(category::supports)
         ?: throw InvalidFileFormatException(originalName(), category)
 
 fun MultipartFile.toUploadCommand(category: FileCategory, fileName: String) = UploadFileCommand(

--- a/systems/configuration/configuration-adapter-in/src/main/kotlin/hs/kr/entrydsm/configuration/adapterin/document/PhotoController.kt
+++ b/systems/configuration/configuration-adapter-in/src/main/kotlin/hs/kr/entrydsm/configuration/adapterin/document/PhotoController.kt
@@ -1,0 +1,42 @@
+package hs.kr.entrydsm.configuration.adapterin.document
+
+import hs.kr.entrydsm.configuration.adapterin.common.ApiResponse
+import hs.kr.entrydsm.configuration.adapterin.document.dto.UploadPhotoResponse
+import hs.kr.entrydsm.configuration.domain.document.FileCategory
+import hs.kr.entrydsm.configuration.domain.document.FileNaming
+import hs.kr.entrydsm.configuration.domain.document.command.IssueDownloadUrlCommand
+import hs.kr.entrydsm.configuration.domain.document.port.`in`.IssueDownloadUrlUseCase
+import hs.kr.entrydsm.configuration.domain.document.port.`in`.UploadFileUseCase
+import org.springframework.web.bind.annotation.PostMapping
+import org.springframework.web.bind.annotation.RequestMapping
+import org.springframework.web.bind.annotation.RequestParam
+import org.springframework.web.bind.annotation.RestController
+import org.springframework.web.multipart.MultipartFile
+
+private val CATEGORY = FileCategory.PHOTO
+
+@RestController
+@RequestMapping("/api/document/v11/photo")
+class PhotoController(
+    private val uploadFileUseCase: UploadFileUseCase,
+    private val issueDownloadUrlUseCase: IssueDownloadUrlUseCase,
+) {
+
+    @PostMapping
+    fun save(@RequestParam("file") file: MultipartFile): ApiResponse<UploadPhotoResponse> {
+        val fileName = FileNaming.photoFileName(file.requireExtension(CATEGORY))
+        val saved = file.inputStream.use {
+            uploadFileUseCase.upload(file.toUploadCommand(CATEGORY, fileName), it)
+        }
+        val downloadUrl = issueDownloadUrlUseCase.issueByCommand(
+            IssueDownloadUrlCommand(CATEGORY, saved.fileName)
+        )
+        return ApiResponse.success(
+            UploadPhotoResponse(
+                key = saved.objectKey,
+                fileName = saved.fileName,
+                url = downloadUrl.downloadUrl,
+            )
+        )
+    }
+}

--- a/systems/configuration/configuration-adapter-in/src/test/kotlin/hs/kr/entrydsm/configuration/adapterin/document/DocumentControllerTest.kt
+++ b/systems/configuration/configuration-adapter-in/src/test/kotlin/hs/kr/entrydsm/configuration/adapterin/document/DocumentControllerTest.kt
@@ -1,0 +1,283 @@
+package hs.kr.entrydsm.configuration.adapterin.document
+
+import hs.kr.entrydsm.configuration.adapterin.common.DocumentExceptionHandler
+import hs.kr.entrydsm.configuration.domain.document.DownloadUrl
+import hs.kr.entrydsm.configuration.domain.document.FileCategory
+import hs.kr.entrydsm.configuration.domain.document.FileDocument
+import hs.kr.entrydsm.configuration.domain.document.command.IssueDownloadUrlCommand
+import hs.kr.entrydsm.configuration.domain.document.command.UploadFileCommand
+import hs.kr.entrydsm.configuration.domain.document.exception.FileDocumentNotFoundException
+import hs.kr.entrydsm.configuration.domain.document.port.`in`.IssueDownloadUrlUseCase
+import hs.kr.entrydsm.configuration.domain.document.port.`in`.ReadFileUseCase
+import hs.kr.entrydsm.configuration.domain.document.port.`in`.UploadFileUseCase
+import org.junit.Assert.assertEquals
+import org.junit.Test
+import org.springframework.mock.web.MockMultipartFile
+import org.springframework.test.web.servlet.MockMvc
+import org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get
+import org.springframework.test.web.servlet.request.MockMvcRequestBuilders.multipart
+import org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath
+import org.springframework.test.web.servlet.result.MockMvcResultMatchers.status
+import org.springframework.test.web.servlet.setup.MockMvcBuilders
+import java.io.InputStream
+import java.time.Instant
+import java.time.LocalDate
+import java.time.format.DateTimeFormatter
+
+class DocumentControllerTest {
+
+    private val upload = RecordingUploadFileUseCase()
+    private val issue = StubIssueDownloadUrlUseCase()
+    private val read = StubReadFileUseCase()
+
+    private fun mockMvc(controller: Any): MockMvc =
+        MockMvcBuilders.standaloneSetup(controller)
+            .setControllerAdvice(DocumentExceptionHandler())
+            .build()
+
+    private fun pdf(name: String = "지원서.pdf") =
+        MockMultipartFile("file", name, null, "content".toByteArray())
+
+    @Test
+    fun `지원서 업로드는 수험번호 기반 파일명으로 저장한다`() {
+        mockMvc(applicationController())
+            .perform(multipart("/api/document/v11/application").file(pdf()).param("receiptCode", "1001"))
+            .andExpect(status().isOk)
+            .andExpect(jsonPath("$.success").value(true))
+            .andExpect(jsonPath("$.data.fileName").value("application_1001.pdf"))
+            .andExpect(jsonPath("$.data.key").value("application/application_1001.pdf"))
+
+        assertEquals(FileCategory.APPLICATION, upload.lastCommand?.category)
+        assertEquals("application_1001.pdf", upload.lastCommand?.fileName)
+        assertEquals("지원서.pdf", upload.lastCommand?.originalName)
+    }
+
+    @Test
+    fun `지원서 업로드는 허용하지 않는 형식을 400으로 거부한다`() {
+        mockMvc(applicationController())
+            .perform(
+                multipart("/api/document/v11/application")
+                    .file(MockMultipartFile("file", "지원서.jpg", null, ByteArray(1)))
+                    .param("receiptCode", "1001"),
+            )
+            .andExpect(status().isBadRequest)
+            .andExpect(jsonPath("$.error.code").value("INVALID_FILE_FORMAT"))
+    }
+
+    @Test
+    fun `지원서 조회는 같은 수험번호의 여러 형식 중 최근 업로드본을 돌려준다`() {
+        read.put(stored("application/application_1001.pdf", Instant.parse("2026-01-01T00:00:00Z")))
+        read.put(stored("application/application_1001.hwp", Instant.parse("2026-02-01T00:00:00Z")))
+
+        mockMvc(applicationController())
+            .perform(get("/api/document/v11/application").param("receiptCode", "1001"))
+            .andExpect(status().isOk)
+            .andExpect(jsonPath("$.data.exists").value(true))
+            .andExpect(jsonPath("$.data.fileName").value("application_1001.hwp"))
+    }
+
+    @Test
+    fun `지원서가 없으면 pdf 기본 파일명과 미존재 표시를 돌려준다`() {
+        mockMvc(applicationController())
+            .perform(get("/api/document/v11/application").param("receiptCode", "1001"))
+            .andExpect(status().isOk)
+            .andExpect(jsonPath("$.data.exists").value(false))
+            .andExpect(jsonPath("$.data.fileName").value("application_1001.pdf"))
+            .andExpect(jsonPath("$.data.key").value("application/application_1001.pdf"))
+    }
+
+    @Test
+    fun `지원서 다운로드는 요청한 형식의 파일로 URL을 발급한다`() {
+        mockMvc(applicationController())
+            .perform(
+                get("/api/document/v11/application/download")
+                    .param("receiptCode", "1001")
+                    .param("format", "hwp"),
+            )
+            .andExpect(status().isOk)
+            .andExpect(jsonPath("$.data.fileName").value("application_1001.hwp"))
+            .andExpect(jsonPath("$.data.expiresIn").value(300))
+
+        assertEquals("application_1001.hwp", issue.lastCommand?.fileName)
+    }
+
+    @Test
+    fun `지원하지 않는 다운로드 형식은 400으로 거부한다`() {
+        mockMvc(applicationController())
+            .perform(
+                get("/api/document/v11/application/download")
+                    .param("receiptCode", "1001")
+                    .param("format", "jpg"),
+            )
+            .andExpect(status().isBadRequest)
+            .andExpect(jsonPath("$.error.code").value("INVALID_FILE_FORMAT"))
+    }
+
+    @Test
+    fun `수험표 다운로드는 수험번호 기반 파일명을 사용한다`() {
+        mockMvc(AdmissionTicketController(upload, issue))
+            .perform(get("/api/document/v11/admission-ticket/download").param("receiptCode", "1001"))
+            .andExpect(status().isOk)
+            .andExpect(jsonPath("$.data.fileName").value("admission_ticket_1001.pdf"))
+
+        assertEquals(FileCategory.ADMISSION_TICKET, issue.lastCommand?.category)
+    }
+
+    @Test
+    fun `수험번호에 경로 문자가 들어오면 400으로 거부한다`() {
+        mockMvc(AdmissionTicketController(upload, issue))
+            .perform(get("/api/document/v11/admission-ticket/download").param("receiptCode", "../1001"))
+            .andExpect(status().isBadRequest)
+            .andExpect(jsonPath("$.error.code").value("INVALID_REQUEST_PARAM"))
+    }
+
+    @Test
+    fun `지원자 명단은 파일명을 주지 않으면 오늘 날짜로 저장한다`() {
+        val expected = "applicants_${DateTimeFormatter.ofPattern("yyyyMMdd").format(LocalDate.now())}.xlsx"
+
+        mockMvc(ApplicantListController(upload, issue))
+            .perform(multipart("/api/document/v11/applicant-list").file(xlsx()))
+            .andExpect(status().isOk)
+            .andExpect(jsonPath("$.data.fileName").value(expected))
+    }
+
+    @Test
+    fun `지원자 명단은 지정한 xlsx 파일명을 그대로 쓴다`() {
+        mockMvc(ApplicantListController(upload, issue))
+            .perform(
+                multipart("/api/document/v11/applicant-list")
+                    .file(xlsx())
+                    .param("fileName", "applicants_20260726.xlsx"),
+            )
+            .andExpect(status().isOk)
+            .andExpect(jsonPath("$.data.fileName").value("applicants_20260726.xlsx"))
+    }
+
+    @Test
+    fun `지원자 명단은 xlsx가 아닌 파일명을 400으로 거부한다`() {
+        mockMvc(ApplicantListController(upload, issue))
+            .perform(
+                multipart("/api/document/v11/applicant-list")
+                    .file(xlsx())
+                    .param("fileName", "applicants.csv"),
+            )
+            .andExpect(status().isBadRequest)
+            .andExpect(jsonPath("$.error.code").value("INVALID_FILE_FORMAT"))
+    }
+
+    @Test
+    fun `첨부파일 업로드는 카테고리 접두사가 붙은 ID를 돌려준다`() {
+        mockMvc(AttachmentController(upload, issue))
+            .perform(multipart("/api/document/v11/attachment").file(pdf("첨부.pdf")))
+            .andExpect(status().isOk)
+            .andExpect(jsonPath("$.data.attachmentId").value("attachment_7"))
+            .andExpect(jsonPath("$.data.fileName").value("첨부.pdf"))
+            .andExpect(jsonPath("$.data.size").value(7))
+    }
+
+    @Test
+    fun `첨부파일 다운로드는 접두사가 붙은 ID만 받는다`() {
+        val mvc = mockMvc(AttachmentController(upload, issue))
+
+        mvc.perform(get("/api/document/v11/attachment/download").param("attachmentId", "attachment_7"))
+            .andExpect(status().isOk)
+            .andExpect(jsonPath("$.data.downloadUrl").value("https://s3/id/7"))
+
+        mvc.perform(get("/api/document/v11/attachment/download").param("attachmentId", "7"))
+            .andExpect(status().isBadRequest)
+            .andExpect(jsonPath("$.error.code").value("INVALID_REQUEST_PARAM"))
+    }
+
+    @Test
+    fun `입학요강 다운로드는 guideline 접두사 ID를 파싱한다`() {
+        mockMvc(GuidelineController(issue))
+            .perform(get("/api/document/v11/guideline/download").param("guidelineId", "guideline_3"))
+            .andExpect(status().isOk)
+            .andExpect(jsonPath("$.data.downloadUrl").value("https://s3/id/3"))
+    }
+
+    @Test
+    fun `증명사진 업로드는 저장 직후 다운로드 URL을 함께 돌려준다`() {
+        mockMvc(PhotoController(upload, issue))
+            .perform(multipart("/api/document/v11/photo").file(MockMultipartFile("file", "사진.png", null, ByteArray(2))))
+            .andExpect(status().isOk)
+            .andExpect(jsonPath("$.data.url").value("https://s3/photo"))
+
+        assertEquals(FileCategory.PHOTO, upload.lastCommand?.category)
+        assert(upload.lastCommand!!.fileName.matches(Regex("photo_[0-9a-f]{32}\\.png")))
+    }
+
+    @Test
+    fun `없는 파일을 조회하면 404를 돌려준다`() {
+        issue.notFound = true
+
+        mockMvc(GuidelineController(issue))
+            .perform(get("/api/document/v11/guideline/download").param("guidelineId", "guideline_3"))
+            .andExpect(status().isNotFound)
+            .andExpect(jsonPath("$.error.code").value("FILE_NOT_FOUND"))
+    }
+
+    private fun applicationController() = ApplicationFileController(upload, issue, read)
+
+    private fun xlsx() = MockMultipartFile("file", "명단.xlsx", null, ByteArray(1))
+
+    private fun stored(objectKey: String, createdAt: Instant) = FileDocument(
+        id = 7,
+        originalName = "지원서",
+        objectKey = objectKey,
+        bucket = "entrydsm",
+        contentType = "application/pdf",
+        sizeBytes = 7,
+        checksum = "abc",
+        createdAt = createdAt,
+    )
+
+    private class RecordingUploadFileUseCase : UploadFileUseCase {
+        var lastCommand: UploadFileCommand? = null
+
+        override fun upload(command: UploadFileCommand, content: InputStream): FileDocument {
+            lastCommand = command
+            return FileDocument(
+                id = 7,
+                originalName = command.originalName,
+                objectKey = command.category.objectKeyOf(command.fileName),
+                bucket = "entrydsm",
+                contentType = "application/octet-stream",
+                sizeBytes = command.sizeBytes,
+                checksum = "abc",
+                createdAt = Instant.parse("2026-01-01T00:00:00Z"),
+            )
+        }
+    }
+
+    private class StubIssueDownloadUrlUseCase : IssueDownloadUrlUseCase {
+        var lastCommand: IssueDownloadUrlCommand? = null
+        var notFound = false
+
+        override fun issueByCommand(command: IssueDownloadUrlCommand): DownloadUrl {
+            lastCommand = command
+            if (notFound) throw FileDocumentNotFoundException(command.fileName)
+            return DownloadUrl(command.fileName, "https://s3/photo", 300)
+        }
+
+        override fun issueById(id: Long): DownloadUrl {
+            if (notFound) throw FileDocumentNotFoundException("id=$id")
+            return DownloadUrl("file_$id.pdf", "https://s3/id/$id", 300)
+        }
+    }
+
+    private class StubReadFileUseCase : ReadFileUseCase {
+        private val byObjectKey = mutableMapOf<String, FileDocument>()
+
+        fun put(fileDocument: FileDocument) {
+            byObjectKey[fileDocument.objectKey] = fileDocument
+        }
+
+        override fun findById(id: Long): FileDocument = throw FileDocumentNotFoundException("id=$id")
+
+        override fun findByFileName(category: FileCategory, fileName: String): FileDocument? =
+            byObjectKey[category.objectKeyOf(fileName)]
+
+        override fun existsById(id: Long): Boolean = false
+    }
+}

--- a/systems/configuration/configuration-bootstrap/ddl/files.sql
+++ b/systems/configuration/configuration-bootstrap/ddl/files.sql
@@ -1,0 +1,18 @@
+-- configuration_db
+-- ddl-auto: validate 이므로 애플리케이션 기동 전에 적용되어 있어야 한다.
+-- 마이그레이션 도구(Flyway 등) 도입 전까지 수기로 적용한다.
+
+CREATE TABLE IF NOT EXISTS files
+(
+    id            BIGINT       NOT NULL AUTO_INCREMENT,
+    original_name VARCHAR(255) NOT NULL,
+    object_key    VARCHAR(255) NOT NULL,
+    bucket        VARCHAR(100) NOT NULL,
+    content_type  VARCHAR(100) NOT NULL,
+    size_bytes    BIGINT       NOT NULL,
+    checksum      VARCHAR(64)  NOT NULL,
+    created_at    TIMESTAMP(6) NOT NULL,
+    PRIMARY KEY (id),
+    UNIQUE KEY uk_files_object_key (object_key)
+) ENGINE = InnoDB
+  DEFAULT CHARSET = utf8mb4;

--- a/systems/configuration/configuration-bootstrap/src/main/resources/application.yaml
+++ b/systems/configuration/configuration-bootstrap/src/main/resources/application.yaml
@@ -17,12 +17,22 @@ spring:
     properties:
       hibernate:
         dialect: org.hibernate.dialect.MySQLDialect
+  servlet:
+    multipart:
+      max-file-size: 21MB
+      max-request-size: 21MB
 
 server:
   shutdown: graceful
 
 grpc:
   port: ${GRPC_PORT:9090}
+
+aws:
+  s3:
+    bucket: ${S3_BUCKET:entrydsm-document-local}
+    region: ${AWS_REGION:ap-northeast-2}
+    presign-expiry-seconds: ${S3_PRESIGN_EXPIRY_SECONDS:600}
 
 management:
   endpoints:


### PR DESCRIPTION
> 스택 PR 4/4 (마지막) — base: `feat(document)-파일-응답-규약-#26`
> **PR 1~3이 먼저 머지되어야 합니다.**

## Summary
- 명세의 파일관리(document) API **11개 전부**를 `/api/document/v11/**` 경로로 구현합니다.
- 멀티파트 업로드 한도와 S3 접속 설정, `files` 테이블 DDL을 추가합니다.

## Related Issue
- Closes #26

## Scope
- In scope: `configuration-adapter-in`의 `document` 패키지, `configuration-bootstrap` 설정
- Out of scope: 인증·인가, gRPC 노출, OpenAPI 어노테이션, 컨트롤러 테스트 (전부 후속 이슈)

## Implementation
컨트롤러 6개로 11개 엔드포인트를 구현합니다.

| 컨트롤러 | 명세 |
| --- | --- |
| `ApplicationFileController` | #1 원서 저장 / #2 조회 / #3 다운 |
| `AdmissionTicketController` | #4 수험표 저장 / #5 다운 |
| `ApplicantListController` | #6 엑셀 저장 / #7 다운 |
| `PhotoController` | #8 증명사진 첨부 |
| `AttachmentController` | #9 게시글 첨부 저장 / #10 다운 |
| `GuidelineController` | #11 전형요강 다운 |

**경로 prefix** — 명세의 document 경로(`/application`, `/photo` 등)에는 `/api/{service}/v11/` 이 없어 규약 §2 위반이고 Gateway 라우팅도 불가능합니다. prefix를 붙이되 도메인명(`document`)을 유지했습니다.

**부트스트랩** — 멀티파트 한도를 21MB로 두어 카테고리별 도메인 규칙(최대 20MB)이 먼저 판정하고, 서블릿 컨테이너 한도는 백스톱으로 남깁니다.

## Testing
- [ ] Unit tests — 컨트롤러 테스트는 후속 이슈
- [ ] Integration tests
- [ ] Manual verification — **실제 S3 / DB에 대해 실행해 보지 않았습니다**

```
bazel test //systems/configuration/...
```

빌드와 도메인 테스트 12개 통과만 확인했습니다.

## Deployment Notes
- Feature flag: 없음
- Migration required: **예** — `configuration-bootstrap/ddl/files.sql`을 **수기로 적용**해야 합니다. `ddl-auto: validate`라 테이블이 없으면 기동에 실패합니다. 마이그레이션 도구 도입은 후속 이슈
- Rollout considerations: `S3_BUCKET`, `AWS_REGION` 환경변수 주입 필요. 버킷과 IAM 권한(`s3:PutObject`, `GetObject`, `HeadObject`, `DeleteObject`)이 선행되어야 합니다

## Checklist
- [x] Matches product/tech requirements
- [x] Backward compatibility considered
- [ ] Docs updated if applicable

## 명세와 의도적으로 다르게 구현한 3곳 — 리뷰 필요

1. **증명사진 `url` (#8)** — 평문 S3 URL 대신 **presigned URL**로 발급합니다. 증명사진은 개인정보인데 공개 버킷이면 키를 아는 누구나 열람할 수 있고, 비공개 버킷이면 명세대로는 아예 동작하지 않습니다. 응답 스키마(`url` 필드)는 그대로 유지했습니다.
2. **원서 조회 (#2)** — 파일 부재 시 404가 아니라 **`200 + exists:false`** 를 반환합니다. "다운로드가 아닌 조회 목적"이라는 명세 설명상 부재는 예외가 아니라 정상 결과입니다. 명세의 `FILE_NOT_FOUND` 행은 삭제가 필요합니다.
3. **`attachmentId` (#9)** — `object_key`에는 랜덤 토큰을 쓰고 ID는 `files` PK로 발급합니다. 명세 예시(`attachment/attachment_1_guide.pdf`)와 달리 **키가 추측 불가능**하고, 업로드 전에 ID를 알아야 하는 순서 문제도 없습니다.

## 알려진 공백

- **전형요강 업로드 API가 명세에 없습니다.** `guidelineId`가 어떻게 생기는지 미정이라 다운로드만 구현했습니다. ID 기반 조회라 어느 prefix로 저장되든 동작합니다.
- **인증이 전혀 없습니다.** 명세의 `인증` 컬럼이 11개 전부 공란이고 소비자가 모두 내부 서비스라 "내부 전용"으로 설계했습니다. 다만 이 전제가 코드로도 인프라로도 강제되어 있지 않고, `systems/gateway`도 아직 스캐폴딩입니다. **현재는 포트가 닿으면 누구나 파일을 올리고 presigned URL을 받을 수 있습니다.** 네트워크 차단 + 서비스 간 공유 시크릿을 별도 이슈로 처리해야 합니다.
- **Admin이 쓸 gRPC 어댑터가 없습니다.** `contracts/proto/configuration.proto`에 파일 RPC 추가가 선행되어야 하며, Admin의 파일 연동 전체가 여기에 막혀 있습니다.
