### PR TITLE
feat(application): Application 공통 기반 구성 #24

### DIFF
--- a/systems/application/application-application/deps.bzl
+++ b/systems/application/application-application/deps.bzl
@@ -1,5 +1,4 @@
 KOTLIN_DEPS = [
-    "@maven//:org_springframework_boot_spring_boot_starter",
     "//systems/application/application-domain:main",
 ]
 

--- a/systems/application/application-application/deps.bzl
+++ b/systems/application/application-application/deps.bzl
@@ -1,4 +1,7 @@
-KOTLIN_DEPS = []
+KOTLIN_DEPS = [
+    "@maven//:org_springframework_boot_spring_boot_starter",
+    "//systems/application/application-domain:main",
+]
 
 TEST_DEPS = [
     "@maven//:junit_junit",

--- a/systems/application/application-application/src/main/kotlin/hs/kr/entrydsm/application/application/exception/ApplicantAccessDeniedException.kt
+++ b/systems/application/application-application/src/main/kotlin/hs/kr/entrydsm/application/application/exception/ApplicantAccessDeniedException.kt
@@ -1,0 +1,5 @@
+package hs.kr.entrydsm.application.application.exception
+
+class ApplicantAccessDeniedException(
+    applicantId: Long,
+) : RuntimeException("Applicant access denied: $applicantId")

--- a/systems/application/application-application/src/main/kotlin/hs/kr/entrydsm/application/application/exception/ApplicantNotFoundException.kt
+++ b/systems/application/application-application/src/main/kotlin/hs/kr/entrydsm/application/application/exception/ApplicantNotFoundException.kt
@@ -1,0 +1,5 @@
+package hs.kr.entrydsm.application.application.exception
+
+class ApplicantNotFoundException(
+    applicantId: Long,
+) : RuntimeException("Applicant not found: $applicantId")

--- a/systems/application/application-application/src/main/kotlin/hs/kr/entrydsm/application/application/exception/AuthenticationRequiredException.kt
+++ b/systems/application/application-application/src/main/kotlin/hs/kr/entrydsm/application/application/exception/AuthenticationRequiredException.kt
@@ -1,0 +1,3 @@
+package hs.kr.entrydsm.application.application.exception
+
+class AuthenticationRequiredException : RuntimeException("authentication is required")

--- a/systems/application/application-application/src/main/kotlin/hs/kr/entrydsm/application/application/port/in/ApplicationPort.kt
+++ b/systems/application/application-application/src/main/kotlin/hs/kr/entrydsm/application/application/port/in/ApplicationPort.kt
@@ -1,0 +1,25 @@
+package hs.kr.entrydsm.application.application.port.`in`
+
+import hs.kr.entrydsm.application.application.port.`in`.command.CreateApplicantCommand
+import hs.kr.entrydsm.application.application.port.`in`.command.SubmitApplicationCommand
+import hs.kr.entrydsm.application.application.port.`in`.command.UpdateFamilyCommand
+import hs.kr.entrydsm.application.application.port.`in`.command.UpdateIntroductionCommand
+import hs.kr.entrydsm.application.application.port.`in`.command.UpdateMiddleSchoolCommand
+import hs.kr.entrydsm.application.application.port.`in`.command.UpdatePersonalCommand
+import hs.kr.entrydsm.application.application.port.`in`.command.UpdateStudyPlanCommand
+import hs.kr.entrydsm.application.application.port.`in`.command.UpdateTypeCommand
+import hs.kr.entrydsm.application.application.port.`in`.result.CreateApplicantResult
+import hs.kr.entrydsm.application.application.port.`in`.result.LandingResult
+
+interface ApplicationPort {
+    fun createApplicant(command: CreateApplicantCommand): CreateApplicantResult
+    fun updateType(command: UpdateTypeCommand)
+    fun updatePersonal(command: UpdatePersonalCommand)
+    fun updateFamily(command: UpdateFamilyCommand)
+    fun updateMiddleSchool(command: UpdateMiddleSchoolCommand)
+    fun updateIntroduction(command: UpdateIntroductionCommand)
+    fun updateStudyPlan(command: UpdateStudyPlanCommand)
+    fun submit(command: SubmitApplicationCommand)
+    fun getLanding(): LandingResult
+}
+

--- a/systems/application/application-application/src/main/kotlin/hs/kr/entrydsm/application/application/port/in/ApplicationPort.kt
+++ b/systems/application/application-application/src/main/kotlin/hs/kr/entrydsm/application/application/port/in/ApplicationPort.kt
@@ -20,6 +20,6 @@ interface ApplicationPort {
     fun updateIntroduction(command: UpdateIntroductionCommand)
     fun updateStudyPlan(command: UpdateStudyPlanCommand)
     fun submit(command: SubmitApplicationCommand)
-    fun getLanding(): LandingResult
+    fun getLanding(accountId: Long?): LandingResult
 }
 

--- a/systems/application/application-application/src/main/kotlin/hs/kr/entrydsm/application/application/port/in/EvaluationPort.kt
+++ b/systems/application/application-application/src/main/kotlin/hs/kr/entrydsm/application/application/port/in/EvaluationPort.kt
@@ -1,0 +1,18 @@
+package hs.kr.entrydsm.application.application.port.`in`
+
+import hs.kr.entrydsm.application.application.port.`in`.command.CalculateEvaluationCommand
+import hs.kr.entrydsm.application.application.port.`in`.command.SaveAcademicRecordCommand
+import hs.kr.entrydsm.application.application.port.`in`.command.SaveCertificatesCommand
+import hs.kr.entrydsm.application.application.port.`in`.command.SaveGedScoresCommand
+import hs.kr.entrydsm.application.application.port.`in`.command.SaveSubjectGradesCommand
+import hs.kr.entrydsm.application.application.port.`in`.result.AcademicRecordResult
+import hs.kr.entrydsm.application.application.port.`in`.result.EvaluationResult
+
+interface EvaluationPort {
+    fun saveSubjectGrades(command: SaveSubjectGradesCommand)
+    fun saveGedScores(command: SaveGedScoresCommand)
+    fun saveAcademicRecord(command: SaveAcademicRecordCommand): AcademicRecordResult
+    fun saveCertificates(command: SaveCertificatesCommand)
+    fun calculateResult(command: CalculateEvaluationCommand): EvaluationResult
+}
+

--- a/systems/application/application-application/src/main/kotlin/hs/kr/entrydsm/application/application/port/in/EvaluationPort.kt
+++ b/systems/application/application-application/src/main/kotlin/hs/kr/entrydsm/application/application/port/in/EvaluationPort.kt
@@ -6,13 +6,12 @@ import hs.kr.entrydsm.application.application.port.`in`.command.SaveCertificates
 import hs.kr.entrydsm.application.application.port.`in`.command.SaveGedScoresCommand
 import hs.kr.entrydsm.application.application.port.`in`.command.SaveSubjectGradesCommand
 import hs.kr.entrydsm.application.application.port.`in`.result.AcademicRecordResult
-import hs.kr.entrydsm.application.application.port.`in`.result.EvaluationResult
 
 interface EvaluationPort {
     fun saveSubjectGrades(command: SaveSubjectGradesCommand)
     fun saveGedScores(command: SaveGedScoresCommand)
     fun saveAcademicRecord(command: SaveAcademicRecordCommand): AcademicRecordResult
     fun saveCertificates(command: SaveCertificatesCommand)
-    fun calculateResult(command: CalculateEvaluationCommand): EvaluationResult
+    fun calculateResult(command: CalculateEvaluationCommand)
 }
 

--- a/systems/application/application-application/src/main/kotlin/hs/kr/entrydsm/application/application/port/in/command/CalculateEvaluationCommand.kt
+++ b/systems/application/application-application/src/main/kotlin/hs/kr/entrydsm/application/application/port/in/command/CalculateEvaluationCommand.kt
@@ -2,4 +2,6 @@ package hs.kr.entrydsm.application.application.port.`in`.command
 
 data class CalculateEvaluationCommand(
     val applicantId: Long,
+    val authorization: String? = null,
+    val userId: Long? = null,
 )

--- a/systems/application/application-application/src/main/kotlin/hs/kr/entrydsm/application/application/port/in/command/CalculateEvaluationCommand.kt
+++ b/systems/application/application-application/src/main/kotlin/hs/kr/entrydsm/application/application/port/in/command/CalculateEvaluationCommand.kt
@@ -1,7 +1,6 @@
 package hs.kr.entrydsm.application.application.port.`in`.command
 
 data class CalculateEvaluationCommand(
-    val applicantId: Long,
     val authorization: String? = null,
     val userId: Long? = null,
 )

--- a/systems/application/application-application/src/main/kotlin/hs/kr/entrydsm/application/application/port/in/command/CalculateEvaluationCommand.kt
+++ b/systems/application/application-application/src/main/kotlin/hs/kr/entrydsm/application/application/port/in/command/CalculateEvaluationCommand.kt
@@ -1,6 +1,5 @@
 package hs.kr.entrydsm.application.application.port.`in`.command
 
 data class CalculateEvaluationCommand(
-    val authorization: String? = null,
     val userId: Long? = null,
 )

--- a/systems/application/application-application/src/main/kotlin/hs/kr/entrydsm/application/application/port/in/command/CalculateEvaluationCommand.kt
+++ b/systems/application/application-application/src/main/kotlin/hs/kr/entrydsm/application/application/port/in/command/CalculateEvaluationCommand.kt
@@ -1,0 +1,5 @@
+package hs.kr.entrydsm.application.application.port.`in`.command
+
+data class CalculateEvaluationCommand(
+    val applicantId: Long,
+)

--- a/systems/application/application-application/src/main/kotlin/hs/kr/entrydsm/application/application/port/in/command/CreateApplicantCommand.kt
+++ b/systems/application/application-application/src/main/kotlin/hs/kr/entrydsm/application/application/port/in/command/CreateApplicantCommand.kt
@@ -1,6 +1,5 @@
 package hs.kr.entrydsm.application.application.port.`in`.command
 
 data class CreateApplicantCommand(
-    val authorization: String? = null,
     val userId: Long? = null,
 )

--- a/systems/application/application-application/src/main/kotlin/hs/kr/entrydsm/application/application/port/in/command/CreateApplicantCommand.kt
+++ b/systems/application/application-application/src/main/kotlin/hs/kr/entrydsm/application/application/port/in/command/CreateApplicantCommand.kt
@@ -1,0 +1,5 @@
+package hs.kr.entrydsm.application.application.port.`in`.command
+
+data class CreateApplicantCommand(
+    val accountId: Long,
+)

--- a/systems/application/application-application/src/main/kotlin/hs/kr/entrydsm/application/application/port/in/command/CreateApplicantCommand.kt
+++ b/systems/application/application-application/src/main/kotlin/hs/kr/entrydsm/application/application/port/in/command/CreateApplicantCommand.kt
@@ -1,7 +1,6 @@
 package hs.kr.entrydsm.application.application.port.`in`.command
 
 data class CreateApplicantCommand(
-    val accountId: Long,
     val authorization: String? = null,
     val userId: Long? = null,
 )

--- a/systems/application/application-application/src/main/kotlin/hs/kr/entrydsm/application/application/port/in/command/CreateApplicantCommand.kt
+++ b/systems/application/application-application/src/main/kotlin/hs/kr/entrydsm/application/application/port/in/command/CreateApplicantCommand.kt
@@ -2,4 +2,6 @@ package hs.kr.entrydsm.application.application.port.`in`.command
 
 data class CreateApplicantCommand(
     val accountId: Long,
+    val authorization: String? = null,
+    val userId: Long? = null,
 )

--- a/systems/application/application-application/src/main/kotlin/hs/kr/entrydsm/application/application/port/in/command/SaveAcademicRecordCommand.kt
+++ b/systems/application/application-application/src/main/kotlin/hs/kr/entrydsm/application/application/port/in/command/SaveAcademicRecordCommand.kt
@@ -1,7 +1,6 @@
 package hs.kr.entrydsm.application.application.port.`in`.command
 
 data class SaveAcademicRecordCommand(
-    val applicantId: Long,
     val authorization: String? = null,
     val userId: Long? = null,
     val absentCount: Int,

--- a/systems/application/application-application/src/main/kotlin/hs/kr/entrydsm/application/application/port/in/command/SaveAcademicRecordCommand.kt
+++ b/systems/application/application-application/src/main/kotlin/hs/kr/entrydsm/application/application/port/in/command/SaveAcademicRecordCommand.kt
@@ -1,0 +1,10 @@
+package hs.kr.entrydsm.application.application.port.`in`.command
+
+data class SaveAcademicRecordCommand(
+    val applicantId: Long,
+    val absentCount: Int,
+    val earlyLeaveCount: Int,
+    val lateCount: Int,
+    val classAbsenceCount: Int,
+    val volunteerTime: Int,
+)

--- a/systems/application/application-application/src/main/kotlin/hs/kr/entrydsm/application/application/port/in/command/SaveAcademicRecordCommand.kt
+++ b/systems/application/application-application/src/main/kotlin/hs/kr/entrydsm/application/application/port/in/command/SaveAcademicRecordCommand.kt
@@ -2,6 +2,8 @@ package hs.kr.entrydsm.application.application.port.`in`.command
 
 data class SaveAcademicRecordCommand(
     val applicantId: Long,
+    val authorization: String? = null,
+    val userId: Long? = null,
     val absentCount: Int,
     val earlyLeaveCount: Int,
     val lateCount: Int,

--- a/systems/application/application-application/src/main/kotlin/hs/kr/entrydsm/application/application/port/in/command/SaveAcademicRecordCommand.kt
+++ b/systems/application/application-application/src/main/kotlin/hs/kr/entrydsm/application/application/port/in/command/SaveAcademicRecordCommand.kt
@@ -1,7 +1,6 @@
 package hs.kr.entrydsm.application.application.port.`in`.command
 
 data class SaveAcademicRecordCommand(
-    val authorization: String? = null,
     val userId: Long? = null,
     val absentCount: Int,
     val earlyLeaveCount: Int,

--- a/systems/application/application-application/src/main/kotlin/hs/kr/entrydsm/application/application/port/in/command/SaveCertificatesCommand.kt
+++ b/systems/application/application-application/src/main/kotlin/hs/kr/entrydsm/application/application/port/in/command/SaveCertificatesCommand.kt
@@ -2,6 +2,8 @@ package hs.kr.entrydsm.application.application.port.`in`.command
 
 data class SaveCertificatesCommand(
     val applicantId: Long,
+    val authorization: String? = null,
+    val userId: Long? = null,
     val isDsmAlgorithmAwarded: Boolean,
     val isProgrammingCertified: Boolean,
 )

--- a/systems/application/application-application/src/main/kotlin/hs/kr/entrydsm/application/application/port/in/command/SaveCertificatesCommand.kt
+++ b/systems/application/application-application/src/main/kotlin/hs/kr/entrydsm/application/application/port/in/command/SaveCertificatesCommand.kt
@@ -1,7 +1,6 @@
 package hs.kr.entrydsm.application.application.port.`in`.command
 
 data class SaveCertificatesCommand(
-    val applicantId: Long,
     val authorization: String? = null,
     val userId: Long? = null,
     val isDsmAlgorithmAwarded: Boolean,

--- a/systems/application/application-application/src/main/kotlin/hs/kr/entrydsm/application/application/port/in/command/SaveCertificatesCommand.kt
+++ b/systems/application/application-application/src/main/kotlin/hs/kr/entrydsm/application/application/port/in/command/SaveCertificatesCommand.kt
@@ -1,0 +1,7 @@
+package hs.kr.entrydsm.application.application.port.`in`.command
+
+data class SaveCertificatesCommand(
+    val applicantId: Long,
+    val isDsmAlgorithmAwarded: Boolean,
+    val isProgrammingCertified: Boolean,
+)

--- a/systems/application/application-application/src/main/kotlin/hs/kr/entrydsm/application/application/port/in/command/SaveCertificatesCommand.kt
+++ b/systems/application/application-application/src/main/kotlin/hs/kr/entrydsm/application/application/port/in/command/SaveCertificatesCommand.kt
@@ -1,7 +1,6 @@
 package hs.kr.entrydsm.application.application.port.`in`.command
 
 data class SaveCertificatesCommand(
-    val authorization: String? = null,
     val userId: Long? = null,
     val isDsmAlgorithmAwarded: Boolean,
     val isProgrammingCertified: Boolean,

--- a/systems/application/application-application/src/main/kotlin/hs/kr/entrydsm/application/application/port/in/command/SaveGedScoresCommand.kt
+++ b/systems/application/application-application/src/main/kotlin/hs/kr/entrydsm/application/application/port/in/command/SaveGedScoresCommand.kt
@@ -4,5 +4,7 @@ import hs.kr.entrydsm.application.domain.model.GedScores
 
 data class SaveGedScoresCommand(
     val applicantId: Long,
+    val authorization: String? = null,
+    val userId: Long? = null,
     val gedScores: GedScores,
 )

--- a/systems/application/application-application/src/main/kotlin/hs/kr/entrydsm/application/application/port/in/command/SaveGedScoresCommand.kt
+++ b/systems/application/application-application/src/main/kotlin/hs/kr/entrydsm/application/application/port/in/command/SaveGedScoresCommand.kt
@@ -3,7 +3,6 @@ package hs.kr.entrydsm.application.application.port.`in`.command
 import hs.kr.entrydsm.application.domain.model.GedScores
 
 data class SaveGedScoresCommand(
-    val applicantId: Long,
     val authorization: String? = null,
     val userId: Long? = null,
     val gedScores: GedScores,

--- a/systems/application/application-application/src/main/kotlin/hs/kr/entrydsm/application/application/port/in/command/SaveGedScoresCommand.kt
+++ b/systems/application/application-application/src/main/kotlin/hs/kr/entrydsm/application/application/port/in/command/SaveGedScoresCommand.kt
@@ -1,0 +1,8 @@
+package hs.kr.entrydsm.application.application.port.`in`.command
+
+import hs.kr.entrydsm.application.domain.model.GedScores
+
+data class SaveGedScoresCommand(
+    val applicantId: Long,
+    val gedScores: GedScores,
+)

--- a/systems/application/application-application/src/main/kotlin/hs/kr/entrydsm/application/application/port/in/command/SaveGedScoresCommand.kt
+++ b/systems/application/application-application/src/main/kotlin/hs/kr/entrydsm/application/application/port/in/command/SaveGedScoresCommand.kt
@@ -3,7 +3,6 @@ package hs.kr.entrydsm.application.application.port.`in`.command
 import hs.kr.entrydsm.application.domain.model.GedScores
 
 data class SaveGedScoresCommand(
-    val authorization: String? = null,
     val userId: Long? = null,
     val gedScores: GedScores,
 )

--- a/systems/application/application-application/src/main/kotlin/hs/kr/entrydsm/application/application/port/in/command/SaveSubjectGradesCommand.kt
+++ b/systems/application/application-application/src/main/kotlin/hs/kr/entrydsm/application/application/port/in/command/SaveSubjectGradesCommand.kt
@@ -1,0 +1,10 @@
+package hs.kr.entrydsm.application.application.port.`in`.command
+
+import hs.kr.entrydsm.application.domain.enum.SchoolSemester
+import hs.kr.entrydsm.application.domain.model.SubjectGrades
+
+data class SaveSubjectGradesCommand(
+    val applicantId: Long,
+    val schoolSemester: SchoolSemester,
+    val subjectGrades: SubjectGrades,
+)

--- a/systems/application/application-application/src/main/kotlin/hs/kr/entrydsm/application/application/port/in/command/SaveSubjectGradesCommand.kt
+++ b/systems/application/application-application/src/main/kotlin/hs/kr/entrydsm/application/application/port/in/command/SaveSubjectGradesCommand.kt
@@ -4,7 +4,6 @@ import hs.kr.entrydsm.application.domain.enum.SchoolSemester
 import hs.kr.entrydsm.application.domain.model.SubjectGrades
 
 data class SaveSubjectGradesCommand(
-    val authorization: String? = null,
     val userId: Long? = null,
     val schoolSemester: SchoolSemester,
     val subjectGrades: SubjectGrades,

--- a/systems/application/application-application/src/main/kotlin/hs/kr/entrydsm/application/application/port/in/command/SaveSubjectGradesCommand.kt
+++ b/systems/application/application-application/src/main/kotlin/hs/kr/entrydsm/application/application/port/in/command/SaveSubjectGradesCommand.kt
@@ -4,7 +4,6 @@ import hs.kr.entrydsm.application.domain.enum.SchoolSemester
 import hs.kr.entrydsm.application.domain.model.SubjectGrades
 
 data class SaveSubjectGradesCommand(
-    val applicantId: Long,
     val authorization: String? = null,
     val userId: Long? = null,
     val schoolSemester: SchoolSemester,

--- a/systems/application/application-application/src/main/kotlin/hs/kr/entrydsm/application/application/port/in/command/SaveSubjectGradesCommand.kt
+++ b/systems/application/application-application/src/main/kotlin/hs/kr/entrydsm/application/application/port/in/command/SaveSubjectGradesCommand.kt
@@ -5,6 +5,8 @@ import hs.kr.entrydsm.application.domain.model.SubjectGrades
 
 data class SaveSubjectGradesCommand(
     val applicantId: Long,
+    val authorization: String? = null,
+    val userId: Long? = null,
     val schoolSemester: SchoolSemester,
     val subjectGrades: SubjectGrades,
 )

--- a/systems/application/application-application/src/main/kotlin/hs/kr/entrydsm/application/application/port/in/command/SubmitApplicationCommand.kt
+++ b/systems/application/application-application/src/main/kotlin/hs/kr/entrydsm/application/application/port/in/command/SubmitApplicationCommand.kt
@@ -2,5 +2,7 @@ package hs.kr.entrydsm.application.application.port.`in`.command
 
 data class SubmitApplicationCommand(
     val applicantId: Long,
+    val authorization: String? = null,
+    val userId: Long? = null,
 )
 

--- a/systems/application/application-application/src/main/kotlin/hs/kr/entrydsm/application/application/port/in/command/SubmitApplicationCommand.kt
+++ b/systems/application/application-application/src/main/kotlin/hs/kr/entrydsm/application/application/port/in/command/SubmitApplicationCommand.kt
@@ -1,0 +1,6 @@
+package hs.kr.entrydsm.application.application.port.`in`.command
+
+data class SubmitApplicationCommand(
+    val applicantId: Long,
+)
+

--- a/systems/application/application-application/src/main/kotlin/hs/kr/entrydsm/application/application/port/in/command/SubmitApplicationCommand.kt
+++ b/systems/application/application-application/src/main/kotlin/hs/kr/entrydsm/application/application/port/in/command/SubmitApplicationCommand.kt
@@ -1,7 +1,6 @@
 package hs.kr.entrydsm.application.application.port.`in`.command
 
 data class SubmitApplicationCommand(
-    val authorization: String? = null,
     val userId: Long? = null,
 )
 

--- a/systems/application/application-application/src/main/kotlin/hs/kr/entrydsm/application/application/port/in/command/SubmitApplicationCommand.kt
+++ b/systems/application/application-application/src/main/kotlin/hs/kr/entrydsm/application/application/port/in/command/SubmitApplicationCommand.kt
@@ -1,7 +1,6 @@
 package hs.kr.entrydsm.application.application.port.`in`.command
 
 data class SubmitApplicationCommand(
-    val applicantId: Long,
     val authorization: String? = null,
     val userId: Long? = null,
 )

--- a/systems/application/application-application/src/main/kotlin/hs/kr/entrydsm/application/application/port/in/command/UpdateFamilyCommand.kt
+++ b/systems/application/application-application/src/main/kotlin/hs/kr/entrydsm/application/application/port/in/command/UpdateFamilyCommand.kt
@@ -5,6 +5,8 @@ import hs.kr.entrydsm.application.domain.enum.GuardianRelation
 
 data class UpdateFamilyCommand(
     val applicantId: Long,
+    val authorization: String? = null,
+    val userId: Long? = null,
     val guardianName: String,
     val guardianPhoneNumber: String,
     val guardianGender: Gender,

--- a/systems/application/application-application/src/main/kotlin/hs/kr/entrydsm/application/application/port/in/command/UpdateFamilyCommand.kt
+++ b/systems/application/application-application/src/main/kotlin/hs/kr/entrydsm/application/application/port/in/command/UpdateFamilyCommand.kt
@@ -1,0 +1,15 @@
+package hs.kr.entrydsm.application.application.port.`in`.command
+
+import hs.kr.entrydsm.application.domain.enum.Gender
+import hs.kr.entrydsm.application.domain.enum.GuardianRelation
+
+data class UpdateFamilyCommand(
+    val applicantId: Long,
+    val guardianName: String,
+    val guardianPhoneNumber: String,
+    val guardianGender: Gender,
+    val guardianRelation: GuardianRelation,
+    val zipCode: String,
+    val addressBase: String,
+    val addressDetail: String,
+)

--- a/systems/application/application-application/src/main/kotlin/hs/kr/entrydsm/application/application/port/in/command/UpdateFamilyCommand.kt
+++ b/systems/application/application-application/src/main/kotlin/hs/kr/entrydsm/application/application/port/in/command/UpdateFamilyCommand.kt
@@ -5,7 +5,6 @@ import hs.kr.entrydsm.application.domain.enum.GuardianRelation
 
 data class UpdateFamilyCommand(
     val applicantId: Long,
-    val authorization: String? = null,
     val userId: Long? = null,
     val guardianName: String,
     val guardianPhoneNumber: String,

--- a/systems/application/application-application/src/main/kotlin/hs/kr/entrydsm/application/application/port/in/command/UpdateIntroductionCommand.kt
+++ b/systems/application/application-application/src/main/kotlin/hs/kr/entrydsm/application/application/port/in/command/UpdateIntroductionCommand.kt
@@ -2,7 +2,6 @@ package hs.kr.entrydsm.application.application.port.`in`.command
 
 data class UpdateIntroductionCommand(
     val applicantId: Long,
-    val authorization: String? = null,
     val userId: Long? = null,
     val introduction: String,
 )

--- a/systems/application/application-application/src/main/kotlin/hs/kr/entrydsm/application/application/port/in/command/UpdateIntroductionCommand.kt
+++ b/systems/application/application-application/src/main/kotlin/hs/kr/entrydsm/application/application/port/in/command/UpdateIntroductionCommand.kt
@@ -1,0 +1,7 @@
+package hs.kr.entrydsm.application.application.port.`in`.command
+
+data class UpdateIntroductionCommand(
+    val applicantId: Long,
+    val introduction: String,
+)
+

--- a/systems/application/application-application/src/main/kotlin/hs/kr/entrydsm/application/application/port/in/command/UpdateIntroductionCommand.kt
+++ b/systems/application/application-application/src/main/kotlin/hs/kr/entrydsm/application/application/port/in/command/UpdateIntroductionCommand.kt
@@ -2,6 +2,8 @@ package hs.kr.entrydsm.application.application.port.`in`.command
 
 data class UpdateIntroductionCommand(
     val applicantId: Long,
+    val authorization: String? = null,
+    val userId: Long? = null,
     val introduction: String,
 )
 

--- a/systems/application/application-application/src/main/kotlin/hs/kr/entrydsm/application/application/port/in/command/UpdateMiddleSchoolCommand.kt
+++ b/systems/application/application-application/src/main/kotlin/hs/kr/entrydsm/application/application/port/in/command/UpdateMiddleSchoolCommand.kt
@@ -2,7 +2,6 @@ package hs.kr.entrydsm.application.application.port.`in`.command
 
 data class UpdateMiddleSchoolCommand(
     val applicantId: Long,
-    val authorization: String? = null,
     val userId: Long? = null,
     val schoolName: String,
     val studentNumber: String,

--- a/systems/application/application-application/src/main/kotlin/hs/kr/entrydsm/application/application/port/in/command/UpdateMiddleSchoolCommand.kt
+++ b/systems/application/application-application/src/main/kotlin/hs/kr/entrydsm/application/application/port/in/command/UpdateMiddleSchoolCommand.kt
@@ -2,6 +2,8 @@ package hs.kr.entrydsm.application.application.port.`in`.command
 
 data class UpdateMiddleSchoolCommand(
     val applicantId: Long,
+    val authorization: String? = null,
+    val userId: Long? = null,
     val schoolName: String,
     val studentNumber: String,
     val schoolPhone: String,

--- a/systems/application/application-application/src/main/kotlin/hs/kr/entrydsm/application/application/port/in/command/UpdateMiddleSchoolCommand.kt
+++ b/systems/application/application-application/src/main/kotlin/hs/kr/entrydsm/application/application/port/in/command/UpdateMiddleSchoolCommand.kt
@@ -1,0 +1,10 @@
+package hs.kr.entrydsm.application.application.port.`in`.command
+
+data class UpdateMiddleSchoolCommand(
+    val applicantId: Long,
+    val schoolName: String,
+    val studentNumber: String,
+    val schoolPhone: String,
+    val teacherName: String,
+)
+

--- a/systems/application/application-application/src/main/kotlin/hs/kr/entrydsm/application/application/port/in/command/UpdatePersonalCommand.kt
+++ b/systems/application/application-application/src/main/kotlin/hs/kr/entrydsm/application/application/port/in/command/UpdatePersonalCommand.kt
@@ -1,0 +1,15 @@
+package hs.kr.entrydsm.application.application.port.`in`.command
+
+import hs.kr.entrydsm.application.domain.enum.Gender
+import hs.kr.entrydsm.application.domain.enum.SpecialAdmissionType
+import java.time.LocalDate
+
+data class UpdatePersonalCommand(
+    val applicantId: Long,
+    val photoFileId: Long,
+    val name: String,
+    val phoneNumber: String,
+    val gender: Gender,
+    val birthdate: LocalDate,
+    val specialAdmissionType: SpecialAdmissionType,
+)

--- a/systems/application/application-application/src/main/kotlin/hs/kr/entrydsm/application/application/port/in/command/UpdatePersonalCommand.kt
+++ b/systems/application/application-application/src/main/kotlin/hs/kr/entrydsm/application/application/port/in/command/UpdatePersonalCommand.kt
@@ -6,7 +6,6 @@ import java.time.LocalDate
 
 data class UpdatePersonalCommand(
     val applicantId: Long,
-    val authorization: String? = null,
     val userId: Long? = null,
     val photoFileId: Long,
     val name: String,

--- a/systems/application/application-application/src/main/kotlin/hs/kr/entrydsm/application/application/port/in/command/UpdatePersonalCommand.kt
+++ b/systems/application/application-application/src/main/kotlin/hs/kr/entrydsm/application/application/port/in/command/UpdatePersonalCommand.kt
@@ -6,6 +6,8 @@ import java.time.LocalDate
 
 data class UpdatePersonalCommand(
     val applicantId: Long,
+    val authorization: String? = null,
+    val userId: Long? = null,
     val photoFileId: Long,
     val name: String,
     val phoneNumber: String,

--- a/systems/application/application-application/src/main/kotlin/hs/kr/entrydsm/application/application/port/in/command/UpdateStudyPlanCommand.kt
+++ b/systems/application/application-application/src/main/kotlin/hs/kr/entrydsm/application/application/port/in/command/UpdateStudyPlanCommand.kt
@@ -2,7 +2,6 @@ package hs.kr.entrydsm.application.application.port.`in`.command
 
 data class UpdateStudyPlanCommand(
     val applicantId: Long,
-    val authorization: String? = null,
     val userId: Long? = null,
     val studyPlan: String,
 )

--- a/systems/application/application-application/src/main/kotlin/hs/kr/entrydsm/application/application/port/in/command/UpdateStudyPlanCommand.kt
+++ b/systems/application/application-application/src/main/kotlin/hs/kr/entrydsm/application/application/port/in/command/UpdateStudyPlanCommand.kt
@@ -2,6 +2,8 @@ package hs.kr.entrydsm.application.application.port.`in`.command
 
 data class UpdateStudyPlanCommand(
     val applicantId: Long,
+    val authorization: String? = null,
+    val userId: Long? = null,
     val studyPlan: String,
 )
 

--- a/systems/application/application-application/src/main/kotlin/hs/kr/entrydsm/application/application/port/in/command/UpdateStudyPlanCommand.kt
+++ b/systems/application/application-application/src/main/kotlin/hs/kr/entrydsm/application/application/port/in/command/UpdateStudyPlanCommand.kt
@@ -1,0 +1,7 @@
+package hs.kr.entrydsm.application.application.port.`in`.command
+
+data class UpdateStudyPlanCommand(
+    val applicantId: Long,
+    val studyPlan: String,
+)
+

--- a/systems/application/application-application/src/main/kotlin/hs/kr/entrydsm/application/application/port/in/command/UpdateTypeCommand.kt
+++ b/systems/application/application-application/src/main/kotlin/hs/kr/entrydsm/application/application/port/in/command/UpdateTypeCommand.kt
@@ -1,0 +1,14 @@
+package hs.kr.entrydsm.application.application.port.`in`.command
+
+import hs.kr.entrydsm.application.domain.enum.AdmissionType
+import hs.kr.entrydsm.application.domain.enum.GraduationType
+import hs.kr.entrydsm.application.domain.enum.Region
+import java.time.YearMonth
+
+data class UpdateTypeCommand(
+    val applicantId: Long,
+    val admissionType: AdmissionType,
+    val region: Region,
+    val graduationType: GraduationType,
+    val graduationDate: YearMonth?,
+)

--- a/systems/application/application-application/src/main/kotlin/hs/kr/entrydsm/application/application/port/in/command/UpdateTypeCommand.kt
+++ b/systems/application/application-application/src/main/kotlin/hs/kr/entrydsm/application/application/port/in/command/UpdateTypeCommand.kt
@@ -7,7 +7,6 @@ import java.time.YearMonth
 
 data class UpdateTypeCommand(
     val applicantId: Long,
-    val authorization: String? = null,
     val userId: Long? = null,
     val admissionType: AdmissionType,
     val region: Region,

--- a/systems/application/application-application/src/main/kotlin/hs/kr/entrydsm/application/application/port/in/command/UpdateTypeCommand.kt
+++ b/systems/application/application-application/src/main/kotlin/hs/kr/entrydsm/application/application/port/in/command/UpdateTypeCommand.kt
@@ -7,6 +7,8 @@ import java.time.YearMonth
 
 data class UpdateTypeCommand(
     val applicantId: Long,
+    val authorization: String? = null,
+    val userId: Long? = null,
     val admissionType: AdmissionType,
     val region: Region,
     val graduationType: GraduationType,

--- a/systems/application/application-application/src/main/kotlin/hs/kr/entrydsm/application/application/port/in/result/AcademicRecordResult.kt
+++ b/systems/application/application-application/src/main/kotlin/hs/kr/entrydsm/application/application/port/in/result/AcademicRecordResult.kt
@@ -1,0 +1,10 @@
+package hs.kr.entrydsm.application.application.port.`in`.result
+
+data class AcademicRecordResult(
+    val absentCount: Int,
+    val earlyLeaveCount: Int,
+    val lateCount: Int,
+    val classAbsenceCount: Int,
+    val volunteerTime: Int,
+)
+

--- a/systems/application/application-application/src/main/kotlin/hs/kr/entrydsm/application/application/port/in/result/CreateApplicantResult.kt
+++ b/systems/application/application-application/src/main/kotlin/hs/kr/entrydsm/application/application/port/in/result/CreateApplicantResult.kt
@@ -1,0 +1,6 @@
+package hs.kr.entrydsm.application.application.port.`in`.result
+
+data class CreateApplicantResult(
+    val applicantId: Long,
+)
+

--- a/systems/application/application-application/src/main/kotlin/hs/kr/entrydsm/application/application/port/in/result/EvaluationResult.kt
+++ b/systems/application/application-application/src/main/kotlin/hs/kr/entrydsm/application/application/port/in/result/EvaluationResult.kt
@@ -1,0 +1,5 @@
+package hs.kr.entrydsm.application.application.port.`in`.result
+
+data class EvaluationResult(
+    val scores: Map<String, Double>,
+)

--- a/systems/application/application-application/src/main/kotlin/hs/kr/entrydsm/application/application/port/in/result/EvaluationResult.kt
+++ b/systems/application/application-application/src/main/kotlin/hs/kr/entrydsm/application/application/port/in/result/EvaluationResult.kt
@@ -1,5 +1,0 @@
-package hs.kr.entrydsm.application.application.port.`in`.result
-
-data class EvaluationResult(
-    val scores: Map<String, Double>,
-)

--- a/systems/application/application-application/src/main/kotlin/hs/kr/entrydsm/application/application/port/in/result/LandingResult.kt
+++ b/systems/application/application-application/src/main/kotlin/hs/kr/entrydsm/application/application/port/in/result/LandingResult.kt
@@ -1,0 +1,6 @@
+package hs.kr.entrydsm.application.application.port.`in`.result
+
+data class LandingResult(
+    val applicantName: String?,
+)
+

--- a/systems/application/application-application/src/main/kotlin/hs/kr/entrydsm/application/application/port/out/ApplicantRepository.kt
+++ b/systems/application/application-application/src/main/kotlin/hs/kr/entrydsm/application/application/port/out/ApplicantRepository.kt
@@ -5,4 +5,5 @@ import hs.kr.entrydsm.application.domain.model.Applicant
 interface ApplicantRepository {
     fun save(applicant: Applicant): Applicant
     fun findById(id: Long): Applicant?
+    fun findByAccountId(accountId: Long): Applicant?
 }

--- a/systems/application/application-application/src/main/kotlin/hs/kr/entrydsm/application/application/port/out/ApplicantRepository.kt
+++ b/systems/application/application-application/src/main/kotlin/hs/kr/entrydsm/application/application/port/out/ApplicantRepository.kt
@@ -1,0 +1,8 @@
+package hs.kr.entrydsm.application.application.port.out
+
+import hs.kr.entrydsm.application.domain.model.Applicant
+
+interface ApplicantRepository {
+    fun save(applicant: Applicant): Applicant
+    fun findById(id: Long): Applicant?
+}

--- a/systems/application/application-application/src/main/kotlin/hs/kr/entrydsm/application/application/service/ApplicationCommandService.kt
+++ b/systems/application/application-application/src/main/kotlin/hs/kr/entrydsm/application/application/service/ApplicationCommandService.kt
@@ -2,6 +2,7 @@ package hs.kr.entrydsm.application.application.service
 
 import hs.kr.entrydsm.application.application.exception.ApplicantAccessDeniedException
 import hs.kr.entrydsm.application.application.exception.ApplicantNotFoundException
+import hs.kr.entrydsm.application.application.exception.AuthenticationRequiredException
 import hs.kr.entrydsm.application.application.port.`in`.ApplicationPort
 import hs.kr.entrydsm.application.application.port.`in`.command.CreateApplicantCommand
 import hs.kr.entrydsm.application.application.port.`in`.command.SubmitApplicationCommand
@@ -31,7 +32,7 @@ class ApplicationCommandService(
     private val applicantRepository: ApplicantRepository,
 ) : ApplicationPort {
     override fun createApplicant(command: CreateApplicantCommand): CreateApplicantResult {
-        return CreateApplicantResult(createApplicant(command.userId ?: command.accountId).id)
+        return CreateApplicantResult(createApplicant(requireUserId(command.userId)).id)
     }
 
     override fun updateType(command: UpdateTypeCommand) {
@@ -92,7 +93,7 @@ class ApplicationCommandService(
     }
 
     override fun submit(command: SubmitApplicationCommand) {
-        submit(command.applicantId, command.userId)
+        submit(command.userId)
     }
 
     override fun getLanding(accountId: Long?): LandingResult {
@@ -238,6 +239,16 @@ class ApplicationCommandService(
         saveTouched(applicant)
     }
 
+    fun submit(userId: Long?) {
+        val applicant = getApplicantByUserId(userId)
+        require(applicant.admissionType != null) { "admission type is required" }
+        require(!applicant.name.isNullOrBlank()) { "personal info is required" }
+        require(!applicant.guardianName.isNullOrBlank()) { "family info is required" }
+        require(!applicant.introduction.isNullOrBlank()) { "introduction is required" }
+        require(!applicant.studyPlan.isNullOrBlank()) { "studyPlan is required" }
+        saveTouched(applicant)
+    }
+
     private fun getApplicant(applicantId: Long, userId: Long? = null): Applicant {
         val applicant = applicantRepository.findById(applicantId)
             ?: throw ApplicantNotFoundException(applicantId)
@@ -246,6 +257,15 @@ class ApplicationCommandService(
         }
         return applicant
     }
+
+    private fun getApplicantByUserId(userId: Long?): Applicant {
+        val accountId = requireUserId(userId)
+        return applicantRepository.findByAccountId(accountId)
+            ?: throw ApplicantNotFoundException(accountId)
+    }
+
+    private fun requireUserId(userId: Long?): Long =
+        userId ?: throw AuthenticationRequiredException()
 
     private fun saveTouched(applicant: Applicant) {
         applicant.touch()

--- a/systems/application/application-application/src/main/kotlin/hs/kr/entrydsm/application/application/service/ApplicationCommandService.kt
+++ b/systems/application/application-application/src/main/kotlin/hs/kr/entrydsm/application/application/service/ApplicationCommandService.kt
@@ -25,9 +25,7 @@ import hs.kr.entrydsm.application.domain.model.Applicant
 import hs.kr.entrydsm.application.domain.model.MiddleSchoolInfo
 import java.time.LocalDate
 import java.time.YearMonth
-import org.springframework.stereotype.Service
 
-@Service
 class ApplicationCommandService(
     private val applicantRepository: ApplicantRepository,
 ) : ApplicationPort {

--- a/systems/application/application-application/src/main/kotlin/hs/kr/entrydsm/application/application/service/ApplicationCommandService.kt
+++ b/systems/application/application-application/src/main/kotlin/hs/kr/entrydsm/application/application/service/ApplicationCommandService.kt
@@ -1,5 +1,6 @@
 package hs.kr.entrydsm.application.application.service
 
+import hs.kr.entrydsm.application.application.exception.ApplicantAccessDeniedException
 import hs.kr.entrydsm.application.application.exception.ApplicantNotFoundException
 import hs.kr.entrydsm.application.application.port.`in`.ApplicationPort
 import hs.kr.entrydsm.application.application.port.`in`.command.CreateApplicantCommand
@@ -30,12 +31,13 @@ class ApplicationCommandService(
     private val applicantRepository: ApplicantRepository,
 ) : ApplicationPort {
     override fun createApplicant(command: CreateApplicantCommand): CreateApplicantResult {
-        return CreateApplicantResult(createApplicant(command.accountId).id)
+        return CreateApplicantResult(createApplicant(command.userId ?: command.accountId).id)
     }
 
     override fun updateType(command: UpdateTypeCommand) {
         updateType(
             applicantId = command.applicantId,
+            userId = command.userId,
             admissionType = command.admissionType,
             region = command.region,
             graduationType = command.graduationType,
@@ -46,6 +48,7 @@ class ApplicationCommandService(
     override fun updatePersonal(command: UpdatePersonalCommand) {
         updatePersonal(
             applicantId = command.applicantId,
+            userId = command.userId,
             photoFileId = command.photoFileId,
             name = command.name,
             phoneNumber = command.phoneNumber,
@@ -58,6 +61,7 @@ class ApplicationCommandService(
     override fun updateFamily(command: UpdateFamilyCommand) {
         updateFamily(
             applicantId = command.applicantId,
+            userId = command.userId,
             guardianName = command.guardianName,
             guardianPhoneNumber = command.guardianPhoneNumber,
             guardianGender = command.guardianGender,
@@ -71,6 +75,7 @@ class ApplicationCommandService(
     override fun updateMiddleSchool(command: UpdateMiddleSchoolCommand) {
         updateMiddleSchool(
             applicantId = command.applicantId,
+            userId = command.userId,
             schoolName = command.schoolName,
             studentNumber = command.studentNumber,
             schoolPhone = command.schoolPhone,
@@ -79,19 +84,21 @@ class ApplicationCommandService(
     }
 
     override fun updateIntroduction(command: UpdateIntroductionCommand) {
-        updateIntroduction(command.applicantId, command.introduction)
+        updateIntroduction(command.applicantId, command.userId, command.introduction)
     }
 
     override fun updateStudyPlan(command: UpdateStudyPlanCommand) {
-        updateStudyPlan(command.applicantId, command.studyPlan)
+        updateStudyPlan(command.applicantId, command.userId, command.studyPlan)
     }
 
     override fun submit(command: SubmitApplicationCommand) {
-        submit(command.applicantId)
+        submit(command.applicantId, command.userId)
     }
 
-    override fun getLanding(): LandingResult {
-        return LandingResult(applicantName = null)
+    override fun getLanding(accountId: Long?): LandingResult {
+        return LandingResult(
+            applicantName = accountId?.let(applicantRepository::findByAccountId)?.name,
+        )
     }
 
     fun createApplicant(accountId: Long = 0): Applicant {
@@ -105,12 +112,13 @@ class ApplicationCommandService(
 
     fun updateType(
         applicantId: Long,
+        userId: Long? = null,
         admissionType: AdmissionType,
         region: Region,
         graduationType: GraduationType,
         graduationDate: YearMonth?,
     ) {
-        val applicant = getApplicant(applicantId)
+        val applicant = getApplicant(applicantId, userId)
         require(graduationType == GraduationType.GED || graduationDate != null) {
             "graduationDate is required unless graduationType is GED"
         }
@@ -127,6 +135,7 @@ class ApplicationCommandService(
 
     fun updatePersonal(
         applicantId: Long,
+        userId: Long? = null,
         photoFileId: Long,
         name: String,
         phoneNumber: String,
@@ -137,7 +146,7 @@ class ApplicationCommandService(
         require(name.isNotBlank()) { "name is required" }
         require(phoneNumber.matches(PHONE_NUMBER_REGEX)) { "phoneNumber format is invalid" }
 
-        val applicant = getApplicant(applicantId)
+        val applicant = getApplicant(applicantId, userId)
         applicant.photoFileId = photoFileId
         applicant.name = name
         applicant.phoneNumber = phoneNumber
@@ -149,6 +158,7 @@ class ApplicationCommandService(
 
     fun updateFamily(
         applicantId: Long,
+        userId: Long? = null,
         guardianName: String,
         guardianPhoneNumber: String,
         guardianGender: Gender,
@@ -163,7 +173,7 @@ class ApplicationCommandService(
         require(addressBase.isNotBlank()) { "addressBase is required" }
         require(addressDetail.isNotBlank()) { "addressDetail is required" }
 
-        val applicant = getApplicant(applicantId)
+        val applicant = getApplicant(applicantId, userId)
         applicant.guardianName = guardianName
         applicant.guardianPhoneNumber = guardianPhoneNumber
         applicant.guardianGender = guardianGender
@@ -176,12 +186,13 @@ class ApplicationCommandService(
 
     fun updateMiddleSchool(
         applicantId: Long,
+        userId: Long? = null,
         schoolName: String,
         studentNumber: String,
         schoolPhone: String,
         teacherName: String,
     ) {
-        val applicant = getApplicant(applicantId)
+        val applicant = getApplicant(applicantId, userId)
         require(applicant.graduationType != GraduationType.GED) {
             "middle school info is unavailable for GED applicants"
         }
@@ -199,26 +210,26 @@ class ApplicationCommandService(
         saveTouched(applicant)
     }
 
-    fun updateIntroduction(applicantId: Long, introduction: String) {
+    fun updateIntroduction(applicantId: Long, userId: Long? = null, introduction: String) {
         require(introduction.isNotBlank()) { "introduction is required" }
         require(introduction.length <= MAX_ESSAY_LENGTH) { "introduction is too long" }
 
-        val applicant = getApplicant(applicantId)
+        val applicant = getApplicant(applicantId, userId)
         applicant.introduction = introduction
         saveTouched(applicant)
     }
 
-    fun updateStudyPlan(applicantId: Long, studyPlan: String) {
+    fun updateStudyPlan(applicantId: Long, userId: Long? = null, studyPlan: String) {
         require(studyPlan.isNotBlank()) { "studyPlan is required" }
         require(studyPlan.length <= MAX_ESSAY_LENGTH) { "studyPlan is too long" }
 
-        val applicant = getApplicant(applicantId)
+        val applicant = getApplicant(applicantId, userId)
         applicant.studyPlan = studyPlan
         saveTouched(applicant)
     }
 
-    fun submit(applicantId: Long) {
-        val applicant = getApplicant(applicantId)
+    fun submit(applicantId: Long, userId: Long? = null) {
+        val applicant = getApplicant(applicantId, userId)
         require(applicant.admissionType != null) { "admission type is required" }
         require(!applicant.name.isNullOrBlank()) { "personal info is required" }
         require(!applicant.guardianName.isNullOrBlank()) { "family info is required" }
@@ -227,9 +238,13 @@ class ApplicationCommandService(
         saveTouched(applicant)
     }
 
-    private fun getApplicant(applicantId: Long): Applicant {
-        return applicantRepository.findById(applicantId)
+    private fun getApplicant(applicantId: Long, userId: Long? = null): Applicant {
+        val applicant = applicantRepository.findById(applicantId)
             ?: throw ApplicantNotFoundException(applicantId)
+        if (userId != null && applicant.accountId != userId) {
+            throw ApplicantAccessDeniedException(applicantId)
+        }
+        return applicant
     }
 
     private fun saveTouched(applicant: Applicant) {

--- a/systems/application/application-application/src/main/kotlin/hs/kr/entrydsm/application/application/service/ApplicationCommandService.kt
+++ b/systems/application/application-application/src/main/kotlin/hs/kr/entrydsm/application/application/service/ApplicationCommandService.kt
@@ -1,0 +1,245 @@
+package hs.kr.entrydsm.application.application.service
+
+import hs.kr.entrydsm.application.application.exception.ApplicantNotFoundException
+import hs.kr.entrydsm.application.application.port.`in`.ApplicationPort
+import hs.kr.entrydsm.application.application.port.`in`.command.CreateApplicantCommand
+import hs.kr.entrydsm.application.application.port.`in`.command.SubmitApplicationCommand
+import hs.kr.entrydsm.application.application.port.`in`.command.UpdateFamilyCommand
+import hs.kr.entrydsm.application.application.port.`in`.command.UpdateIntroductionCommand
+import hs.kr.entrydsm.application.application.port.`in`.command.UpdateMiddleSchoolCommand
+import hs.kr.entrydsm.application.application.port.`in`.command.UpdatePersonalCommand
+import hs.kr.entrydsm.application.application.port.`in`.command.UpdateStudyPlanCommand
+import hs.kr.entrydsm.application.application.port.`in`.command.UpdateTypeCommand
+import hs.kr.entrydsm.application.application.port.`in`.result.CreateApplicantResult
+import hs.kr.entrydsm.application.application.port.`in`.result.LandingResult
+import hs.kr.entrydsm.application.application.port.out.ApplicantRepository
+import hs.kr.entrydsm.application.domain.enum.AdmissionType
+import hs.kr.entrydsm.application.domain.enum.Gender
+import hs.kr.entrydsm.application.domain.enum.GraduationType
+import hs.kr.entrydsm.application.domain.enum.GuardianRelation
+import hs.kr.entrydsm.application.domain.enum.Region
+import hs.kr.entrydsm.application.domain.enum.SpecialAdmissionType
+import hs.kr.entrydsm.application.domain.model.Applicant
+import hs.kr.entrydsm.application.domain.model.MiddleSchoolInfo
+import java.time.LocalDate
+import java.time.YearMonth
+import org.springframework.stereotype.Service
+
+@Service
+class ApplicationCommandService(
+    private val applicantRepository: ApplicantRepository,
+) : ApplicationPort {
+    override fun createApplicant(command: CreateApplicantCommand): CreateApplicantResult {
+        return CreateApplicantResult(createApplicant(command.accountId).id)
+    }
+
+    override fun updateType(command: UpdateTypeCommand) {
+        updateType(
+            applicantId = command.applicantId,
+            admissionType = command.admissionType,
+            region = command.region,
+            graduationType = command.graduationType,
+            graduationDate = command.graduationDate,
+        )
+    }
+
+    override fun updatePersonal(command: UpdatePersonalCommand) {
+        updatePersonal(
+            applicantId = command.applicantId,
+            photoFileId = command.photoFileId,
+            name = command.name,
+            phoneNumber = command.phoneNumber,
+            gender = command.gender,
+            birthdate = command.birthdate,
+            specialAdmissionType = command.specialAdmissionType,
+        )
+    }
+
+    override fun updateFamily(command: UpdateFamilyCommand) {
+        updateFamily(
+            applicantId = command.applicantId,
+            guardianName = command.guardianName,
+            guardianPhoneNumber = command.guardianPhoneNumber,
+            guardianGender = command.guardianGender,
+            guardianRelation = command.guardianRelation,
+            zipCode = command.zipCode,
+            addressBase = command.addressBase,
+            addressDetail = command.addressDetail,
+        )
+    }
+
+    override fun updateMiddleSchool(command: UpdateMiddleSchoolCommand) {
+        updateMiddleSchool(
+            applicantId = command.applicantId,
+            schoolName = command.schoolName,
+            studentNumber = command.studentNumber,
+            schoolPhone = command.schoolPhone,
+            teacherName = command.teacherName,
+        )
+    }
+
+    override fun updateIntroduction(command: UpdateIntroductionCommand) {
+        updateIntroduction(command.applicantId, command.introduction)
+    }
+
+    override fun updateStudyPlan(command: UpdateStudyPlanCommand) {
+        updateStudyPlan(command.applicantId, command.studyPlan)
+    }
+
+    override fun submit(command: SubmitApplicationCommand) {
+        submit(command.applicantId)
+    }
+
+    override fun getLanding(): LandingResult {
+        return LandingResult(applicantName = null)
+    }
+
+    fun createApplicant(accountId: Long = 0): Applicant {
+        return applicantRepository.save(
+            Applicant(
+                id = NEW_APPLICANT_ID,
+                accountId = accountId,
+            ),
+        )
+    }
+
+    fun updateType(
+        applicantId: Long,
+        admissionType: AdmissionType,
+        region: Region,
+        graduationType: GraduationType,
+        graduationDate: YearMonth?,
+    ) {
+        val applicant = getApplicant(applicantId)
+        require(graduationType == GraduationType.GED || graduationDate != null) {
+            "graduationDate is required unless graduationType is GED"
+        }
+        require(graduationType != GraduationType.GED || graduationDate == null) {
+            "graduationDate must be null when graduationType is GED"
+        }
+
+        applicant.admissionType = admissionType
+        applicant.region = region
+        applicant.graduationType = graduationType
+        applicant.graduationDate = graduationDate
+        saveTouched(applicant)
+    }
+
+    fun updatePersonal(
+        applicantId: Long,
+        photoFileId: Long,
+        name: String,
+        phoneNumber: String,
+        gender: Gender,
+        birthdate: LocalDate,
+        specialAdmissionType: SpecialAdmissionType,
+    ) {
+        require(name.isNotBlank()) { "name is required" }
+        require(phoneNumber.matches(PHONE_NUMBER_REGEX)) { "phoneNumber format is invalid" }
+
+        val applicant = getApplicant(applicantId)
+        applicant.photoFileId = photoFileId
+        applicant.name = name
+        applicant.phoneNumber = phoneNumber
+        applicant.gender = gender
+        applicant.birthdate = birthdate
+        applicant.specialAdmissionType = specialAdmissionType
+        saveTouched(applicant)
+    }
+
+    fun updateFamily(
+        applicantId: Long,
+        guardianName: String,
+        guardianPhoneNumber: String,
+        guardianGender: Gender,
+        guardianRelation: GuardianRelation,
+        zipCode: String,
+        addressBase: String,
+        addressDetail: String,
+    ) {
+        require(guardianName.isNotBlank()) { "guardianName is required" }
+        require(guardianPhoneNumber.matches(PHONE_NUMBER_REGEX)) { "guardianPhoneNumber format is invalid" }
+        require(zipCode.isNotBlank()) { "zipCode is required" }
+        require(addressBase.isNotBlank()) { "addressBase is required" }
+        require(addressDetail.isNotBlank()) { "addressDetail is required" }
+
+        val applicant = getApplicant(applicantId)
+        applicant.guardianName = guardianName
+        applicant.guardianPhoneNumber = guardianPhoneNumber
+        applicant.guardianGender = guardianGender
+        applicant.guardianRelation = guardianRelation
+        applicant.zipCode = zipCode
+        applicant.addressBase = addressBase
+        applicant.addressDetail = addressDetail
+        saveTouched(applicant)
+    }
+
+    fun updateMiddleSchool(
+        applicantId: Long,
+        schoolName: String,
+        studentNumber: String,
+        schoolPhone: String,
+        teacherName: String,
+    ) {
+        val applicant = getApplicant(applicantId)
+        require(applicant.graduationType != GraduationType.GED) {
+            "middle school info is unavailable for GED applicants"
+        }
+        require(schoolName.isNotBlank()) { "schoolName is required" }
+        require(studentNumber.isNotBlank()) { "studentNumber is required" }
+        require(schoolPhone.isNotBlank()) { "schoolPhone is required" }
+        require(teacherName.isNotBlank()) { "teacherName is required" }
+
+        applicant.middleSchoolInfo = MiddleSchoolInfo(
+            schoolName = schoolName,
+            studentNumber = studentNumber,
+            schoolPhone = schoolPhone,
+            teacherName = teacherName,
+        )
+        saveTouched(applicant)
+    }
+
+    fun updateIntroduction(applicantId: Long, introduction: String) {
+        require(introduction.isNotBlank()) { "introduction is required" }
+        require(introduction.length <= MAX_ESSAY_LENGTH) { "introduction is too long" }
+
+        val applicant = getApplicant(applicantId)
+        applicant.introduction = introduction
+        saveTouched(applicant)
+    }
+
+    fun updateStudyPlan(applicantId: Long, studyPlan: String) {
+        require(studyPlan.isNotBlank()) { "studyPlan is required" }
+        require(studyPlan.length <= MAX_ESSAY_LENGTH) { "studyPlan is too long" }
+
+        val applicant = getApplicant(applicantId)
+        applicant.studyPlan = studyPlan
+        saveTouched(applicant)
+    }
+
+    fun submit(applicantId: Long) {
+        val applicant = getApplicant(applicantId)
+        require(applicant.admissionType != null) { "admission type is required" }
+        require(!applicant.name.isNullOrBlank()) { "personal info is required" }
+        require(!applicant.guardianName.isNullOrBlank()) { "family info is required" }
+        require(!applicant.introduction.isNullOrBlank()) { "introduction is required" }
+        require(!applicant.studyPlan.isNullOrBlank()) { "studyPlan is required" }
+        saveTouched(applicant)
+    }
+
+    private fun getApplicant(applicantId: Long): Applicant {
+        return applicantRepository.findById(applicantId)
+            ?: throw ApplicantNotFoundException(applicantId)
+    }
+
+    private fun saveTouched(applicant: Applicant) {
+        applicant.touch()
+        applicantRepository.save(applicant)
+    }
+
+    companion object {
+        private const val NEW_APPLICANT_ID = 0L
+        private val PHONE_NUMBER_REGEX = Regex("^010-\\d{4}-\\d{4}$")
+        private const val MAX_ESSAY_LENGTH = 1500
+    }
+}

--- a/systems/application/application-application/src/main/kotlin/hs/kr/entrydsm/application/application/service/EvaluationCommandService.kt
+++ b/systems/application/application-application/src/main/kotlin/hs/kr/entrydsm/application/application/service/EvaluationCommandService.kt
@@ -1,7 +1,7 @@
 package hs.kr.entrydsm.application.application.service
 
-import hs.kr.entrydsm.application.application.exception.ApplicantAccessDeniedException
 import hs.kr.entrydsm.application.application.exception.ApplicantNotFoundException
+import hs.kr.entrydsm.application.application.exception.AuthenticationRequiredException
 import hs.kr.entrydsm.application.application.port.`in`.EvaluationPort
 import hs.kr.entrydsm.application.application.port.`in`.command.CalculateEvaluationCommand
 import hs.kr.entrydsm.application.application.port.`in`.command.SaveAcademicRecordCommand
@@ -9,7 +9,6 @@ import hs.kr.entrydsm.application.application.port.`in`.command.SaveCertificates
 import hs.kr.entrydsm.application.application.port.`in`.command.SaveGedScoresCommand
 import hs.kr.entrydsm.application.application.port.`in`.command.SaveSubjectGradesCommand
 import hs.kr.entrydsm.application.application.port.`in`.result.AcademicRecordResult
-import hs.kr.entrydsm.application.application.port.`in`.result.EvaluationResult
 import hs.kr.entrydsm.application.application.port.out.ApplicantRepository
 import hs.kr.entrydsm.application.domain.enum.GraduationType
 import hs.kr.entrydsm.application.domain.enum.SchoolSemester
@@ -28,16 +27,15 @@ class EvaluationCommandService(
     private val scoreCalculator = ScoreCalculator()
 
     override fun saveSubjectGrades(command: SaveSubjectGradesCommand) {
-        saveSubjectGrades(command.applicantId, command.userId, command.schoolSemester, command.subjectGrades)
+        saveSubjectGrades(command.userId, command.schoolSemester, command.subjectGrades)
     }
 
     override fun saveGedScores(command: SaveGedScoresCommand) {
-        saveGedScores(command.applicantId, command.userId, command.gedScores)
+        saveGedScores(command.userId, command.gedScores)
     }
 
     override fun saveAcademicRecord(command: SaveAcademicRecordCommand): AcademicRecordResult {
         val record = saveAcademicRecord(
-            applicantId = command.applicantId,
             userId = command.userId,
             absentCount = command.absentCount,
             earlyLeaveCount = command.earlyLeaveCount,
@@ -56,24 +54,22 @@ class EvaluationCommandService(
 
     override fun saveCertificates(command: SaveCertificatesCommand) {
         saveCertificates(
-            applicantId = command.applicantId,
             userId = command.userId,
             isDsmAlgorithmAwarded = command.isDsmAlgorithmAwarded,
             isProgrammingCertified = command.isProgrammingCertified,
         )
     }
 
-    override fun calculateResult(command: CalculateEvaluationCommand): EvaluationResult {
-        return EvaluationResult(calculateResult(command.applicantId, command.userId))
+    override fun calculateResult(command: CalculateEvaluationCommand) {
+        calculateResult(command.userId)
     }
 
     fun saveSubjectGrades(
-        applicantId: Long,
-        userId: Long? = null,
+        userId: Long?,
         schoolSemester: SchoolSemester,
         subjectGrades: SubjectGrades,
     ) {
-        val applicant = getApplicant(applicantId, userId)
+        val applicant = getApplicantByUserId(userId)
         require(applicant.graduationType != GraduationType.GED) {
             "subject grades are unavailable for GED applicants"
         }
@@ -85,8 +81,8 @@ class EvaluationCommandService(
         applicantRepository.save(applicant)
     }
 
-    fun saveGedScores(applicantId: Long, userId: Long? = null, gedScores: GedScores) {
-        val applicant = getApplicant(applicantId, userId)
+    fun saveGedScores(userId: Long?, gedScores: GedScores) {
+        val applicant = getApplicantByUserId(userId)
         require(applicant.graduationType == GraduationType.GED) {
             "GED scores are available only for GED applicants"
         }
@@ -99,8 +95,7 @@ class EvaluationCommandService(
     }
 
     fun saveAcademicRecord(
-        applicantId: Long,
-        userId: Long? = null,
+        userId: Long?,
         absentCount: Int,
         earlyLeaveCount: Int,
         lateCount: Int,
@@ -113,7 +108,7 @@ class EvaluationCommandService(
         require(classAbsenceCount >= 0) { "classAbsenceCount must be greater than or equal to 0" }
         require(volunteerTime >= 0) { "volunteerTime must be greater than or equal to 0" }
 
-        val applicant = getApplicant(applicantId, userId)
+        val applicant = getApplicantByUserId(userId)
         val record = getOrCreateAcademicRecord(applicant)
         record.absentCount = absentCount
         record.earlyLeaveCount = earlyLeaveCount
@@ -127,12 +122,11 @@ class EvaluationCommandService(
     }
 
     fun saveCertificates(
-        applicantId: Long,
-        userId: Long? = null,
+        userId: Long?,
         isDsmAlgorithmAwarded: Boolean,
         isProgrammingCertified: Boolean,
     ) {
-        val applicant = getApplicant(applicantId, userId)
+        val applicant = getApplicantByUserId(userId)
         val record = getOrCreateAcademicRecord(applicant)
         record.isDsmAlgorithmAwarded = isDsmAlgorithmAwarded
         record.isProgrammingCertified = isProgrammingCertified
@@ -141,8 +135,8 @@ class EvaluationCommandService(
         applicantRepository.save(applicant)
     }
 
-    fun calculateResult(applicantId: Long, userId: Long? = null): Map<String, Double> {
-        val applicant = getApplicant(applicantId, userId)
+    fun calculateResult(userId: Long?) {
+        val applicant = getApplicantByUserId(userId)
         val admissionType = requireNotNull(applicant.admissionType) {
             "admissionType is required"
         }
@@ -151,17 +145,16 @@ class EvaluationCommandService(
         applicant.totalScoreUpdatedAt = LocalDateTime.now()
         applicant.touch()
         applicantRepository.save(applicant)
-        return result.mapKeys { it.key.name }
     }
 
-    private fun getApplicant(applicantId: Long, userId: Long? = null): Applicant {
-        val applicant = applicantRepository.findById(applicantId)
-            ?: throw ApplicantNotFoundException(applicantId)
-        if (userId != null && applicant.accountId != userId) {
-            throw ApplicantAccessDeniedException(applicantId)
-        }
-        return applicant
+    private fun getApplicantByUserId(userId: Long?): Applicant {
+        val accountId = requireUserId(userId)
+        return applicantRepository.findByAccountId(accountId)
+            ?: throw ApplicantNotFoundException(accountId)
     }
+
+    private fun requireUserId(userId: Long?): Long =
+        userId ?: throw AuthenticationRequiredException()
 
     private fun getOrCreateAcademicRecord(applicant: Applicant): AcademicRecord {
         return applicant.academicRecord ?: AcademicRecord()

--- a/systems/application/application-application/src/main/kotlin/hs/kr/entrydsm/application/application/service/EvaluationCommandService.kt
+++ b/systems/application/application-application/src/main/kotlin/hs/kr/entrydsm/application/application/service/EvaluationCommandService.kt
@@ -1,5 +1,6 @@
 package hs.kr.entrydsm.application.application.service
 
+import hs.kr.entrydsm.application.application.exception.ApplicantAccessDeniedException
 import hs.kr.entrydsm.application.application.exception.ApplicantNotFoundException
 import hs.kr.entrydsm.application.application.port.`in`.EvaluationPort
 import hs.kr.entrydsm.application.application.port.`in`.command.CalculateEvaluationCommand
@@ -10,6 +11,7 @@ import hs.kr.entrydsm.application.application.port.`in`.command.SaveSubjectGrade
 import hs.kr.entrydsm.application.application.port.`in`.result.AcademicRecordResult
 import hs.kr.entrydsm.application.application.port.`in`.result.EvaluationResult
 import hs.kr.entrydsm.application.application.port.out.ApplicantRepository
+import hs.kr.entrydsm.application.domain.enum.GraduationType
 import hs.kr.entrydsm.application.domain.enum.SchoolSemester
 import hs.kr.entrydsm.application.domain.model.AcademicRecord
 import hs.kr.entrydsm.application.domain.model.Applicant
@@ -26,16 +28,17 @@ class EvaluationCommandService(
     private val scoreCalculator = ScoreCalculator()
 
     override fun saveSubjectGrades(command: SaveSubjectGradesCommand) {
-        saveSubjectGrades(command.applicantId, command.schoolSemester, command.subjectGrades)
+        saveSubjectGrades(command.applicantId, command.userId, command.schoolSemester, command.subjectGrades)
     }
 
     override fun saveGedScores(command: SaveGedScoresCommand) {
-        saveGedScores(command.applicantId, command.gedScores)
+        saveGedScores(command.applicantId, command.userId, command.gedScores)
     }
 
     override fun saveAcademicRecord(command: SaveAcademicRecordCommand): AcademicRecordResult {
         val record = saveAcademicRecord(
             applicantId = command.applicantId,
+            userId = command.userId,
             absentCount = command.absentCount,
             earlyLeaveCount = command.earlyLeaveCount,
             lateCount = command.lateCount,
@@ -53,40 +56,42 @@ class EvaluationCommandService(
 
     override fun saveCertificates(command: SaveCertificatesCommand) {
         saveCertificates(
-            command.applicantId,
-            command.isDsmAlgorithmAwarded,
-            command.isProgrammingCertified,
+            applicantId = command.applicantId,
+            userId = command.userId,
+            isDsmAlgorithmAwarded = command.isDsmAlgorithmAwarded,
+            isProgrammingCertified = command.isProgrammingCertified,
         )
     }
 
     override fun calculateResult(command: CalculateEvaluationCommand): EvaluationResult {
-        return EvaluationResult(calculateResult(command.applicantId))
+        return EvaluationResult(calculateResult(command.applicantId, command.userId))
     }
 
     fun saveSubjectGrades(
         applicantId: Long,
+        userId: Long? = null,
         schoolSemester: SchoolSemester,
         subjectGrades: SubjectGrades,
     ) {
-        val applicant = getApplicant(applicantId)
+        val applicant = getApplicant(applicantId, userId)
+        require(applicant.graduationType != GraduationType.GED) {
+            "subject grades are unavailable for GED applicants"
+        }
         val record = getOrCreateAcademicRecord(applicant)
+        record.gedScores = null
         record.subjectGrades[schoolSemester] = subjectGrades
         applicant.academicRecord = record
         applicant.touch()
         applicantRepository.save(applicant)
     }
 
-    fun saveGedScores(applicantId: Long, gedScores: GedScores) {
-        validateScore(gedScores.koreanScore)
-        validateScore(gedScores.mathScore)
-        validateScore(gedScores.englishScore)
-        validateScore(gedScores.scienceScore)
-        validateScore(gedScores.societyScore)
-        validateScore(gedScores.technologyScore)
-        validateScore(gedScores.historyScore)
-
-        val applicant = getApplicant(applicantId)
+    fun saveGedScores(applicantId: Long, userId: Long? = null, gedScores: GedScores) {
+        val applicant = getApplicant(applicantId, userId)
+        require(applicant.graduationType == GraduationType.GED) {
+            "GED scores are available only for GED applicants"
+        }
         val record = getOrCreateAcademicRecord(applicant)
+        record.subjectGrades.clear()
         record.gedScores = gedScores
         applicant.academicRecord = record
         applicant.touch()
@@ -95,6 +100,7 @@ class EvaluationCommandService(
 
     fun saveAcademicRecord(
         applicantId: Long,
+        userId: Long? = null,
         absentCount: Int,
         earlyLeaveCount: Int,
         lateCount: Int,
@@ -107,7 +113,7 @@ class EvaluationCommandService(
         require(classAbsenceCount >= 0) { "classAbsenceCount must be greater than or equal to 0" }
         require(volunteerTime >= 0) { "volunteerTime must be greater than or equal to 0" }
 
-        val applicant = getApplicant(applicantId)
+        val applicant = getApplicant(applicantId, userId)
         val record = getOrCreateAcademicRecord(applicant)
         record.absentCount = absentCount
         record.earlyLeaveCount = earlyLeaveCount
@@ -122,10 +128,11 @@ class EvaluationCommandService(
 
     fun saveCertificates(
         applicantId: Long,
+        userId: Long? = null,
         isDsmAlgorithmAwarded: Boolean,
         isProgrammingCertified: Boolean,
     ) {
-        val applicant = getApplicant(applicantId)
+        val applicant = getApplicant(applicantId, userId)
         val record = getOrCreateAcademicRecord(applicant)
         record.isDsmAlgorithmAwarded = isDsmAlgorithmAwarded
         record.isProgrammingCertified = isProgrammingCertified
@@ -134,25 +141,29 @@ class EvaluationCommandService(
         applicantRepository.save(applicant)
     }
 
-    fun calculateResult(applicantId: Long): Map<String, Double> {
-        val applicant = getApplicant(applicantId)
+    fun calculateResult(applicantId: Long, userId: Long? = null): Map<String, Double> {
+        val applicant = getApplicant(applicantId, userId)
+        val admissionType = requireNotNull(applicant.admissionType) {
+            "admissionType is required"
+        }
         val result = scoreCalculator.calculate(applicant)
-        applicant.totalScore = result["REGULAR"]
+        applicant.totalScore = result.getValue(admissionType)
         applicant.totalScoreUpdatedAt = LocalDateTime.now()
+        applicant.touch()
         applicantRepository.save(applicant)
-        return result
+        return result.mapKeys { it.key.name }
     }
 
-    private fun getApplicant(applicantId: Long): Applicant {
-        return applicantRepository.findById(applicantId)
+    private fun getApplicant(applicantId: Long, userId: Long? = null): Applicant {
+        val applicant = applicantRepository.findById(applicantId)
             ?: throw ApplicantNotFoundException(applicantId)
+        if (userId != null && applicant.accountId != userId) {
+            throw ApplicantAccessDeniedException(applicantId)
+        }
+        return applicant
     }
 
     private fun getOrCreateAcademicRecord(applicant: Applicant): AcademicRecord {
         return applicant.academicRecord ?: AcademicRecord()
-    }
-
-    private fun validateScore(score: Int) {
-        require(score in 0..100) { "score must be between 0 and 100" }
     }
 }

--- a/systems/application/application-application/src/main/kotlin/hs/kr/entrydsm/application/application/service/EvaluationCommandService.kt
+++ b/systems/application/application-application/src/main/kotlin/hs/kr/entrydsm/application/application/service/EvaluationCommandService.kt
@@ -21,9 +21,8 @@ import java.time.LocalDateTime
 
 class EvaluationCommandService(
     private val applicantRepository: ApplicantRepository,
+    private val scoreCalculator: ScoreCalculator,
 ) : EvaluationPort {
-    private val scoreCalculator = ScoreCalculator()
-
     override fun saveSubjectGrades(command: SaveSubjectGradesCommand) {
         saveSubjectGrades(command.userId, command.schoolSemester, command.subjectGrades)
     }

--- a/systems/application/application-application/src/main/kotlin/hs/kr/entrydsm/application/application/service/EvaluationCommandService.kt
+++ b/systems/application/application-application/src/main/kotlin/hs/kr/entrydsm/application/application/service/EvaluationCommandService.kt
@@ -18,9 +18,7 @@ import hs.kr.entrydsm.application.domain.model.GedScores
 import hs.kr.entrydsm.application.domain.model.SubjectGrades
 import hs.kr.entrydsm.application.domain.service.ScoreCalculator
 import java.time.LocalDateTime
-import org.springframework.stereotype.Service
 
-@Service
 class EvaluationCommandService(
     private val applicantRepository: ApplicantRepository,
 ) : EvaluationPort {

--- a/systems/application/application-application/src/main/kotlin/hs/kr/entrydsm/application/application/service/EvaluationCommandService.kt
+++ b/systems/application/application-application/src/main/kotlin/hs/kr/entrydsm/application/application/service/EvaluationCommandService.kt
@@ -1,0 +1,158 @@
+package hs.kr.entrydsm.application.application.service
+
+import hs.kr.entrydsm.application.application.exception.ApplicantNotFoundException
+import hs.kr.entrydsm.application.application.port.`in`.EvaluationPort
+import hs.kr.entrydsm.application.application.port.`in`.command.CalculateEvaluationCommand
+import hs.kr.entrydsm.application.application.port.`in`.command.SaveAcademicRecordCommand
+import hs.kr.entrydsm.application.application.port.`in`.command.SaveCertificatesCommand
+import hs.kr.entrydsm.application.application.port.`in`.command.SaveGedScoresCommand
+import hs.kr.entrydsm.application.application.port.`in`.command.SaveSubjectGradesCommand
+import hs.kr.entrydsm.application.application.port.`in`.result.AcademicRecordResult
+import hs.kr.entrydsm.application.application.port.`in`.result.EvaluationResult
+import hs.kr.entrydsm.application.application.port.out.ApplicantRepository
+import hs.kr.entrydsm.application.domain.enum.SchoolSemester
+import hs.kr.entrydsm.application.domain.model.AcademicRecord
+import hs.kr.entrydsm.application.domain.model.Applicant
+import hs.kr.entrydsm.application.domain.model.GedScores
+import hs.kr.entrydsm.application.domain.model.SubjectGrades
+import hs.kr.entrydsm.application.domain.service.ScoreCalculator
+import java.time.LocalDateTime
+import org.springframework.stereotype.Service
+
+@Service
+class EvaluationCommandService(
+    private val applicantRepository: ApplicantRepository,
+) : EvaluationPort {
+    private val scoreCalculator = ScoreCalculator()
+
+    override fun saveSubjectGrades(command: SaveSubjectGradesCommand) {
+        saveSubjectGrades(command.applicantId, command.schoolSemester, command.subjectGrades)
+    }
+
+    override fun saveGedScores(command: SaveGedScoresCommand) {
+        saveGedScores(command.applicantId, command.gedScores)
+    }
+
+    override fun saveAcademicRecord(command: SaveAcademicRecordCommand): AcademicRecordResult {
+        val record = saveAcademicRecord(
+            applicantId = command.applicantId,
+            absentCount = command.absentCount,
+            earlyLeaveCount = command.earlyLeaveCount,
+            lateCount = command.lateCount,
+            classAbsenceCount = command.classAbsenceCount,
+            volunteerTime = command.volunteerTime,
+        )
+        return AcademicRecordResult(
+            absentCount = record.absentCount,
+            earlyLeaveCount = record.earlyLeaveCount,
+            lateCount = record.lateCount,
+            classAbsenceCount = record.classAbsenceCount,
+            volunteerTime = record.volunteerTime,
+        )
+    }
+
+    override fun saveCertificates(command: SaveCertificatesCommand) {
+        saveCertificates(
+            command.applicantId,
+            command.isDsmAlgorithmAwarded,
+            command.isProgrammingCertified,
+        )
+    }
+
+    override fun calculateResult(command: CalculateEvaluationCommand): EvaluationResult {
+        return EvaluationResult(calculateResult(command.applicantId))
+    }
+
+    fun saveSubjectGrades(
+        applicantId: Long,
+        schoolSemester: SchoolSemester,
+        subjectGrades: SubjectGrades,
+    ) {
+        val applicant = getApplicant(applicantId)
+        val record = getOrCreateAcademicRecord(applicant)
+        record.subjectGrades[schoolSemester] = subjectGrades
+        applicant.academicRecord = record
+        applicant.touch()
+        applicantRepository.save(applicant)
+    }
+
+    fun saveGedScores(applicantId: Long, gedScores: GedScores) {
+        validateScore(gedScores.koreanScore)
+        validateScore(gedScores.mathScore)
+        validateScore(gedScores.englishScore)
+        validateScore(gedScores.scienceScore)
+        validateScore(gedScores.societyScore)
+        validateScore(gedScores.technologyScore)
+        validateScore(gedScores.historyScore)
+
+        val applicant = getApplicant(applicantId)
+        val record = getOrCreateAcademicRecord(applicant)
+        record.gedScores = gedScores
+        applicant.academicRecord = record
+        applicant.touch()
+        applicantRepository.save(applicant)
+    }
+
+    fun saveAcademicRecord(
+        applicantId: Long,
+        absentCount: Int,
+        earlyLeaveCount: Int,
+        lateCount: Int,
+        classAbsenceCount: Int,
+        volunteerTime: Int,
+    ): AcademicRecord {
+        require(absentCount >= 0) { "absentCount must be greater than or equal to 0" }
+        require(earlyLeaveCount >= 0) { "earlyLeaveCount must be greater than or equal to 0" }
+        require(lateCount >= 0) { "lateCount must be greater than or equal to 0" }
+        require(classAbsenceCount >= 0) { "classAbsenceCount must be greater than or equal to 0" }
+        require(volunteerTime >= 0) { "volunteerTime must be greater than or equal to 0" }
+
+        val applicant = getApplicant(applicantId)
+        val record = getOrCreateAcademicRecord(applicant)
+        record.absentCount = absentCount
+        record.earlyLeaveCount = earlyLeaveCount
+        record.lateCount = lateCount
+        record.classAbsenceCount = classAbsenceCount
+        record.volunteerTime = volunteerTime
+        applicant.academicRecord = record
+        applicant.touch()
+        applicantRepository.save(applicant)
+        return record
+    }
+
+    fun saveCertificates(
+        applicantId: Long,
+        isDsmAlgorithmAwarded: Boolean,
+        isProgrammingCertified: Boolean,
+    ) {
+        val applicant = getApplicant(applicantId)
+        val record = getOrCreateAcademicRecord(applicant)
+        record.isDsmAlgorithmAwarded = isDsmAlgorithmAwarded
+        record.isProgrammingCertified = isProgrammingCertified
+        applicant.academicRecord = record
+        applicant.touch()
+        applicantRepository.save(applicant)
+    }
+
+    fun calculateResult(applicantId: Long): Map<String, Double> {
+        val applicant = getApplicant(applicantId)
+        val result = scoreCalculator.calculate(applicant)
+        applicant.totalScore = result["REGULAR"]
+        applicant.totalScoreUpdatedAt = LocalDateTime.now()
+        applicantRepository.save(applicant)
+        return result
+    }
+
+    private fun getApplicant(applicantId: Long): Applicant {
+        return applicantRepository.findById(applicantId)
+            ?: throw ApplicantNotFoundException(applicantId)
+    }
+
+    private fun getOrCreateAcademicRecord(applicant: Applicant): AcademicRecord {
+        return applicant.academicRecord ?: AcademicRecord()
+    }
+
+    private fun validateScore(score: Int) {
+        require(score in 0..100) { "score must be between 0 and 100" }
+    }
+}

--- a/systems/application/application-domain/BUILD.bazel
+++ b/systems/application/application-domain/BUILD.bazel
@@ -17,5 +17,5 @@ kt_jvm_test(
     javac_opts = "//:javac_options",
     kotlinc_opts = "//:kotlinc_options",
     test_class = "hs.kr.entrydsm.application.domain.ApplicationDomainModuleTest",
-    deps = MODULE_DEPS + TEST_DEPS,
+    deps = [":main"] + MODULE_DEPS + TEST_DEPS,
 )

--- a/systems/application/application-domain/src/main/kotlin/hs/kr/entrydsm/application/domain/enum/AdmissionType.kt
+++ b/systems/application/application-domain/src/main/kotlin/hs/kr/entrydsm/application/domain/enum/AdmissionType.kt
@@ -1,0 +1,7 @@
+package hs.kr.entrydsm.application.domain.enum
+
+enum class AdmissionType {
+    REGULAR,
+    MEISTER,
+    SOCIAL,
+}

--- a/systems/application/application-domain/src/main/kotlin/hs/kr/entrydsm/application/domain/enum/Gender.kt
+++ b/systems/application/application-domain/src/main/kotlin/hs/kr/entrydsm/application/domain/enum/Gender.kt
@@ -1,0 +1,7 @@
+package hs.kr.entrydsm.application.domain.enum
+
+enum class Gender {
+    MALE,
+    FEMALE,
+}
+

--- a/systems/application/application-domain/src/main/kotlin/hs/kr/entrydsm/application/domain/enum/GraduationType.kt
+++ b/systems/application/application-domain/src/main/kotlin/hs/kr/entrydsm/application/domain/enum/GraduationType.kt
@@ -1,0 +1,7 @@
+package hs.kr.entrydsm.application.domain.enum
+
+enum class GraduationType {
+    PROSPECTIVE,
+    GRADUATED,
+    GED,
+}

--- a/systems/application/application-domain/src/main/kotlin/hs/kr/entrydsm/application/domain/enum/GuardianRelation.kt
+++ b/systems/application/application-domain/src/main/kotlin/hs/kr/entrydsm/application/domain/enum/GuardianRelation.kt
@@ -1,0 +1,8 @@
+package hs.kr.entrydsm.application.domain.enum
+
+enum class GuardianRelation {
+    FATHER,
+    MOTHER,
+    OTHER,
+}
+

--- a/systems/application/application-domain/src/main/kotlin/hs/kr/entrydsm/application/domain/enum/PassResultStatus.kt
+++ b/systems/application/application-domain/src/main/kotlin/hs/kr/entrydsm/application/domain/enum/PassResultStatus.kt
@@ -1,0 +1,7 @@
+package hs.kr.entrydsm.application.domain.enum
+
+enum class PassResultStatus {
+    PASS,
+    FAIL,
+    PENDING,
+}

--- a/systems/application/application-domain/src/main/kotlin/hs/kr/entrydsm/application/domain/enum/Region.kt
+++ b/systems/application/application-domain/src/main/kotlin/hs/kr/entrydsm/application/domain/enum/Region.kt
@@ -1,0 +1,6 @@
+package hs.kr.entrydsm.application.domain.enum
+
+enum class Region {
+    DAEJEON,
+    NATIONAL,
+}

--- a/systems/application/application-domain/src/main/kotlin/hs/kr/entrydsm/application/domain/enum/ResultType.kt
+++ b/systems/application/application-domain/src/main/kotlin/hs/kr/entrydsm/application/domain/enum/ResultType.kt
@@ -1,0 +1,6 @@
+package hs.kr.entrydsm.application.domain.enum
+
+enum class ResultType {
+    DOCUMENT,
+    FINAL,
+}

--- a/systems/application/application-domain/src/main/kotlin/hs/kr/entrydsm/application/domain/enum/SchoolSemester.kt
+++ b/systems/application/application-domain/src/main/kotlin/hs/kr/entrydsm/application/domain/enum/SchoolSemester.kt
@@ -1,0 +1,9 @@
+package hs.kr.entrydsm.application.domain.enum
+
+enum class SchoolSemester {
+    SECOND_GRADE_FIRST_SEMESTER,
+    SECOND_GRADE_SECOND_SEMESTER,
+    THIRD_GRADE_FIRST_SEMESTER,
+    THIRD_GRADE_SECOND_SEMESTER,
+}
+

--- a/systems/application/application-domain/src/main/kotlin/hs/kr/entrydsm/application/domain/enum/SpecialAdmissionType.kt
+++ b/systems/application/application-domain/src/main/kotlin/hs/kr/entrydsm/application/domain/enum/SpecialAdmissionType.kt
@@ -1,0 +1,12 @@
+package hs.kr.entrydsm.application.domain.enum
+
+enum class SpecialAdmissionType {
+    NONE,
+    NATIONAL_MERIT,
+    ONE_PARENT,
+    MULTICULTURAL,
+    BASIC_LIVING,
+    NEAR_POVERTY,
+    TEEN_HOUSEHOLDER,
+}
+

--- a/systems/application/application-domain/src/main/kotlin/hs/kr/entrydsm/application/domain/enum/SubjectGrade.kt
+++ b/systems/application/application-domain/src/main/kotlin/hs/kr/entrydsm/application/domain/enum/SubjectGrade.kt
@@ -1,0 +1,11 @@
+package hs.kr.entrydsm.application.domain.enum
+
+enum class SubjectGrade {
+    A,
+    B,
+    C,
+    D,
+    E,
+    X,
+}
+

--- a/systems/application/application-domain/src/main/kotlin/hs/kr/entrydsm/application/domain/model/Applicant.kt
+++ b/systems/application/application-domain/src/main/kotlin/hs/kr/entrydsm/application/domain/model/Applicant.kt
@@ -1,0 +1,86 @@
+package hs.kr.entrydsm.application.domain.model
+
+import hs.kr.entrydsm.application.domain.enum.AdmissionType
+import hs.kr.entrydsm.application.domain.enum.Gender
+import hs.kr.entrydsm.application.domain.enum.GraduationType
+import hs.kr.entrydsm.application.domain.enum.GuardianRelation
+import hs.kr.entrydsm.application.domain.enum.Region
+import hs.kr.entrydsm.application.domain.enum.SchoolSemester
+import hs.kr.entrydsm.application.domain.enum.SpecialAdmissionType
+import hs.kr.entrydsm.application.domain.enum.SubjectGrade
+import java.time.LocalDate
+import java.time.LocalDateTime
+import java.time.YearMonth
+
+data class Applicant(
+    val id: Long,
+    val accountId: Long,
+    var photoFileId: Long? = null,
+    var name: String? = null,
+    var phoneNumber: String? = null,
+    var gender: Gender? = null,
+    var birthdate: LocalDate? = null,
+    var specialAdmissionType: SpecialAdmissionType = SpecialAdmissionType.NONE,
+    var admissionType: AdmissionType? = null,
+    var region: Region? = null,
+    var graduationType: GraduationType? = null,
+    var graduationDate: YearMonth? = null,
+    var guardianName: String? = null,
+    var guardianPhoneNumber: String? = null,
+    var guardianGender: Gender? = null,
+    var guardianRelation: GuardianRelation? = null,
+    var addressBase: String? = null,
+    var addressDetail: String? = null,
+    var zipCode: String? = null,
+    var introduction: String? = null,
+    var studyPlan: String? = null,
+    var middleSchoolInfo: MiddleSchoolInfo? = null,
+    var academicRecord: AcademicRecord? = null,
+    var totalScore: Double? = null,
+    var totalScoreUpdatedAt: LocalDateTime? = null,
+    val createdAt: LocalDateTime = LocalDateTime.now(),
+    var updatedAt: LocalDateTime = LocalDateTime.now(),
+) {
+    fun touch() {
+        updatedAt = LocalDateTime.now()
+    }
+}
+
+data class MiddleSchoolInfo(
+    val schoolName: String,
+    val studentNumber: String,
+    val schoolPhone: String,
+    val teacherName: String,
+)
+
+data class AcademicRecord(
+    var absentCount: Int = 0,
+    var lateCount: Int = 0,
+    var earlyLeaveCount: Int = 0,
+    var classAbsenceCount: Int = 0,
+    var volunteerTime: Int = 0,
+    var isDsmAlgorithmAwarded: Boolean = false,
+    var isProgrammingCertified: Boolean = false,
+    val subjectGrades: MutableMap<SchoolSemester, SubjectGrades> = linkedMapOf(),
+    var gedScores: GedScores? = null,
+)
+
+data class SubjectGrades(
+    val koreanGrade: SubjectGrade,
+    val mathGrade: SubjectGrade,
+    val englishGrade: SubjectGrade,
+    val scienceGrade: SubjectGrade,
+    val societyGrade: SubjectGrade,
+    val technologyGrade: SubjectGrade,
+    val historyGrade: SubjectGrade,
+)
+
+data class GedScores(
+    val koreanScore: Int,
+    val mathScore: Int,
+    val englishScore: Int,
+    val scienceScore: Int,
+    val societyScore: Int,
+    val technologyScore: Int,
+    val historyScore: Int,
+)

--- a/systems/application/application-domain/src/main/kotlin/hs/kr/entrydsm/application/domain/model/Applicant.kt
+++ b/systems/application/application-domain/src/main/kotlin/hs/kr/entrydsm/application/domain/model/Applicant.kt
@@ -63,7 +63,15 @@ data class AcademicRecord(
     var isProgrammingCertified: Boolean = false,
     val subjectGrades: MutableMap<SchoolSemester, SubjectGrades> = linkedMapOf(),
     var gedScores: GedScores? = null,
-)
+) {
+    init {
+        require(absentCount >= 0) { "absentCount must be greater than or equal to 0" }
+        require(lateCount >= 0) { "lateCount must be greater than or equal to 0" }
+        require(earlyLeaveCount >= 0) { "earlyLeaveCount must be greater than or equal to 0" }
+        require(classAbsenceCount >= 0) { "classAbsenceCount must be greater than or equal to 0" }
+        require(volunteerTime >= 0) { "volunteerTime must be greater than or equal to 0" }
+    }
+}
 
 data class SubjectGrades(
     val koreanGrade: SubjectGrade,
@@ -83,4 +91,18 @@ data class GedScores(
     val societyScore: Int,
     val technologyScore: Int,
     val historyScore: Int,
-)
+) {
+    init {
+        listOf(
+            koreanScore,
+            mathScore,
+            englishScore,
+            scienceScore,
+            societyScore,
+            technologyScore,
+            historyScore,
+        ).forEach { score ->
+            require(score in 0..100) { "score must be between 0 and 100" }
+        }
+    }
+}

--- a/systems/application/application-domain/src/main/kotlin/hs/kr/entrydsm/application/domain/service/ScoreCalculator.kt
+++ b/systems/application/application-domain/src/main/kotlin/hs/kr/entrydsm/application/domain/service/ScoreCalculator.kt
@@ -28,8 +28,8 @@ class ScoreCalculator {
             else -> calculateSchoolBaseScore(record, applicant.graduationType)
         }
 
-        val attendanceScore = calculateAttendanceScore(record)
-        val volunteerScore = calculateVolunteerScore(record.volunteerTime)
+        val attendanceScore = calculateAttendanceScore(record, applicant.graduationType)
+        val volunteerScore = calculateVolunteerScore(record.volunteerTime, applicant.graduationType)
         val regularAdditionalScore = calculateRegularAdditionalScore(record)
         val specialAdditionalScore = calculateSpecialAdditionalScore(record)
 
@@ -110,7 +110,14 @@ class ScoreCalculator {
         return if (points.isEmpty()) EMPTY_SCORE else points.average()
     }
 
-    private fun calculateAttendanceScore(record: AcademicRecord): Double {
+    private fun calculateAttendanceScore(
+        record: AcademicRecord,
+        graduationType: GraduationType?,
+    ): Double {
+        if (graduationType == GraduationType.GED) {
+            return EMPTY_SCORE
+        }
+
         val convertedAbsences = record.absentCount + floor(
             (
                 record.lateCount +
@@ -122,7 +129,14 @@ class ScoreCalculator {
         return (ATTENDANCE_MAX_SCORE - convertedAbsences).coerceAtLeast(EMPTY_SCORE)
     }
 
-    private fun calculateVolunteerScore(volunteerTime: Int): Double {
+    private fun calculateVolunteerScore(
+        volunteerTime: Int,
+        graduationType: GraduationType?,
+    ): Double {
+        if (graduationType == GraduationType.GED) {
+            return EMPTY_SCORE
+        }
+
         return volunteerTime.coerceIn(0, VOLUNTEER_MAX_SCORE.toInt()).toDouble()
     }
 

--- a/systems/application/application-domain/src/main/kotlin/hs/kr/entrydsm/application/domain/service/ScoreCalculator.kt
+++ b/systems/application/application-domain/src/main/kotlin/hs/kr/entrydsm/application/domain/service/ScoreCalculator.kt
@@ -1,0 +1,197 @@
+package hs.kr.entrydsm.application.domain.service
+
+import hs.kr.entrydsm.application.domain.enum.GraduationType
+import hs.kr.entrydsm.application.domain.enum.SchoolSemester
+import hs.kr.entrydsm.application.domain.enum.SubjectGrade
+import hs.kr.entrydsm.application.domain.model.AcademicRecord
+import hs.kr.entrydsm.application.domain.model.Applicant
+import hs.kr.entrydsm.application.domain.model.GedScores
+import hs.kr.entrydsm.application.domain.model.SubjectGrades
+import kotlin.math.floor
+import kotlin.math.round
+
+class ScoreCalculator {
+    fun calculate(applicant: Applicant): Map<String, Double> {
+        val record = applicant.academicRecord ?: return mapOf(
+            "REGULAR" to EMPTY_SCORE,
+            "SOCIAL" to EMPTY_SCORE,
+            "MEISTER" to EMPTY_SCORE,
+        )
+
+        val gedScores = record.gedScores
+        val baseSubjectScore = if (gedScores != null) {
+            calculateGedBaseScore(gedScores)
+        } else {
+            calculateSchoolBaseScore(record, applicant.graduationType)
+        }
+
+        val attendanceScore = calculateAttendanceScore(record)
+        val volunteerScore = calculateVolunteerScore(record.volunteerTime)
+        val regularAdditionalScore = calculateRegularAdditionalScore(record)
+        val specialAdditionalScore = calculateSpecialAdditionalScore(record)
+
+        val regularScore = calculateTotalScore(
+            subjectScore = baseSubjectScore * REGULAR_SUBJECT_SCORE_MULTIPLIER,
+            attendanceScore = attendanceScore,
+            volunteerScore = volunteerScore,
+            additionalScore = regularAdditionalScore,
+            maxScore = REGULAR_FIRST_SCREENING_MAX_SCORE,
+        )
+        val specialScore = calculateTotalScore(
+            subjectScore = baseSubjectScore,
+            attendanceScore = attendanceScore,
+            volunteerScore = volunteerScore,
+            additionalScore = specialAdditionalScore,
+            maxScore = SPECIAL_FIRST_SCREENING_MAX_SCORE,
+        )
+
+        return mapOf(
+            "REGULAR" to regularScore,
+            "SOCIAL" to specialScore,
+            "MEISTER" to specialScore,
+        )
+    }
+
+    private fun calculateSchoolBaseScore(
+        record: AcademicRecord,
+        graduationType: GraduationType?,
+    ): Double {
+        if (record.subjectGrades.isEmpty()) {
+            return EMPTY_SCORE
+        }
+
+        val semesterWeights = when (graduationType) {
+            GraduationType.GRADUATED -> GRADUATED_SEMESTER_WEIGHTS
+            else -> PROSPECTIVE_GRADUATION_SEMESTER_WEIGHTS
+        }
+        val weightedScores = semesterWeights.mapNotNull { (semester, weight) ->
+            record.subjectGrades[semester]
+                ?.let(::calculateSemesterAveragePoint)
+                ?.let { averagePoint -> (averagePoint / MAX_GRADE_POINT) * weight to weight }
+        }
+        if (weightedScores.isEmpty()) {
+            return EMPTY_SCORE
+        }
+
+        val earnedScore = weightedScores.sumOf { it.first }
+        val reflectedWeight = weightedScores.sumOf { it.second }
+        return roundToThirdDecimal(earnedScore / reflectedWeight * SPECIAL_SUBJECT_MAX_SCORE)
+    }
+
+    private fun calculateGedBaseScore(scores: GedScores): Double {
+        val average = listOf(
+            scores.koreanScore,
+            scores.mathScore,
+            scores.englishScore,
+            scores.scienceScore,
+            scores.societyScore,
+            scores.technologyScore,
+            scores.historyScore,
+        ).average()
+
+        return roundToThirdDecimal(average / PERFECT_GED_SCORE * SPECIAL_SUBJECT_MAX_SCORE)
+    }
+
+    private fun calculateSemesterAveragePoint(subjectGrades: SubjectGrades): Double {
+        val points = listOf(
+            subjectGrades.koreanGrade,
+            subjectGrades.mathGrade,
+            subjectGrades.englishGrade,
+            subjectGrades.scienceGrade,
+            subjectGrades.societyGrade,
+            subjectGrades.technologyGrade,
+            subjectGrades.historyGrade,
+        ).filterNot { it == SubjectGrade.X }
+            .map(::gradeToPoint)
+
+        return if (points.isEmpty()) EMPTY_SCORE else points.average()
+    }
+
+    private fun calculateAttendanceScore(record: AcademicRecord): Double {
+        val convertedAbsences = record.absentCount + floor(
+            (
+                record.lateCount +
+                    record.earlyLeaveCount +
+                    record.classAbsenceCount
+                ) / ATTENDANCE_CONVERSION_UNIT.toDouble(),
+        ).toInt()
+
+        return (ATTENDANCE_MAX_SCORE - convertedAbsences).coerceAtLeast(EMPTY_SCORE)
+    }
+
+    private fun calculateVolunteerScore(volunteerTime: Int): Double {
+        return volunteerTime.coerceIn(0, VOLUNTEER_MAX_SCORE.toInt()).toDouble()
+    }
+
+    private fun calculateRegularAdditionalScore(record: AcademicRecord): Double {
+        return if (record.isDsmAlgorithmAwarded) DSM_ALGORITHM_AWARD_SCORE else EMPTY_SCORE
+    }
+
+    private fun calculateSpecialAdditionalScore(record: AcademicRecord): Double {
+        var score = EMPTY_SCORE
+        if (record.isDsmAlgorithmAwarded) {
+            score += DSM_ALGORITHM_AWARD_SCORE
+        }
+        if (record.isProgrammingCertified) {
+            score += PROGRAMMING_CERTIFICATE_SCORE
+        }
+        return score.coerceAtMost(SPECIAL_ADDITIONAL_MAX_SCORE)
+    }
+
+    private fun calculateTotalScore(
+        subjectScore: Double,
+        attendanceScore: Double,
+        volunteerScore: Double,
+        additionalScore: Double,
+        maxScore: Double,
+    ): Double {
+        return roundToThirdDecimal(
+            (subjectScore + attendanceScore + volunteerScore + additionalScore)
+                .coerceIn(EMPTY_SCORE, maxScore),
+        )
+    }
+
+    private fun gradeToPoint(grade: SubjectGrade): Double {
+        return when (grade) {
+            SubjectGrade.A -> 5.0
+            SubjectGrade.B -> 4.0
+            SubjectGrade.C -> 3.0
+            SubjectGrade.D -> 2.0
+            SubjectGrade.E -> 1.0
+            SubjectGrade.X -> 0.0
+        }
+    }
+
+    private fun roundToThirdDecimal(score: Double): Double {
+        return round(score * ROUNDING_SCALE) / ROUNDING_SCALE
+    }
+
+    companion object {
+        private const val EMPTY_SCORE = 0.0
+        private const val MAX_GRADE_POINT = 5.0
+        private const val PERFECT_GED_SCORE = 100.0
+        private const val SPECIAL_SUBJECT_MAX_SCORE = 80.0
+        private const val REGULAR_SUBJECT_SCORE_MULTIPLIER = 1.75
+        private const val ATTENDANCE_MAX_SCORE = 15.0
+        private const val ATTENDANCE_CONVERSION_UNIT = 3
+        private const val VOLUNTEER_MAX_SCORE = 15.0
+        private const val DSM_ALGORITHM_AWARD_SCORE = 3.0
+        private const val PROGRAMMING_CERTIFICATE_SCORE = 6.0
+        private const val SPECIAL_ADDITIONAL_MAX_SCORE = 9.0
+        private const val REGULAR_FIRST_SCREENING_MAX_SCORE = 173.0
+        private const val SPECIAL_FIRST_SCREENING_MAX_SCORE = 119.0
+        private const val ROUNDING_SCALE = 1000.0
+
+        private val PROSPECTIVE_GRADUATION_SEMESTER_WEIGHTS = linkedMapOf(
+            SchoolSemester.THIRD_GRADE_FIRST_SEMESTER to 40.0,
+            SchoolSemester.SECOND_GRADE_SECOND_SEMESTER to 20.0,
+            SchoolSemester.SECOND_GRADE_FIRST_SEMESTER to 20.0,
+        )
+        private val GRADUATED_SEMESTER_WEIGHTS = linkedMapOf(
+            SchoolSemester.THIRD_GRADE_SECOND_SEMESTER to 20.0,
+            SchoolSemester.THIRD_GRADE_FIRST_SEMESTER to 20.0,
+            SchoolSemester.SECOND_GRADE_SECOND_SEMESTER to 20.0,
+            SchoolSemester.SECOND_GRADE_FIRST_SEMESTER to 20.0,
+        )
+    }
+}

--- a/systems/application/application-domain/src/main/kotlin/hs/kr/entrydsm/application/domain/service/ScoreCalculator.kt
+++ b/systems/application/application-domain/src/main/kotlin/hs/kr/entrydsm/application/domain/service/ScoreCalculator.kt
@@ -1,5 +1,6 @@
 package hs.kr.entrydsm.application.domain.service
 
+import hs.kr.entrydsm.application.domain.enum.AdmissionType
 import hs.kr.entrydsm.application.domain.enum.GraduationType
 import hs.kr.entrydsm.application.domain.enum.SchoolSemester
 import hs.kr.entrydsm.application.domain.enum.SubjectGrade
@@ -11,18 +12,20 @@ import kotlin.math.floor
 import kotlin.math.round
 
 class ScoreCalculator {
-    fun calculate(applicant: Applicant): Map<String, Double> {
+    fun calculate(applicant: Applicant): Map<AdmissionType, Double> {
         val record = applicant.academicRecord ?: return mapOf(
-            "REGULAR" to EMPTY_SCORE,
-            "SOCIAL" to EMPTY_SCORE,
-            "MEISTER" to EMPTY_SCORE,
+            AdmissionType.REGULAR to EMPTY_SCORE,
+            AdmissionType.SOCIAL to EMPTY_SCORE,
+            AdmissionType.MEISTER to EMPTY_SCORE,
         )
 
-        val gedScores = record.gedScores
-        val baseSubjectScore = if (gedScores != null) {
-            calculateGedBaseScore(gedScores)
-        } else {
-            calculateSchoolBaseScore(record, applicant.graduationType)
+        val baseSubjectScore = when (applicant.graduationType) {
+            GraduationType.GED -> calculateGedBaseScore(
+                requireNotNull(record.gedScores) {
+                    "gedScores is required for GED applicants"
+                },
+            )
+            else -> calculateSchoolBaseScore(record, applicant.graduationType)
         }
 
         val attendanceScore = calculateAttendanceScore(record)
@@ -46,9 +49,9 @@ class ScoreCalculator {
         )
 
         return mapOf(
-            "REGULAR" to regularScore,
-            "SOCIAL" to specialScore,
-            "MEISTER" to specialScore,
+            AdmissionType.REGULAR to regularScore,
+            AdmissionType.SOCIAL to specialScore,
+            AdmissionType.MEISTER to specialScore,
         )
     }
 

--- a/systems/application/application-domain/src/test/kotlin/hs/kr/entrydsm/TestMain.kt
+++ b/systems/application/application-domain/src/test/kotlin/hs/kr/entrydsm/TestMain.kt
@@ -1,11 +1,12 @@
 package hs.kr.entrydsm.application.domain
 
-import org.junit.Assert.assertTrue
-import org.junit.Test
+import hs.kr.entrydsm.application.domain.service.ScoreCalculatorTest
+import org.junit.runner.RunWith
+import org.junit.runners.Suite
 
-class ApplicationDomainModuleTest {
-    @Test
-    fun moduleLoads() {
-        assertTrue(true)
-    }
-}
+@RunWith(Suite::class)
+@Suite.SuiteClasses(
+    ApplicationEnumTest::class,
+    ScoreCalculatorTest::class,
+)
+class ApplicationDomainModuleTest

--- a/systems/application/application-domain/src/test/kotlin/hs/kr/entrydsm/application/domain/ApplicationEnumTest.kt
+++ b/systems/application/application-domain/src/test/kotlin/hs/kr/entrydsm/application/domain/ApplicationEnumTest.kt
@@ -1,0 +1,60 @@
+package hs.kr.entrydsm.application.domain
+
+import hs.kr.entrydsm.application.domain.enum.AdmissionType
+import hs.kr.entrydsm.application.domain.enum.GraduationType
+import hs.kr.entrydsm.application.domain.enum.GuardianRelation
+import hs.kr.entrydsm.application.domain.enum.PassResultStatus
+import hs.kr.entrydsm.application.domain.enum.Region
+import hs.kr.entrydsm.application.domain.enum.ResultType
+import org.junit.Assert.assertEquals
+import org.junit.Test
+
+class ApplicationEnumTest {
+    @Test
+    fun admissionTypeContainsExpectedValues() {
+        assertEquals(
+            listOf("REGULAR", "MEISTER", "SOCIAL"),
+            AdmissionType.entries.map { it.name },
+        )
+    }
+
+    @Test
+    fun graduationTypeContainsExpectedValues() {
+        assertEquals(
+            listOf("PROSPECTIVE", "GRADUATED", "GED"),
+            GraduationType.entries.map { it.name },
+        )
+    }
+
+    @Test
+    fun guardianRelationContainsExpectedValues() {
+        assertEquals(
+            listOf("FATHER", "MOTHER", "OTHER"),
+            GuardianRelation.entries.map { it.name },
+        )
+    }
+
+    @Test
+    fun passResultStatusContainsExpectedValues() {
+        assertEquals(
+            listOf("PASS", "FAIL", "PENDING"),
+            PassResultStatus.entries.map { it.name },
+        )
+    }
+
+    @Test
+    fun regionContainsExpectedValues() {
+        assertEquals(
+            listOf("DAEJEON", "NATIONAL"),
+            Region.entries.map { it.name },
+        )
+    }
+
+    @Test
+    fun resultTypeContainsExpectedValues() {
+        assertEquals(
+            listOf("DOCUMENT", "FINAL"),
+            ResultType.entries.map { it.name },
+        )
+    }
+}

--- a/systems/application/application-domain/src/test/kotlin/hs/kr/entrydsm/application/domain/service/ScoreCalculatorTest.kt
+++ b/systems/application/application-domain/src/test/kotlin/hs/kr/entrydsm/application/domain/service/ScoreCalculatorTest.kt
@@ -1,0 +1,88 @@
+package hs.kr.entrydsm.application.domain.service
+
+import hs.kr.entrydsm.application.domain.enum.AdmissionType
+import hs.kr.entrydsm.application.domain.enum.GraduationType
+import hs.kr.entrydsm.application.domain.enum.SchoolSemester
+import hs.kr.entrydsm.application.domain.enum.SubjectGrade
+import hs.kr.entrydsm.application.domain.model.AcademicRecord
+import hs.kr.entrydsm.application.domain.model.Applicant
+import hs.kr.entrydsm.application.domain.model.GedScores
+import hs.kr.entrydsm.application.domain.model.SubjectGrades
+import org.junit.Assert.assertEquals
+import org.junit.Test
+
+class ScoreCalculatorTest {
+    private val calculator = ScoreCalculator()
+
+    @Test
+    fun calculatesProspectiveApplicantScores() {
+        val applicant = Applicant(
+            id = 1L,
+            accountId = 1L,
+            graduationType = GraduationType.PROSPECTIVE,
+            academicRecord = AcademicRecord(
+                volunteerTime = 20,
+                isDsmAlgorithmAwarded = true,
+                isProgrammingCertified = true,
+                subjectGrades = linkedMapOf(
+                    SchoolSemester.THIRD_GRADE_FIRST_SEMESTER to all(SubjectGrade.A),
+                    SchoolSemester.SECOND_GRADE_SECOND_SEMESTER to all(SubjectGrade.A),
+                    SchoolSemester.SECOND_GRADE_FIRST_SEMESTER to all(SubjectGrade.A),
+                ),
+            ),
+        )
+
+        val result = calculator.calculate(applicant)
+
+        assertEquals(173.0, result.getValue(AdmissionType.REGULAR), 0.0)
+        assertEquals(119.0, result.getValue(AdmissionType.SOCIAL), 0.0)
+        assertEquals(119.0, result.getValue(AdmissionType.MEISTER), 0.0)
+    }
+
+    @Test
+    fun calculatesGedScores() {
+        val applicant = Applicant(
+            id = 1L,
+            accountId = 1L,
+            graduationType = GraduationType.GED,
+            academicRecord = AcademicRecord(
+                volunteerTime = 15,
+                gedScores = GedScores(
+                    koreanScore = 100,
+                    mathScore = 100,
+                    englishScore = 100,
+                    scienceScore = 100,
+                    societyScore = 100,
+                    technologyScore = 100,
+                    historyScore = 100,
+                ),
+            ),
+        )
+
+        val result = calculator.calculate(applicant)
+
+        assertEquals(170.0, result.getValue(AdmissionType.REGULAR), 0.0)
+        assertEquals(110.0, result.getValue(AdmissionType.SOCIAL), 0.0)
+        assertEquals(110.0, result.getValue(AdmissionType.MEISTER), 0.0)
+    }
+
+    @Test
+    fun returnsZeroWhenAcademicRecordDoesNotExist() {
+        val result = calculator.calculate(Applicant(id = 1L, accountId = 1L))
+
+        assertEquals(0.0, result.getValue(AdmissionType.REGULAR), 0.0)
+        assertEquals(0.0, result.getValue(AdmissionType.SOCIAL), 0.0)
+        assertEquals(0.0, result.getValue(AdmissionType.MEISTER), 0.0)
+    }
+
+    private fun all(grade: SubjectGrade): SubjectGrades =
+        SubjectGrades(
+            koreanGrade = grade,
+            mathGrade = grade,
+            englishGrade = grade,
+            scienceGrade = grade,
+            societyGrade = grade,
+            technologyGrade = grade,
+            historyGrade = grade,
+        )
+}

--- a/systems/application/application-domain/src/test/kotlin/hs/kr/entrydsm/application/domain/service/ScoreCalculatorTest.kt
+++ b/systems/application/application-domain/src/test/kotlin/hs/kr/entrydsm/application/domain/service/ScoreCalculatorTest.kt
@@ -46,6 +46,10 @@ class ScoreCalculatorTest {
             accountId = 1L,
             graduationType = GraduationType.GED,
             academicRecord = AcademicRecord(
+                absentCount = 10,
+                lateCount = 6,
+                earlyLeaveCount = 6,
+                classAbsenceCount = 6,
                 volunteerTime = 15,
                 gedScores = GedScores(
                     koreanScore = 100,
@@ -61,9 +65,9 @@ class ScoreCalculatorTest {
 
         val result = calculator.calculate(applicant)
 
-        assertEquals(170.0, result.getValue(AdmissionType.REGULAR), 0.0)
-        assertEquals(110.0, result.getValue(AdmissionType.SOCIAL), 0.0)
-        assertEquals(110.0, result.getValue(AdmissionType.MEISTER), 0.0)
+        assertEquals(140.0, result.getValue(AdmissionType.REGULAR), 0.0)
+        assertEquals(80.0, result.getValue(AdmissionType.SOCIAL), 0.0)
+        assertEquals(80.0, result.getValue(AdmissionType.MEISTER), 0.0)
     }
 
     @Test


### PR DESCRIPTION
## Summary
원서작성 및 성적산출 기능의 공통 domain/application 기반을 구성했습니다.
지원자 모델, 지원 전형/지역/졸업 구분/합격 결과 enum을 추가했습니다.
2027학년도 대덕소프트웨어마이스터고 1차 전형 성적 산출 로직을 도메인 서비스로 구성했습니다.
원서작성과 성적산출 API에서 사용할 input/output port, command/result, application service를 정의했습니다.

## Related Issue
Related to #24 

## Scope
In scope:
- Applicant domain model
- 지원 전형, 지역, 졸업 구분, 합격 결과 관련 enum
- ScoreCalculator
- Application/Evaluation input port
- ApplicantRepository output port
- 원서작성 및 성적산출 application service
- application exception

Out of scope:
- REST controller
- JPA 저장소 구현
- bootstrap 실행 설정
- 실제 DB 연동
- controller/test 구성

## Implementation
Applicant 모델에 지원자 기본 정보, 보호자 정보, 주소, 자기소개서/학업계획서, 성적 정보를 구성했습니다.
ScoreCalculator는 2027학년도 전형 요강 기준으로 내신, 출결, 봉사, 가산점 기반 1차 전형 점수를 계산합니다.
ApplicationService는 지원서 생성, 조회, 수정 흐름을 담당합니다.
EvaluationService는 지원자의 성적 정보를 기반으로 전형별 산출 결과를 반환합니다.
저장소는 ApplicantRepository port로만 정의하고 실제 구현은 후속 PR에서 연결합니다.

## Testing
- Unit test code: 후속 PR에서 추가
- Integration tests: 후속 PR에서 추가
- Manual verification: 후속 PR에서 전체 build/test 수행 예정

## Deployment Notes
Feature flag: 없음  
Migration required: 없음  
Rollout considerations:
- 이 PR은 domain/application 계층만 포함합니다.
- 실제 API 실행과 DB 연동은 후속 PR 병합 이후 가능합니다.

## Checklist
- [x] Matches product/tech requirements
- [x] Backward compatibility considered
- [ ] API success flow verified in a running environment
- [ ] Real persistence adapter connected