### PR TITLE
feat(application): Application REST API 구성 #24

### DIFF
--- a/systems/application/application-adapter-in/BUILD.bazel
+++ b/systems/application/application-adapter-in/BUILD.bazel
@@ -17,5 +17,5 @@ kt_jvm_test(
     javac_opts = "//:javac_options",
     kotlinc_opts = "//:kotlinc_options",
     test_class = "hs.kr.entrydsm.application.adapterin.ApplicationAdapterInModuleTest",
-    deps = MODULE_DEPS + TEST_DEPS,
+    deps = [":main"] + MODULE_DEPS + TEST_DEPS,
 )

--- a/systems/application/application-adapter-in/deps.bzl
+++ b/systems/application/application-adapter-in/deps.bzl
@@ -1,5 +1,6 @@
 KOTLIN_DEPS = [
     "@maven//:org_springframework_boot_spring_boot_starter_web",
+    "@maven//:org_springframework_boot_spring_boot_starter_security",
     "//systems/application/application-application:main",
     "//systems/application/application-domain:main",
 ]

--- a/systems/application/application-adapter-in/deps.bzl
+++ b/systems/application/application-adapter-in/deps.bzl
@@ -1,6 +1,5 @@
 KOTLIN_DEPS = [
     "@maven//:org_springframework_boot_spring_boot_starter_web",
-    "@maven//:org_springframework_boot_spring_boot_starter_security",
     "//systems/application/application-application:main",
     "//systems/application/application-domain:main",
 ]

--- a/systems/application/application-adapter-in/deps.bzl
+++ b/systems/application/application-adapter-in/deps.bzl
@@ -1,4 +1,8 @@
-KOTLIN_DEPS = []
+KOTLIN_DEPS = [
+    "@maven//:org_springframework_boot_spring_boot_starter_web",
+    "//systems/application/application-application:main",
+    "//systems/application/application-domain:main",
+]
 
 TEST_DEPS = [
     "@maven//:junit_junit",

--- a/systems/application/application-adapter-in/src/main/kotlin/hs/kr/entrydsm/application/adapterin/web/ApplicationController.kt
+++ b/systems/application/application-adapter-in/src/main/kotlin/hs/kr/entrydsm/application/adapterin/web/ApplicationController.kt
@@ -28,6 +28,7 @@ import java.time.LocalDate
 import java.time.YearMonth
 import org.springframework.http.HttpHeaders
 import org.springframework.http.HttpStatus
+import org.springframework.security.core.annotation.AuthenticationPrincipal
 import org.springframework.web.bind.annotation.GetMapping
 import org.springframework.web.bind.annotation.PatchMapping
 import org.springframework.web.bind.annotation.PathVariable
@@ -47,8 +48,9 @@ class ApplicationController(
     @GetMapping("/landing")
     fun getLanding(
         @RequestHeader(HttpHeaders.AUTHORIZATION, required = false) authorization: String?,
+        @AuthenticationPrincipal(expression = "userId") userId: Long? = null,
     ): ApiResponse<LandingResponse> {
-        val result = applicationPort.getLanding()
+        val result = applicationPort.getLanding(userId)
         return ApiResponse(data = result.toResponse(landingScheduleProperties))
     }
 
@@ -56,10 +58,15 @@ class ApplicationController(
     @ResponseStatus(HttpStatus.CREATED)
     fun createApplicant(
         @RequestHeader(HttpHeaders.AUTHORIZATION, required = false) authorization: String?,
+        @AuthenticationPrincipal(expression = "userId") userId: Long? = null,
         @RequestBody request: CreateApplicantRequest,
     ): ApiResponse<CreateApplicantResponse> {
         val result = applicationPort.createApplicant(
-            CreateApplicantCommand(accountId = request.accountId),
+            CreateApplicantCommand(
+                authorization = authorization,
+                userId = userId,
+                accountId = request.accountId,
+            ),
         )
         return ApiResponse(data = result.toResponse())
     }
@@ -67,11 +74,14 @@ class ApplicationController(
     @PatchMapping("/{id}/type")
     fun updateType(
         @RequestHeader(HttpHeaders.AUTHORIZATION, required = false) authorization: String?,
+        @AuthenticationPrincipal(expression = "userId") userId: Long? = null,
         @PathVariable id: Long,
         @RequestBody request: UpdateTypeRequest,
     ): ApiResponse<Unit> {
         applicationPort.updateType(
             UpdateTypeCommand(
+                authorization = authorization,
+                userId = userId,
                 applicantId = id,
                 admissionType = request.admissionType,
                 region = request.region,
@@ -84,11 +94,15 @@ class ApplicationController(
 
     @PatchMapping("/{id}/personal")
     fun updatePersonal(
+        @RequestHeader(HttpHeaders.AUTHORIZATION, required = false) authorization: String?,
+        @AuthenticationPrincipal(expression = "userId") userId: Long? = null,
         @PathVariable id: Long,
         @RequestBody request: UpdatePersonalRequest,
     ): ApiResponse<Unit> {
         applicationPort.updatePersonal(
             UpdatePersonalCommand(
+                authorization = authorization,
+                userId = userId,
                 applicantId = id,
                 photoFileId = request.photoFileId,
                 name = request.name,
@@ -104,11 +118,14 @@ class ApplicationController(
     @PatchMapping("/{id}/family")
     fun updateFamily(
         @RequestHeader(HttpHeaders.AUTHORIZATION, required = false) authorization: String?,
+        @AuthenticationPrincipal(expression = "userId") userId: Long? = null,
         @PathVariable id: Long,
         @RequestBody request: UpdateFamilyRequest,
     ): ApiResponse<Unit> {
         applicationPort.updateFamily(
             UpdateFamilyCommand(
+                authorization = authorization,
+                userId = userId,
                 applicantId = id,
                 guardianName = request.guardianName,
                 guardianPhoneNumber = request.guardianPhoneNumber,
@@ -125,11 +142,14 @@ class ApplicationController(
     @PatchMapping("/{id}/middle-school")
     fun updateMiddleSchool(
         @RequestHeader(HttpHeaders.AUTHORIZATION, required = false) authorization: String?,
+        @AuthenticationPrincipal(expression = "userId") userId: Long? = null,
         @PathVariable id: Long,
         @RequestBody request: UpdateMiddleSchoolRequest,
     ): ApiResponse<Unit> {
         applicationPort.updateMiddleSchool(
             UpdateMiddleSchoolCommand(
+                authorization = authorization,
+                userId = userId,
                 applicantId = id,
                 schoolName = request.schoolName,
                 studentNumber = request.studentNumber,
@@ -143,11 +163,17 @@ class ApplicationController(
     @PatchMapping("/{id}/self-introduction")
     fun updateIntroduction(
         @RequestHeader(HttpHeaders.AUTHORIZATION, required = false) authorization: String?,
+        @AuthenticationPrincipal(expression = "userId") userId: Long? = null,
         @PathVariable id: Long,
         @RequestBody request: UpdateIntroductionRequest,
     ): ApiResponse<Unit> {
         applicationPort.updateIntroduction(
-            UpdateIntroductionCommand(id, request.introduction),
+            UpdateIntroductionCommand(
+                authorization = authorization,
+                userId = userId,
+                applicantId = id,
+                introduction = request.introduction,
+            ),
         )
         return ApiResponse(data = null)
     }
@@ -155,20 +181,33 @@ class ApplicationController(
     @PatchMapping("/{id}/study-plan")
     fun updateStudyPlan(
         @RequestHeader(HttpHeaders.AUTHORIZATION, required = false) authorization: String?,
+        @AuthenticationPrincipal(expression = "userId") userId: Long? = null,
         @PathVariable id: Long,
         @RequestBody request: UpdateStudyPlanRequest,
     ): ApiResponse<Unit> {
-        applicationPort.updateStudyPlan(UpdateStudyPlanCommand(id, request.studyPlan))
+        applicationPort.updateStudyPlan(
+            UpdateStudyPlanCommand(
+                authorization = authorization,
+                userId = userId,
+                applicantId = id,
+                studyPlan = request.studyPlan,
+            ),
+        )
         return ApiResponse(data = null)
     }
 
     @PatchMapping
     fun submit(
         @RequestHeader(HttpHeaders.AUTHORIZATION, required = false) authorization: String?,
+        @AuthenticationPrincipal(expression = "userId") userId: Long? = null,
         @RequestBody request: SubmitApplicationRequest,
     ): ApiResponse<Unit> {
         applicationPort.submit(
-            SubmitApplicationCommand(request.applicantId),
+            SubmitApplicationCommand(
+                authorization = authorization,
+                userId = userId,
+                applicantId = request.applicantId,
+            ),
         )
         return ApiResponse(data = null)
     }

--- a/systems/application/application-adapter-in/src/main/kotlin/hs/kr/entrydsm/application/adapterin/web/ApplicationController.kt
+++ b/systems/application/application-adapter-in/src/main/kotlin/hs/kr/entrydsm/application/adapterin/web/ApplicationController.kt
@@ -3,8 +3,6 @@ package hs.kr.entrydsm.application.adapterin.web
 import hs.kr.entrydsm.application.adapterin.web.config.LandingScheduleProperties
 import hs.kr.entrydsm.application.adapterin.web.dto.common.ApiResponse
 import hs.kr.entrydsm.application.adapterin.web.dto.common.toResponse
-import hs.kr.entrydsm.application.adapterin.web.dto.request.CreateApplicantRequest
-import hs.kr.entrydsm.application.adapterin.web.dto.request.SubmitApplicationRequest
 import hs.kr.entrydsm.application.adapterin.web.dto.request.UpdateFamilyRequest
 import hs.kr.entrydsm.application.adapterin.web.dto.request.UpdateIntroductionRequest
 import hs.kr.entrydsm.application.adapterin.web.dto.request.UpdateMiddleSchoolRequest
@@ -59,13 +57,11 @@ class ApplicationController(
     fun createApplicant(
         @RequestHeader(HttpHeaders.AUTHORIZATION, required = false) authorization: String?,
         @AuthenticationPrincipal(expression = "userId") userId: Long? = null,
-        @RequestBody request: CreateApplicantRequest,
     ): ApiResponse<CreateApplicantResponse> {
         val result = applicationPort.createApplicant(
             CreateApplicantCommand(
                 authorization = authorization,
                 userId = userId,
-                accountId = request.accountId,
             ),
         )
         return ApiResponse(data = result.toResponse())
@@ -200,13 +196,11 @@ class ApplicationController(
     fun submit(
         @RequestHeader(HttpHeaders.AUTHORIZATION, required = false) authorization: String?,
         @AuthenticationPrincipal(expression = "userId") userId: Long? = null,
-        @RequestBody request: SubmitApplicationRequest,
     ): ApiResponse<Unit> {
         applicationPort.submit(
             SubmitApplicationCommand(
                 authorization = authorization,
                 userId = userId,
-                applicantId = request.applicantId,
             ),
         )
         return ApiResponse(data = null)

--- a/systems/application/application-adapter-in/src/main/kotlin/hs/kr/entrydsm/application/adapterin/web/ApplicationController.kt
+++ b/systems/application/application-adapter-in/src/main/kotlin/hs/kr/entrydsm/application/adapterin/web/ApplicationController.kt
@@ -24,9 +24,7 @@ import hs.kr.entrydsm.application.domain.enum.GuardianRelation
 import hs.kr.entrydsm.application.domain.enum.SpecialAdmissionType
 import java.time.LocalDate
 import java.time.YearMonth
-import org.springframework.http.HttpHeaders
 import org.springframework.http.HttpStatus
-import org.springframework.security.core.annotation.AuthenticationPrincipal
 import org.springframework.web.bind.annotation.GetMapping
 import org.springframework.web.bind.annotation.PatchMapping
 import org.springframework.web.bind.annotation.PathVariable
@@ -45,8 +43,7 @@ class ApplicationController(
 ) {
     @GetMapping("/landing")
     fun getLanding(
-        @RequestHeader(HttpHeaders.AUTHORIZATION, required = false) authorization: String?,
-        @AuthenticationPrincipal(expression = "userId") userId: Long? = null,
+        @RequestHeader(USER_ID_HEADER, required = false) userId: Long? = null,
     ): ApiResponse<LandingResponse> {
         val result = applicationPort.getLanding(userId)
         return ApiResponse(data = result.toResponse(landingScheduleProperties))
@@ -55,12 +52,10 @@ class ApplicationController(
     @PostMapping
     @ResponseStatus(HttpStatus.CREATED)
     fun createApplicant(
-        @RequestHeader(HttpHeaders.AUTHORIZATION, required = false) authorization: String?,
-        @AuthenticationPrincipal(expression = "userId") userId: Long? = null,
+        @RequestHeader(USER_ID_HEADER, required = false) userId: Long? = null,
     ): ApiResponse<CreateApplicantResponse> {
         val result = applicationPort.createApplicant(
             CreateApplicantCommand(
-                authorization = authorization,
                 userId = userId,
             ),
         )
@@ -69,14 +64,12 @@ class ApplicationController(
 
     @PatchMapping("/{id}/type")
     fun updateType(
-        @RequestHeader(HttpHeaders.AUTHORIZATION, required = false) authorization: String?,
-        @AuthenticationPrincipal(expression = "userId") userId: Long? = null,
+        @RequestHeader(USER_ID_HEADER, required = false) userId: Long? = null,
         @PathVariable id: Long,
         @RequestBody request: UpdateTypeRequest,
     ): ApiResponse<Unit> {
         applicationPort.updateType(
             UpdateTypeCommand(
-                authorization = authorization,
                 userId = userId,
                 applicantId = id,
                 admissionType = request.admissionType,
@@ -90,14 +83,12 @@ class ApplicationController(
 
     @PatchMapping("/{id}/personal")
     fun updatePersonal(
-        @RequestHeader(HttpHeaders.AUTHORIZATION, required = false) authorization: String?,
-        @AuthenticationPrincipal(expression = "userId") userId: Long? = null,
+        @RequestHeader(USER_ID_HEADER, required = false) userId: Long? = null,
         @PathVariable id: Long,
         @RequestBody request: UpdatePersonalRequest,
     ): ApiResponse<Unit> {
         applicationPort.updatePersonal(
             UpdatePersonalCommand(
-                authorization = authorization,
                 userId = userId,
                 applicantId = id,
                 photoFileId = request.photoFileId,
@@ -113,14 +104,12 @@ class ApplicationController(
 
     @PatchMapping("/{id}/family")
     fun updateFamily(
-        @RequestHeader(HttpHeaders.AUTHORIZATION, required = false) authorization: String?,
-        @AuthenticationPrincipal(expression = "userId") userId: Long? = null,
+        @RequestHeader(USER_ID_HEADER, required = false) userId: Long? = null,
         @PathVariable id: Long,
         @RequestBody request: UpdateFamilyRequest,
     ): ApiResponse<Unit> {
         applicationPort.updateFamily(
             UpdateFamilyCommand(
-                authorization = authorization,
                 userId = userId,
                 applicantId = id,
                 guardianName = request.guardianName,
@@ -137,14 +126,12 @@ class ApplicationController(
 
     @PatchMapping("/{id}/middle-school")
     fun updateMiddleSchool(
-        @RequestHeader(HttpHeaders.AUTHORIZATION, required = false) authorization: String?,
-        @AuthenticationPrincipal(expression = "userId") userId: Long? = null,
+        @RequestHeader(USER_ID_HEADER, required = false) userId: Long? = null,
         @PathVariable id: Long,
         @RequestBody request: UpdateMiddleSchoolRequest,
     ): ApiResponse<Unit> {
         applicationPort.updateMiddleSchool(
             UpdateMiddleSchoolCommand(
-                authorization = authorization,
                 userId = userId,
                 applicantId = id,
                 schoolName = request.schoolName,
@@ -158,14 +145,12 @@ class ApplicationController(
 
     @PatchMapping("/{id}/self-introduction")
     fun updateIntroduction(
-        @RequestHeader(HttpHeaders.AUTHORIZATION, required = false) authorization: String?,
-        @AuthenticationPrincipal(expression = "userId") userId: Long? = null,
+        @RequestHeader(USER_ID_HEADER, required = false) userId: Long? = null,
         @PathVariable id: Long,
         @RequestBody request: UpdateIntroductionRequest,
     ): ApiResponse<Unit> {
         applicationPort.updateIntroduction(
             UpdateIntroductionCommand(
-                authorization = authorization,
                 userId = userId,
                 applicantId = id,
                 introduction = request.introduction,
@@ -176,14 +161,12 @@ class ApplicationController(
 
     @PatchMapping("/{id}/study-plan")
     fun updateStudyPlan(
-        @RequestHeader(HttpHeaders.AUTHORIZATION, required = false) authorization: String?,
-        @AuthenticationPrincipal(expression = "userId") userId: Long? = null,
+        @RequestHeader(USER_ID_HEADER, required = false) userId: Long? = null,
         @PathVariable id: Long,
         @RequestBody request: UpdateStudyPlanRequest,
     ): ApiResponse<Unit> {
         applicationPort.updateStudyPlan(
             UpdateStudyPlanCommand(
-                authorization = authorization,
                 userId = userId,
                 applicantId = id,
                 studyPlan = request.studyPlan,
@@ -194,12 +177,10 @@ class ApplicationController(
 
     @PatchMapping
     fun submit(
-        @RequestHeader(HttpHeaders.AUTHORIZATION, required = false) authorization: String?,
-        @AuthenticationPrincipal(expression = "userId") userId: Long? = null,
+        @RequestHeader(USER_ID_HEADER, required = false) userId: Long? = null,
     ): ApiResponse<Unit> {
         applicationPort.submit(
             SubmitApplicationCommand(
-                authorization = authorization,
                 userId = userId,
             ),
         )
@@ -221,5 +202,9 @@ class ApplicationController(
             "OTHER" -> GuardianRelation.OTHER
             else -> throw IllegalArgumentException("guardianRelation must be FATHER, MOTHER, or OTHER")
         }
+    }
+
+    private companion object {
+        const val USER_ID_HEADER = "user-id"
     }
 }

--- a/systems/application/application-adapter-in/src/main/kotlin/hs/kr/entrydsm/application/adapterin/web/ApplicationController.kt
+++ b/systems/application/application-adapter-in/src/main/kotlin/hs/kr/entrydsm/application/adapterin/web/ApplicationController.kt
@@ -1,0 +1,192 @@
+package hs.kr.entrydsm.application.adapterin.web
+
+import hs.kr.entrydsm.application.adapterin.web.config.LandingScheduleProperties
+import hs.kr.entrydsm.application.adapterin.web.dto.common.ApiResponse
+import hs.kr.entrydsm.application.adapterin.web.dto.common.toResponse
+import hs.kr.entrydsm.application.adapterin.web.dto.request.CreateApplicantRequest
+import hs.kr.entrydsm.application.adapterin.web.dto.request.SubmitApplicationRequest
+import hs.kr.entrydsm.application.adapterin.web.dto.request.UpdateFamilyRequest
+import hs.kr.entrydsm.application.adapterin.web.dto.request.UpdateIntroductionRequest
+import hs.kr.entrydsm.application.adapterin.web.dto.request.UpdateMiddleSchoolRequest
+import hs.kr.entrydsm.application.adapterin.web.dto.request.UpdatePersonalRequest
+import hs.kr.entrydsm.application.adapterin.web.dto.request.UpdateStudyPlanRequest
+import hs.kr.entrydsm.application.adapterin.web.dto.request.UpdateTypeRequest
+import hs.kr.entrydsm.application.adapterin.web.dto.response.CreateApplicantResponse
+import hs.kr.entrydsm.application.adapterin.web.dto.response.LandingResponse
+import hs.kr.entrydsm.application.application.port.`in`.ApplicationPort
+import hs.kr.entrydsm.application.application.port.`in`.command.CreateApplicantCommand
+import hs.kr.entrydsm.application.application.port.`in`.command.SubmitApplicationCommand
+import hs.kr.entrydsm.application.application.port.`in`.command.UpdateFamilyCommand
+import hs.kr.entrydsm.application.application.port.`in`.command.UpdateIntroductionCommand
+import hs.kr.entrydsm.application.application.port.`in`.command.UpdateMiddleSchoolCommand
+import hs.kr.entrydsm.application.application.port.`in`.command.UpdatePersonalCommand
+import hs.kr.entrydsm.application.application.port.`in`.command.UpdateStudyPlanCommand
+import hs.kr.entrydsm.application.application.port.`in`.command.UpdateTypeCommand
+import hs.kr.entrydsm.application.domain.enum.GuardianRelation
+import hs.kr.entrydsm.application.domain.enum.SpecialAdmissionType
+import java.time.LocalDate
+import java.time.YearMonth
+import org.springframework.http.HttpHeaders
+import org.springframework.http.HttpStatus
+import org.springframework.web.bind.annotation.GetMapping
+import org.springframework.web.bind.annotation.PatchMapping
+import org.springframework.web.bind.annotation.PathVariable
+import org.springframework.web.bind.annotation.PostMapping
+import org.springframework.web.bind.annotation.RequestBody
+import org.springframework.web.bind.annotation.RequestHeader
+import org.springframework.web.bind.annotation.RequestMapping
+import org.springframework.web.bind.annotation.ResponseStatus
+import org.springframework.web.bind.annotation.RestController
+
+@RestController
+@RequestMapping("/api/application/v11/applicants")
+class ApplicationController(
+    private val applicationPort: ApplicationPort,
+    private val landingScheduleProperties: LandingScheduleProperties,
+) {
+    @GetMapping("/landing")
+    fun getLanding(
+        @RequestHeader(HttpHeaders.AUTHORIZATION, required = false) authorization: String?,
+    ): ApiResponse<LandingResponse> {
+        val result = applicationPort.getLanding()
+        return ApiResponse(data = result.toResponse(landingScheduleProperties))
+    }
+
+    @PostMapping
+    @ResponseStatus(HttpStatus.CREATED)
+    fun createApplicant(
+        @RequestHeader(HttpHeaders.AUTHORIZATION, required = false) authorization: String?,
+        @RequestBody request: CreateApplicantRequest,
+    ): ApiResponse<CreateApplicantResponse> {
+        val result = applicationPort.createApplicant(
+            CreateApplicantCommand(accountId = request.accountId),
+        )
+        return ApiResponse(data = result.toResponse())
+    }
+
+    @PatchMapping("/{id}/type")
+    fun updateType(
+        @RequestHeader(HttpHeaders.AUTHORIZATION, required = false) authorization: String?,
+        @PathVariable id: Long,
+        @RequestBody request: UpdateTypeRequest,
+    ): ApiResponse<Unit> {
+        applicationPort.updateType(
+            UpdateTypeCommand(
+                applicantId = id,
+                admissionType = request.admissionType,
+                region = request.region,
+                graduationType = request.graduationType,
+                graduationDate = request.graduationDate?.let(YearMonth::parse),
+            ),
+        )
+        return ApiResponse(data = null)
+    }
+
+    @PatchMapping("/{id}/personal")
+    fun updatePersonal(
+        @PathVariable id: Long,
+        @RequestBody request: UpdatePersonalRequest,
+    ): ApiResponse<Unit> {
+        applicationPort.updatePersonal(
+            UpdatePersonalCommand(
+                applicantId = id,
+                photoFileId = request.photoFileId,
+                name = request.name,
+                phoneNumber = request.phoneNumber,
+                gender = request.gender,
+                birthdate = parseDate(request.birthdate),
+                specialAdmissionType = request.specialAdmissionType ?: SpecialAdmissionType.NONE,
+            ),
+        )
+        return ApiResponse(data = null)
+    }
+
+    @PatchMapping("/{id}/family")
+    fun updateFamily(
+        @RequestHeader(HttpHeaders.AUTHORIZATION, required = false) authorization: String?,
+        @PathVariable id: Long,
+        @RequestBody request: UpdateFamilyRequest,
+    ): ApiResponse<Unit> {
+        applicationPort.updateFamily(
+            UpdateFamilyCommand(
+                applicantId = id,
+                guardianName = request.guardianName,
+                guardianPhoneNumber = request.guardianPhoneNumber,
+                guardianGender = request.guardianGender,
+                guardianRelation = request.guardianRelation.toGuardianRelation(),
+                zipCode = request.address.zipCode,
+                addressBase = request.address.addressBase,
+                addressDetail = request.address.addressDetail,
+            ),
+        )
+        return ApiResponse(data = null)
+    }
+
+    @PatchMapping("/{id}/middle-school")
+    fun updateMiddleSchool(
+        @RequestHeader(HttpHeaders.AUTHORIZATION, required = false) authorization: String?,
+        @PathVariable id: Long,
+        @RequestBody request: UpdateMiddleSchoolRequest,
+    ): ApiResponse<Unit> {
+        applicationPort.updateMiddleSchool(
+            UpdateMiddleSchoolCommand(
+                applicantId = id,
+                schoolName = request.schoolName,
+                studentNumber = request.studentNumber,
+                schoolPhone = request.schoolPhone,
+                teacherName = request.teacherName,
+            ),
+        )
+        return ApiResponse(data = null)
+    }
+
+    @PatchMapping("/{id}/self-introduction")
+    fun updateIntroduction(
+        @RequestHeader(HttpHeaders.AUTHORIZATION, required = false) authorization: String?,
+        @PathVariable id: Long,
+        @RequestBody request: UpdateIntroductionRequest,
+    ): ApiResponse<Unit> {
+        applicationPort.updateIntroduction(
+            UpdateIntroductionCommand(id, request.introduction),
+        )
+        return ApiResponse(data = null)
+    }
+
+    @PatchMapping("/{id}/study-plan")
+    fun updateStudyPlan(
+        @RequestHeader(HttpHeaders.AUTHORIZATION, required = false) authorization: String?,
+        @PathVariable id: Long,
+        @RequestBody request: UpdateStudyPlanRequest,
+    ): ApiResponse<Unit> {
+        applicationPort.updateStudyPlan(UpdateStudyPlanCommand(id, request.studyPlan))
+        return ApiResponse(data = null)
+    }
+
+    @PatchMapping
+    fun submit(
+        @RequestHeader(HttpHeaders.AUTHORIZATION, required = false) authorization: String?,
+        @RequestBody request: SubmitApplicationRequest,
+    ): ApiResponse<Unit> {
+        applicationPort.submit(
+            SubmitApplicationCommand(request.applicantId),
+        )
+        return ApiResponse(data = null)
+    }
+
+    private fun parseDate(value: String): LocalDate {
+        return if (value.length == 7) {
+            YearMonth.parse(value).atDay(1)
+        } else {
+            LocalDate.parse(value)
+        }
+    }
+
+    private fun String.toGuardianRelation(): GuardianRelation {
+        return when (uppercase()) {
+            "FATHER", "FATHER_RELATION" -> GuardianRelation.FATHER
+            "MOTHER", "MOTHER_RELATION" -> GuardianRelation.MOTHER
+            "OTHER" -> GuardianRelation.OTHER
+            else -> throw IllegalArgumentException("guardianRelation must be FATHER, MOTHER, or OTHER")
+        }
+    }
+}

--- a/systems/application/application-adapter-in/src/main/kotlin/hs/kr/entrydsm/application/adapterin/web/EvaluationController.kt
+++ b/systems/application/application-adapter-in/src/main/kotlin/hs/kr/entrydsm/application/adapterin/web/EvaluationController.kt
@@ -15,8 +15,6 @@ import hs.kr.entrydsm.application.application.port.`in`.command.SaveGedScoresCom
 import hs.kr.entrydsm.application.application.port.`in`.command.SaveSubjectGradesCommand
 import hs.kr.entrydsm.application.domain.enum.SchoolSemester
 import hs.kr.entrydsm.application.domain.model.GedScores
-import org.springframework.http.HttpHeaders
-import org.springframework.security.core.annotation.AuthenticationPrincipal
 import org.springframework.web.bind.annotation.PostMapping
 import org.springframework.web.bind.annotation.RequestBody
 import org.springframework.web.bind.annotation.RequestHeader
@@ -30,33 +28,29 @@ class EvaluationController(
 ) {
     @PostMapping("/grades/expected")
     fun saveExpectedGrades(
-        @RequestHeader(HttpHeaders.AUTHORIZATION, required = false) authorization: String?,
-        @AuthenticationPrincipal(expression = "userId") userId: Long? = null,
+        @RequestHeader(USER_ID_HEADER, required = false) userId: Long? = null,
         @RequestBody request: SaveSubjectGradesRequest,
     ): ApiResponse<Unit> {
-        saveSubjectGrades(authorization, userId, request)
+        saveSubjectGrades(userId, request)
         return ApiResponse(data = null)
     }
 
     @PostMapping("/grades/graduated")
     fun saveGraduatedGrades(
-        @RequestHeader(HttpHeaders.AUTHORIZATION, required = false) authorization: String?,
-        @AuthenticationPrincipal(expression = "userId") userId: Long? = null,
+        @RequestHeader(USER_ID_HEADER, required = false) userId: Long? = null,
         @RequestBody request: SaveSubjectGradesRequest,
     ): ApiResponse<Unit> {
-        saveSubjectGrades(authorization, userId, request)
+        saveSubjectGrades(userId, request)
         return ApiResponse(data = null)
     }
 
     @PostMapping("/ged-scores")
     fun saveGedScores(
-        @RequestHeader(HttpHeaders.AUTHORIZATION, required = false) authorization: String?,
-        @AuthenticationPrincipal(expression = "userId") userId: Long? = null,
+        @RequestHeader(USER_ID_HEADER, required = false) userId: Long? = null,
         @RequestBody request: SaveGedScoresRequest,
     ): ApiResponse<Unit> {
         evaluationPort.saveGedScores(
             SaveGedScoresCommand(
-                authorization = authorization,
                 userId = userId,
                 gedScores = GedScores(
                     koreanScore = request.koreanScore,
@@ -74,13 +68,11 @@ class EvaluationController(
 
     @PostMapping("/academic-records")
     fun saveAcademicRecords(
-        @RequestHeader(HttpHeaders.AUTHORIZATION, required = false) authorization: String?,
-        @AuthenticationPrincipal(expression = "userId") userId: Long? = null,
+        @RequestHeader(USER_ID_HEADER, required = false) userId: Long? = null,
         @RequestBody request: SaveAcademicRecordRequest,
     ): ApiResponse<AcademicRecordResponse> {
         val result = evaluationPort.saveAcademicRecord(
             SaveAcademicRecordCommand(
-                authorization = authorization,
                 userId = userId,
                 absentCount = request.absentCount,
                 earlyLeaveCount = request.earlyLeaveCount,
@@ -94,13 +86,11 @@ class EvaluationController(
 
     @PostMapping("/certificates")
     fun saveCertificates(
-        @RequestHeader(HttpHeaders.AUTHORIZATION, required = false) authorization: String?,
-        @AuthenticationPrincipal(expression = "userId") userId: Long? = null,
+        @RequestHeader(USER_ID_HEADER, required = false) userId: Long? = null,
         @RequestBody request: SaveCertificatesRequest,
     ): ApiResponse<Unit> {
         evaluationPort.saveCertificates(
             SaveCertificatesCommand(
-                authorization = authorization,
                 userId = userId,
                 isDsmAlgorithmAwarded = request.isDsmAlgorithmAwarded,
                 isProgrammingCertified = request.isProgrammingCertified,
@@ -111,12 +101,10 @@ class EvaluationController(
 
     @PostMapping("/result")
     fun getResult(
-        @RequestHeader(HttpHeaders.AUTHORIZATION, required = false) authorization: String?,
-        @AuthenticationPrincipal(expression = "userId") userId: Long? = null,
+        @RequestHeader(USER_ID_HEADER, required = false) userId: Long? = null,
     ): ApiResponse<Unit> {
         evaluationPort.calculateResult(
             CalculateEvaluationCommand(
-                authorization = authorization,
                 userId = userId,
             ),
         )
@@ -124,18 +112,20 @@ class EvaluationController(
     }
 
     private fun saveSubjectGrades(
-        authorization: String?,
         userId: Long?,
         request: SaveSubjectGradesRequest,
     ) {
         evaluationPort.saveSubjectGrades(
             SaveSubjectGradesCommand(
-                authorization = authorization,
                 userId = userId,
                 schoolSemester = request.schoolSemester.toSchoolSemester(),
                 subjectGrades = request.subjects.toDomain(),
             ),
         )
+    }
+
+    private companion object {
+        const val USER_ID_HEADER = "user-id"
     }
 }
 

--- a/systems/application/application-adapter-in/src/main/kotlin/hs/kr/entrydsm/application/adapterin/web/EvaluationController.kt
+++ b/systems/application/application-adapter-in/src/main/kotlin/hs/kr/entrydsm/application/adapterin/web/EvaluationController.kt
@@ -1,0 +1,126 @@
+package hs.kr.entrydsm.application.adapterin.web
+
+import hs.kr.entrydsm.application.adapterin.web.dto.common.ApiResponse
+import hs.kr.entrydsm.application.adapterin.web.dto.common.toResponse
+import hs.kr.entrydsm.application.adapterin.web.dto.request.SaveAcademicRecordRequest
+import hs.kr.entrydsm.application.adapterin.web.dto.request.SaveCertificatesRequest
+import hs.kr.entrydsm.application.adapterin.web.dto.request.SaveGedScoresRequest
+import hs.kr.entrydsm.application.adapterin.web.dto.request.SaveSubjectGradesRequest
+import hs.kr.entrydsm.application.adapterin.web.dto.response.AcademicRecordResponse
+import hs.kr.entrydsm.application.adapterin.web.dto.response.EvaluationResultResponse
+import hs.kr.entrydsm.application.application.port.`in`.EvaluationPort
+import hs.kr.entrydsm.application.application.port.`in`.command.CalculateEvaluationCommand
+import hs.kr.entrydsm.application.application.port.`in`.command.SaveAcademicRecordCommand
+import hs.kr.entrydsm.application.application.port.`in`.command.SaveCertificatesCommand
+import hs.kr.entrydsm.application.application.port.`in`.command.SaveGedScoresCommand
+import hs.kr.entrydsm.application.application.port.`in`.command.SaveSubjectGradesCommand
+import hs.kr.entrydsm.application.domain.enum.SchoolSemester
+import hs.kr.entrydsm.application.domain.model.GedScores
+import org.springframework.web.bind.annotation.GetMapping
+import org.springframework.web.bind.annotation.PostMapping
+import org.springframework.web.bind.annotation.RequestBody
+import org.springframework.web.bind.annotation.RequestMapping
+import org.springframework.web.bind.annotation.RequestParam
+import org.springframework.web.bind.annotation.RestController
+
+@RestController
+@RequestMapping("/api/evaluation/v11/evaluations")
+class EvaluationController(
+    private val evaluationPort: EvaluationPort,
+) {
+    @PostMapping("/grades/expected")
+    fun saveExpectedGrades(
+        @RequestBody request: SaveSubjectGradesRequest,
+    ): ApiResponse<Unit> {
+        saveSubjectGrades(request)
+        return ApiResponse(data = null)
+    }
+
+    @PostMapping("/grades/graduated")
+    fun saveGraduatedGrades(
+        @RequestBody request: SaveSubjectGradesRequest,
+    ): ApiResponse<Unit> {
+        saveSubjectGrades(request)
+        return ApiResponse(data = null)
+    }
+
+    @PostMapping("/ged-scores")
+    fun saveGedScores(
+        @RequestBody request: SaveGedScoresRequest,
+    ): ApiResponse<Unit> {
+        evaluationPort.saveGedScores(
+            SaveGedScoresCommand(
+                applicantId = request.applicantId,
+                gedScores = GedScores(
+                    koreanScore = request.koreanScore,
+                    mathScore = request.mathScore,
+                    englishScore = request.englishScore,
+                    scienceScore = request.scienceScore,
+                    societyScore = request.societyScore,
+                    technologyScore = request.technologyScore,
+                    historyScore = request.historyScore,
+                ),
+            ),
+        )
+        return ApiResponse(data = null)
+    }
+
+    @PostMapping("/academic-records")
+    fun saveAcademicRecords(
+        @RequestBody request: SaveAcademicRecordRequest,
+    ): ApiResponse<AcademicRecordResponse> {
+        val result = evaluationPort.saveAcademicRecord(
+            SaveAcademicRecordCommand(
+                applicantId = request.applicantId,
+                absentCount = request.absentCount,
+                earlyLeaveCount = request.earlyLeaveCount,
+                lateCount = request.lateCount,
+                classAbsenceCount = request.classAbsenceCount,
+                volunteerTime = request.resolvedVolunteerTime(),
+            ),
+        )
+        return ApiResponse(data = result.toResponse())
+    }
+
+    @PostMapping("/certificates")
+    fun saveCertificates(
+        @RequestBody request: SaveCertificatesRequest,
+    ): ApiResponse<Unit> {
+        evaluationPort.saveCertificates(
+            SaveCertificatesCommand(
+                applicantId = request.applicantId,
+                isDsmAlgorithmAwarded = request.isDsmAlgorithmAwarded,
+                isProgrammingCertified = request.isProgrammingCertified,
+            ),
+        )
+        return ApiResponse(data = null)
+    }
+
+    @GetMapping("/result")
+    fun getResult(
+        @RequestParam applicantId: Long,
+    ): ApiResponse<EvaluationResultResponse> {
+        val result = evaluationPort.calculateResult(CalculateEvaluationCommand(applicantId))
+        return ApiResponse(data = result.toResponse())
+    }
+
+    private fun saveSubjectGrades(request: SaveSubjectGradesRequest) {
+        evaluationPort.saveSubjectGrades(
+            SaveSubjectGradesCommand(
+                applicantId = request.applicantId,
+                schoolSemester = request.schoolSemester.toSchoolSemester(),
+                subjectGrades = request.subjects.toDomain(),
+            ),
+        )
+    }
+}
+
+private fun String.toSchoolSemester(): SchoolSemester {
+    return when (this) {
+        "2-1" -> SchoolSemester.SECOND_GRADE_FIRST_SEMESTER
+        "2-2" -> SchoolSemester.SECOND_GRADE_SECOND_SEMESTER
+        "3-1" -> SchoolSemester.THIRD_GRADE_FIRST_SEMESTER
+        "3-2" -> SchoolSemester.THIRD_GRADE_SECOND_SEMESTER
+        else -> throw IllegalArgumentException("schoolSemester must be one of 2-1, 2-2, 3-1, 3-2")
+    }
+}

--- a/systems/application/application-adapter-in/src/main/kotlin/hs/kr/entrydsm/application/adapterin/web/EvaluationController.kt
+++ b/systems/application/application-adapter-in/src/main/kotlin/hs/kr/entrydsm/application/adapterin/web/EvaluationController.kt
@@ -7,7 +7,6 @@ import hs.kr.entrydsm.application.adapterin.web.dto.request.SaveCertificatesRequ
 import hs.kr.entrydsm.application.adapterin.web.dto.request.SaveGedScoresRequest
 import hs.kr.entrydsm.application.adapterin.web.dto.request.SaveSubjectGradesRequest
 import hs.kr.entrydsm.application.adapterin.web.dto.response.AcademicRecordResponse
-import hs.kr.entrydsm.application.adapterin.web.dto.response.EvaluationResultResponse
 import hs.kr.entrydsm.application.application.port.`in`.EvaluationPort
 import hs.kr.entrydsm.application.application.port.`in`.command.CalculateEvaluationCommand
 import hs.kr.entrydsm.application.application.port.`in`.command.SaveAcademicRecordCommand
@@ -18,12 +17,10 @@ import hs.kr.entrydsm.application.domain.enum.SchoolSemester
 import hs.kr.entrydsm.application.domain.model.GedScores
 import org.springframework.http.HttpHeaders
 import org.springframework.security.core.annotation.AuthenticationPrincipal
-import org.springframework.web.bind.annotation.GetMapping
 import org.springframework.web.bind.annotation.PostMapping
 import org.springframework.web.bind.annotation.RequestBody
 import org.springframework.web.bind.annotation.RequestHeader
 import org.springframework.web.bind.annotation.RequestMapping
-import org.springframework.web.bind.annotation.RequestParam
 import org.springframework.web.bind.annotation.RestController
 
 @RestController
@@ -61,7 +58,6 @@ class EvaluationController(
             SaveGedScoresCommand(
                 authorization = authorization,
                 userId = userId,
-                applicantId = request.applicantId,
                 gedScores = GedScores(
                     koreanScore = request.koreanScore,
                     mathScore = request.mathScore,
@@ -86,12 +82,11 @@ class EvaluationController(
             SaveAcademicRecordCommand(
                 authorization = authorization,
                 userId = userId,
-                applicantId = request.applicantId,
                 absentCount = request.absentCount,
                 earlyLeaveCount = request.earlyLeaveCount,
                 lateCount = request.lateCount,
                 classAbsenceCount = request.classAbsenceCount,
-                volunteerTime = request.resolvedVolunteerTime(),
+                volunteerTime = request.volunteerTime,
             ),
         )
         return ApiResponse(data = result.toResponse())
@@ -107,7 +102,6 @@ class EvaluationController(
             SaveCertificatesCommand(
                 authorization = authorization,
                 userId = userId,
-                applicantId = request.applicantId,
                 isDsmAlgorithmAwarded = request.isDsmAlgorithmAwarded,
                 isProgrammingCertified = request.isProgrammingCertified,
             ),
@@ -115,20 +109,18 @@ class EvaluationController(
         return ApiResponse(data = null)
     }
 
-    @GetMapping("/result")
+    @PostMapping("/result")
     fun getResult(
         @RequestHeader(HttpHeaders.AUTHORIZATION, required = false) authorization: String?,
         @AuthenticationPrincipal(expression = "userId") userId: Long? = null,
-        @RequestParam applicantId: Long,
-    ): ApiResponse<EvaluationResultResponse> {
-        val result = evaluationPort.calculateResult(
+    ): ApiResponse<Unit> {
+        evaluationPort.calculateResult(
             CalculateEvaluationCommand(
                 authorization = authorization,
                 userId = userId,
-                applicantId = applicantId,
             ),
         )
-        return ApiResponse(data = result.toResponse())
+        return ApiResponse(data = null)
     }
 
     private fun saveSubjectGrades(
@@ -140,7 +132,6 @@ class EvaluationController(
             SaveSubjectGradesCommand(
                 authorization = authorization,
                 userId = userId,
-                applicantId = request.applicantId,
                 schoolSemester = request.schoolSemester.toSchoolSemester(),
                 subjectGrades = request.subjects.toDomain(),
             ),

--- a/systems/application/application-adapter-in/src/main/kotlin/hs/kr/entrydsm/application/adapterin/web/EvaluationController.kt
+++ b/systems/application/application-adapter-in/src/main/kotlin/hs/kr/entrydsm/application/adapterin/web/EvaluationController.kt
@@ -16,9 +16,12 @@ import hs.kr.entrydsm.application.application.port.`in`.command.SaveGedScoresCom
 import hs.kr.entrydsm.application.application.port.`in`.command.SaveSubjectGradesCommand
 import hs.kr.entrydsm.application.domain.enum.SchoolSemester
 import hs.kr.entrydsm.application.domain.model.GedScores
+import org.springframework.http.HttpHeaders
+import org.springframework.security.core.annotation.AuthenticationPrincipal
 import org.springframework.web.bind.annotation.GetMapping
 import org.springframework.web.bind.annotation.PostMapping
 import org.springframework.web.bind.annotation.RequestBody
+import org.springframework.web.bind.annotation.RequestHeader
 import org.springframework.web.bind.annotation.RequestMapping
 import org.springframework.web.bind.annotation.RequestParam
 import org.springframework.web.bind.annotation.RestController
@@ -30,26 +33,34 @@ class EvaluationController(
 ) {
     @PostMapping("/grades/expected")
     fun saveExpectedGrades(
+        @RequestHeader(HttpHeaders.AUTHORIZATION, required = false) authorization: String?,
+        @AuthenticationPrincipal(expression = "userId") userId: Long? = null,
         @RequestBody request: SaveSubjectGradesRequest,
     ): ApiResponse<Unit> {
-        saveSubjectGrades(request)
+        saveSubjectGrades(authorization, userId, request)
         return ApiResponse(data = null)
     }
 
     @PostMapping("/grades/graduated")
     fun saveGraduatedGrades(
+        @RequestHeader(HttpHeaders.AUTHORIZATION, required = false) authorization: String?,
+        @AuthenticationPrincipal(expression = "userId") userId: Long? = null,
         @RequestBody request: SaveSubjectGradesRequest,
     ): ApiResponse<Unit> {
-        saveSubjectGrades(request)
+        saveSubjectGrades(authorization, userId, request)
         return ApiResponse(data = null)
     }
 
     @PostMapping("/ged-scores")
     fun saveGedScores(
+        @RequestHeader(HttpHeaders.AUTHORIZATION, required = false) authorization: String?,
+        @AuthenticationPrincipal(expression = "userId") userId: Long? = null,
         @RequestBody request: SaveGedScoresRequest,
     ): ApiResponse<Unit> {
         evaluationPort.saveGedScores(
             SaveGedScoresCommand(
+                authorization = authorization,
+                userId = userId,
                 applicantId = request.applicantId,
                 gedScores = GedScores(
                     koreanScore = request.koreanScore,
@@ -67,10 +78,14 @@ class EvaluationController(
 
     @PostMapping("/academic-records")
     fun saveAcademicRecords(
+        @RequestHeader(HttpHeaders.AUTHORIZATION, required = false) authorization: String?,
+        @AuthenticationPrincipal(expression = "userId") userId: Long? = null,
         @RequestBody request: SaveAcademicRecordRequest,
     ): ApiResponse<AcademicRecordResponse> {
         val result = evaluationPort.saveAcademicRecord(
             SaveAcademicRecordCommand(
+                authorization = authorization,
+                userId = userId,
                 applicantId = request.applicantId,
                 absentCount = request.absentCount,
                 earlyLeaveCount = request.earlyLeaveCount,
@@ -84,10 +99,14 @@ class EvaluationController(
 
     @PostMapping("/certificates")
     fun saveCertificates(
+        @RequestHeader(HttpHeaders.AUTHORIZATION, required = false) authorization: String?,
+        @AuthenticationPrincipal(expression = "userId") userId: Long? = null,
         @RequestBody request: SaveCertificatesRequest,
     ): ApiResponse<Unit> {
         evaluationPort.saveCertificates(
             SaveCertificatesCommand(
+                authorization = authorization,
+                userId = userId,
                 applicantId = request.applicantId,
                 isDsmAlgorithmAwarded = request.isDsmAlgorithmAwarded,
                 isProgrammingCertified = request.isProgrammingCertified,
@@ -98,15 +117,29 @@ class EvaluationController(
 
     @GetMapping("/result")
     fun getResult(
+        @RequestHeader(HttpHeaders.AUTHORIZATION, required = false) authorization: String?,
+        @AuthenticationPrincipal(expression = "userId") userId: Long? = null,
         @RequestParam applicantId: Long,
     ): ApiResponse<EvaluationResultResponse> {
-        val result = evaluationPort.calculateResult(CalculateEvaluationCommand(applicantId))
+        val result = evaluationPort.calculateResult(
+            CalculateEvaluationCommand(
+                authorization = authorization,
+                userId = userId,
+                applicantId = applicantId,
+            ),
+        )
         return ApiResponse(data = result.toResponse())
     }
 
-    private fun saveSubjectGrades(request: SaveSubjectGradesRequest) {
+    private fun saveSubjectGrades(
+        authorization: String?,
+        userId: Long?,
+        request: SaveSubjectGradesRequest,
+    ) {
         evaluationPort.saveSubjectGrades(
             SaveSubjectGradesCommand(
+                authorization = authorization,
+                userId = userId,
                 applicantId = request.applicantId,
                 schoolSemester = request.schoolSemester.toSchoolSemester(),
                 subjectGrades = request.subjects.toDomain(),

--- a/systems/application/application-adapter-in/src/main/kotlin/hs/kr/entrydsm/application/adapterin/web/config/LandingScheduleProperties.kt
+++ b/systems/application/application-adapter-in/src/main/kotlin/hs/kr/entrydsm/application/adapterin/web/config/LandingScheduleProperties.kt
@@ -1,0 +1,17 @@
+package hs.kr.entrydsm.application.adapterin.web.config
+
+import java.time.LocalDateTime
+import org.springframework.beans.factory.annotation.Value
+import org.springframework.stereotype.Component
+
+@Component
+class LandingScheduleProperties(
+    @Value("\${entrydsm.application.schedule.application-start-at}")
+    val applicationStartAt: LocalDateTime,
+
+    @Value("\${entrydsm.application.schedule.application-end-at}")
+    val applicationEndAt: LocalDateTime,
+
+    @Value("\${entrydsm.application.schedule.result-announced-at}")
+    val resultAnnouncedAt: LocalDateTime,
+)

--- a/systems/application/application-adapter-in/src/main/kotlin/hs/kr/entrydsm/application/adapterin/web/dto/common/ApiResponse.kt
+++ b/systems/application/application-adapter-in/src/main/kotlin/hs/kr/entrydsm/application/adapterin/web/dto/common/ApiResponse.kt
@@ -1,0 +1,7 @@
+package hs.kr.entrydsm.application.adapterin.web.dto.common
+
+data class ApiResponse<T>(
+    val success: Boolean = true,
+    val data: T?,
+    val error: ErrorDetail? = null,
+)

--- a/systems/application/application-adapter-in/src/main/kotlin/hs/kr/entrydsm/application/adapterin/web/dto/common/ErrorDetail.kt
+++ b/systems/application/application-adapter-in/src/main/kotlin/hs/kr/entrydsm/application/adapterin/web/dto/common/ErrorDetail.kt
@@ -1,0 +1,8 @@
+package hs.kr.entrydsm.application.adapterin.web.dto.common
+
+data class ErrorDetail(
+    val code: String,
+    val message: String,
+    val status: Int,
+)
+

--- a/systems/application/application-adapter-in/src/main/kotlin/hs/kr/entrydsm/application/adapterin/web/dto/common/ErrorResponse.kt
+++ b/systems/application/application-adapter-in/src/main/kotlin/hs/kr/entrydsm/application/adapterin/web/dto/common/ErrorResponse.kt
@@ -1,0 +1,10 @@
+package hs.kr.entrydsm.application.adapterin.web.dto.common
+
+import java.time.Instant
+
+data class ErrorResponse(
+    val success: Boolean = false,
+    val error: ErrorDetail,
+    val timestamp: Instant = Instant.now(),
+)
+

--- a/systems/application/application-adapter-in/src/main/kotlin/hs/kr/entrydsm/application/adapterin/web/dto/common/ResponseMapper.kt
+++ b/systems/application/application-adapter-in/src/main/kotlin/hs/kr/entrydsm/application/adapterin/web/dto/common/ResponseMapper.kt
@@ -1,0 +1,40 @@
+package hs.kr.entrydsm.application.adapterin.web.dto.common
+
+import hs.kr.entrydsm.application.adapterin.web.config.LandingScheduleProperties
+import hs.kr.entrydsm.application.adapterin.web.dto.response.AcademicRecordResponse
+import hs.kr.entrydsm.application.adapterin.web.dto.response.CreateApplicantResponse
+import hs.kr.entrydsm.application.adapterin.web.dto.response.EvaluationResultResponse
+import hs.kr.entrydsm.application.adapterin.web.dto.response.LandingResponse
+import hs.kr.entrydsm.application.adapterin.web.dto.response.PeriodResponse
+import hs.kr.entrydsm.application.adapterin.web.dto.response.ScheduleResponse
+import hs.kr.entrydsm.application.application.port.`in`.result.AcademicRecordResult
+import hs.kr.entrydsm.application.application.port.`in`.result.CreateApplicantResult
+import hs.kr.entrydsm.application.application.port.`in`.result.EvaluationResult
+import hs.kr.entrydsm.application.application.port.`in`.result.LandingResult
+
+fun CreateApplicantResult.toResponse(): CreateApplicantResponse =
+    CreateApplicantResponse(applicantId = applicantId)
+
+fun LandingResult.toResponse(scheduleProperties: LandingScheduleProperties): LandingResponse =
+    LandingResponse(
+        applicantName = applicantName,
+        schedule = ScheduleResponse(
+            applicationPeriod = PeriodResponse(
+                startAt = scheduleProperties.applicationStartAt,
+                endAt = scheduleProperties.applicationEndAt,
+            ),
+            resultAnnouncedAt = scheduleProperties.resultAnnouncedAt,
+        ),
+    )
+
+fun AcademicRecordResult.toResponse(): AcademicRecordResponse =
+    AcademicRecordResponse(
+        absentCount = absentCount,
+        earlyLeaveCount = earlyLeaveCount,
+        lateCount = lateCount,
+        classAbsenceCount = classAbsenceCount,
+        volunteerTime = volunteerTime,
+    )
+
+fun EvaluationResult.toResponse(): EvaluationResultResponse =
+    EvaluationResultResponse(scores = scores)

--- a/systems/application/application-adapter-in/src/main/kotlin/hs/kr/entrydsm/application/adapterin/web/dto/common/ResponseMapper.kt
+++ b/systems/application/application-adapter-in/src/main/kotlin/hs/kr/entrydsm/application/adapterin/web/dto/common/ResponseMapper.kt
@@ -3,13 +3,11 @@ package hs.kr.entrydsm.application.adapterin.web.dto.common
 import hs.kr.entrydsm.application.adapterin.web.config.LandingScheduleProperties
 import hs.kr.entrydsm.application.adapterin.web.dto.response.AcademicRecordResponse
 import hs.kr.entrydsm.application.adapterin.web.dto.response.CreateApplicantResponse
-import hs.kr.entrydsm.application.adapterin.web.dto.response.EvaluationResultResponse
 import hs.kr.entrydsm.application.adapterin.web.dto.response.LandingResponse
 import hs.kr.entrydsm.application.adapterin.web.dto.response.PeriodResponse
 import hs.kr.entrydsm.application.adapterin.web.dto.response.ScheduleResponse
 import hs.kr.entrydsm.application.application.port.`in`.result.AcademicRecordResult
 import hs.kr.entrydsm.application.application.port.`in`.result.CreateApplicantResult
-import hs.kr.entrydsm.application.application.port.`in`.result.EvaluationResult
 import hs.kr.entrydsm.application.application.port.`in`.result.LandingResult
 
 fun CreateApplicantResult.toResponse(): CreateApplicantResponse =
@@ -35,6 +33,3 @@ fun AcademicRecordResult.toResponse(): AcademicRecordResponse =
         classAbsenceCount = classAbsenceCount,
         volunteerTime = volunteerTime,
     )
-
-fun EvaluationResult.toResponse(): EvaluationResultResponse =
-    EvaluationResultResponse(scores = scores)

--- a/systems/application/application-adapter-in/src/main/kotlin/hs/kr/entrydsm/application/adapterin/web/dto/request/AddressRequest.kt
+++ b/systems/application/application-adapter-in/src/main/kotlin/hs/kr/entrydsm/application/adapterin/web/dto/request/AddressRequest.kt
@@ -1,0 +1,8 @@
+package hs.kr.entrydsm.application.adapterin.web.dto.request
+
+data class AddressRequest(
+    val zipCode: String,
+    val addressBase: String,
+    val addressDetail: String,
+)
+

--- a/systems/application/application-adapter-in/src/main/kotlin/hs/kr/entrydsm/application/adapterin/web/dto/request/CreateApplicantRequest.kt
+++ b/systems/application/application-adapter-in/src/main/kotlin/hs/kr/entrydsm/application/adapterin/web/dto/request/CreateApplicantRequest.kt
@@ -1,0 +1,5 @@
+package hs.kr.entrydsm.application.adapterin.web.dto.request
+
+data class CreateApplicantRequest(
+    val accountId: Long,
+)

--- a/systems/application/application-adapter-in/src/main/kotlin/hs/kr/entrydsm/application/adapterin/web/dto/request/CreateApplicantRequest.kt
+++ b/systems/application/application-adapter-in/src/main/kotlin/hs/kr/entrydsm/application/adapterin/web/dto/request/CreateApplicantRequest.kt
@@ -1,5 +1,0 @@
-package hs.kr.entrydsm.application.adapterin.web.dto.request
-
-data class CreateApplicantRequest(
-    val accountId: Long,
-)

--- a/systems/application/application-adapter-in/src/main/kotlin/hs/kr/entrydsm/application/adapterin/web/dto/request/SaveAcademicRecordRequest.kt
+++ b/systems/application/application-adapter-in/src/main/kotlin/hs/kr/entrydsm/application/adapterin/web/dto/request/SaveAcademicRecordRequest.kt
@@ -1,15 +1,9 @@
 package hs.kr.entrydsm.application.adapterin.web.dto.request
 
 data class SaveAcademicRecordRequest(
-    val applicantId: Long,
     val absentCount: Int,
     val earlyLeaveCount: Int,
     val lateCount: Int,
     val classAbsenceCount: Int,
-    val volunteerTime: Int? = null,
-    val volunteer_time: Int? = null,
-) {
-    fun resolvedVolunteerTime(): Int =
-        volunteerTime ?: volunteer_time
-            ?: throw IllegalArgumentException("volunteerTime is required")
-}
+    val volunteerTime: Int,
+)

--- a/systems/application/application-adapter-in/src/main/kotlin/hs/kr/entrydsm/application/adapterin/web/dto/request/SaveAcademicRecordRequest.kt
+++ b/systems/application/application-adapter-in/src/main/kotlin/hs/kr/entrydsm/application/adapterin/web/dto/request/SaveAcademicRecordRequest.kt
@@ -1,0 +1,15 @@
+package hs.kr.entrydsm.application.adapterin.web.dto.request
+
+data class SaveAcademicRecordRequest(
+    val applicantId: Long,
+    val absentCount: Int,
+    val earlyLeaveCount: Int,
+    val lateCount: Int,
+    val classAbsenceCount: Int,
+    val volunteerTime: Int? = null,
+    val volunteer_time: Int? = null,
+) {
+    fun resolvedVolunteerTime(): Int =
+        volunteerTime ?: volunteer_time
+            ?: throw IllegalArgumentException("volunteerTime is required")
+}

--- a/systems/application/application-adapter-in/src/main/kotlin/hs/kr/entrydsm/application/adapterin/web/dto/request/SaveCertificatesRequest.kt
+++ b/systems/application/application-adapter-in/src/main/kotlin/hs/kr/entrydsm/application/adapterin/web/dto/request/SaveCertificatesRequest.kt
@@ -1,7 +1,6 @@
 package hs.kr.entrydsm.application.adapterin.web.dto.request
 
 data class SaveCertificatesRequest(
-    val applicantId: Long,
     val isDsmAlgorithmAwarded: Boolean,
     val isProgrammingCertified: Boolean,
 )

--- a/systems/application/application-adapter-in/src/main/kotlin/hs/kr/entrydsm/application/adapterin/web/dto/request/SaveCertificatesRequest.kt
+++ b/systems/application/application-adapter-in/src/main/kotlin/hs/kr/entrydsm/application/adapterin/web/dto/request/SaveCertificatesRequest.kt
@@ -1,0 +1,7 @@
+package hs.kr.entrydsm.application.adapterin.web.dto.request
+
+data class SaveCertificatesRequest(
+    val applicantId: Long,
+    val isDsmAlgorithmAwarded: Boolean,
+    val isProgrammingCertified: Boolean,
+)

--- a/systems/application/application-adapter-in/src/main/kotlin/hs/kr/entrydsm/application/adapterin/web/dto/request/SaveGedScoresRequest.kt
+++ b/systems/application/application-adapter-in/src/main/kotlin/hs/kr/entrydsm/application/adapterin/web/dto/request/SaveGedScoresRequest.kt
@@ -1,0 +1,12 @@
+package hs.kr.entrydsm.application.adapterin.web.dto.request
+
+data class SaveGedScoresRequest(
+    val applicantId: Long,
+    val koreanScore: Int,
+    val societyScore: Int,
+    val englishScore: Int,
+    val historyScore: Int,
+    val mathScore: Int,
+    val scienceScore: Int,
+    val technologyScore: Int,
+)

--- a/systems/application/application-adapter-in/src/main/kotlin/hs/kr/entrydsm/application/adapterin/web/dto/request/SaveGedScoresRequest.kt
+++ b/systems/application/application-adapter-in/src/main/kotlin/hs/kr/entrydsm/application/adapterin/web/dto/request/SaveGedScoresRequest.kt
@@ -1,7 +1,6 @@
 package hs.kr.entrydsm.application.adapterin.web.dto.request
 
 data class SaveGedScoresRequest(
-    val applicantId: Long,
     val koreanScore: Int,
     val societyScore: Int,
     val englishScore: Int,

--- a/systems/application/application-adapter-in/src/main/kotlin/hs/kr/entrydsm/application/adapterin/web/dto/request/SaveSubjectGradesRequest.kt
+++ b/systems/application/application-adapter-in/src/main/kotlin/hs/kr/entrydsm/application/adapterin/web/dto/request/SaveSubjectGradesRequest.kt
@@ -1,0 +1,7 @@
+package hs.kr.entrydsm.application.adapterin.web.dto.request
+
+data class SaveSubjectGradesRequest(
+    val applicantId: Long,
+    val schoolSemester: String,
+    val subjects: SubjectGradesRequest,
+)

--- a/systems/application/application-adapter-in/src/main/kotlin/hs/kr/entrydsm/application/adapterin/web/dto/request/SaveSubjectGradesRequest.kt
+++ b/systems/application/application-adapter-in/src/main/kotlin/hs/kr/entrydsm/application/adapterin/web/dto/request/SaveSubjectGradesRequest.kt
@@ -1,7 +1,6 @@
 package hs.kr.entrydsm.application.adapterin.web.dto.request
 
 data class SaveSubjectGradesRequest(
-    val applicantId: Long,
     val schoolSemester: String,
     val subjects: SubjectGradesRequest,
 )

--- a/systems/application/application-adapter-in/src/main/kotlin/hs/kr/entrydsm/application/adapterin/web/dto/request/SubjectGradesRequest.kt
+++ b/systems/application/application-adapter-in/src/main/kotlin/hs/kr/entrydsm/application/adapterin/web/dto/request/SubjectGradesRequest.kt
@@ -1,0 +1,25 @@
+package hs.kr.entrydsm.application.adapterin.web.dto.request
+
+import hs.kr.entrydsm.application.domain.enum.SubjectGrade
+import hs.kr.entrydsm.application.domain.model.SubjectGrades
+
+data class SubjectGradesRequest(
+    val koreanGrade: SubjectGrade,
+    val societyGrade: SubjectGrade,
+    val englishGrade: SubjectGrade,
+    val historyGrade: SubjectGrade,
+    val mathGrade: SubjectGrade,
+    val scienceGrade: SubjectGrade,
+    val technologyGrade: SubjectGrade,
+) {
+    fun toDomain(): SubjectGrades =
+        SubjectGrades(
+            koreanGrade = koreanGrade,
+            societyGrade = societyGrade,
+            englishGrade = englishGrade,
+            historyGrade = historyGrade,
+            mathGrade = mathGrade,
+            scienceGrade = scienceGrade,
+            technologyGrade = technologyGrade,
+        )
+}

--- a/systems/application/application-adapter-in/src/main/kotlin/hs/kr/entrydsm/application/adapterin/web/dto/request/SubmitApplicationRequest.kt
+++ b/systems/application/application-adapter-in/src/main/kotlin/hs/kr/entrydsm/application/adapterin/web/dto/request/SubmitApplicationRequest.kt
@@ -1,0 +1,6 @@
+package hs.kr.entrydsm.application.adapterin.web.dto.request
+
+data class SubmitApplicationRequest(
+    val applicantId: Long,
+)
+

--- a/systems/application/application-adapter-in/src/main/kotlin/hs/kr/entrydsm/application/adapterin/web/dto/request/SubmitApplicationRequest.kt
+++ b/systems/application/application-adapter-in/src/main/kotlin/hs/kr/entrydsm/application/adapterin/web/dto/request/SubmitApplicationRequest.kt
@@ -1,6 +1,0 @@
-package hs.kr.entrydsm.application.adapterin.web.dto.request
-
-data class SubmitApplicationRequest(
-    val applicantId: Long,
-)
-

--- a/systems/application/application-adapter-in/src/main/kotlin/hs/kr/entrydsm/application/adapterin/web/dto/request/UpdateFamilyRequest.kt
+++ b/systems/application/application-adapter-in/src/main/kotlin/hs/kr/entrydsm/application/adapterin/web/dto/request/UpdateFamilyRequest.kt
@@ -1,0 +1,11 @@
+package hs.kr.entrydsm.application.adapterin.web.dto.request
+
+import hs.kr.entrydsm.application.domain.enum.Gender
+
+data class UpdateFamilyRequest(
+    val guardianName: String,
+    val guardianPhoneNumber: String,
+    val guardianGender: Gender,
+    val guardianRelation: String,
+    val address: AddressRequest,
+)

--- a/systems/application/application-adapter-in/src/main/kotlin/hs/kr/entrydsm/application/adapterin/web/dto/request/UpdateIntroductionRequest.kt
+++ b/systems/application/application-adapter-in/src/main/kotlin/hs/kr/entrydsm/application/adapterin/web/dto/request/UpdateIntroductionRequest.kt
@@ -1,0 +1,6 @@
+package hs.kr.entrydsm.application.adapterin.web.dto.request
+
+data class UpdateIntroductionRequest(
+    val introduction: String,
+)
+

--- a/systems/application/application-adapter-in/src/main/kotlin/hs/kr/entrydsm/application/adapterin/web/dto/request/UpdateMiddleSchoolRequest.kt
+++ b/systems/application/application-adapter-in/src/main/kotlin/hs/kr/entrydsm/application/adapterin/web/dto/request/UpdateMiddleSchoolRequest.kt
@@ -1,0 +1,9 @@
+package hs.kr.entrydsm.application.adapterin.web.dto.request
+
+data class UpdateMiddleSchoolRequest(
+    val schoolName: String,
+    val studentNumber: String,
+    val schoolPhone: String,
+    val teacherName: String,
+)
+

--- a/systems/application/application-adapter-in/src/main/kotlin/hs/kr/entrydsm/application/adapterin/web/dto/request/UpdatePersonalRequest.kt
+++ b/systems/application/application-adapter-in/src/main/kotlin/hs/kr/entrydsm/application/adapterin/web/dto/request/UpdatePersonalRequest.kt
@@ -1,0 +1,13 @@
+package hs.kr.entrydsm.application.adapterin.web.dto.request
+
+import hs.kr.entrydsm.application.domain.enum.Gender
+import hs.kr.entrydsm.application.domain.enum.SpecialAdmissionType
+
+data class UpdatePersonalRequest(
+    val photoFileId: Long,
+    val name: String,
+    val phoneNumber: String,
+    val gender: Gender,
+    val birthdate: String,
+    val specialAdmissionType: SpecialAdmissionType? = null,
+)

--- a/systems/application/application-adapter-in/src/main/kotlin/hs/kr/entrydsm/application/adapterin/web/dto/request/UpdateStudyPlanRequest.kt
+++ b/systems/application/application-adapter-in/src/main/kotlin/hs/kr/entrydsm/application/adapterin/web/dto/request/UpdateStudyPlanRequest.kt
@@ -1,0 +1,6 @@
+package hs.kr.entrydsm.application.adapterin.web.dto.request
+
+data class UpdateStudyPlanRequest(
+    val studyPlan: String,
+)
+

--- a/systems/application/application-adapter-in/src/main/kotlin/hs/kr/entrydsm/application/adapterin/web/dto/request/UpdateTypeRequest.kt
+++ b/systems/application/application-adapter-in/src/main/kotlin/hs/kr/entrydsm/application/adapterin/web/dto/request/UpdateTypeRequest.kt
@@ -1,0 +1,12 @@
+package hs.kr.entrydsm.application.adapterin.web.dto.request
+
+import hs.kr.entrydsm.application.domain.enum.AdmissionType
+import hs.kr.entrydsm.application.domain.enum.GraduationType
+import hs.kr.entrydsm.application.domain.enum.Region
+
+data class UpdateTypeRequest(
+    val admissionType: AdmissionType,
+    val region: Region,
+    val graduationType: GraduationType,
+    val graduationDate: String?,
+)

--- a/systems/application/application-adapter-in/src/main/kotlin/hs/kr/entrydsm/application/adapterin/web/dto/response/AcademicRecordResponse.kt
+++ b/systems/application/application-adapter-in/src/main/kotlin/hs/kr/entrydsm/application/adapterin/web/dto/response/AcademicRecordResponse.kt
@@ -1,0 +1,10 @@
+package hs.kr.entrydsm.application.adapterin.web.dto.response
+
+data class AcademicRecordResponse(
+    val absentCount: Int,
+    val earlyLeaveCount: Int,
+    val lateCount: Int,
+    val classAbsenceCount: Int,
+    val volunteerTime: Int,
+)
+

--- a/systems/application/application-adapter-in/src/main/kotlin/hs/kr/entrydsm/application/adapterin/web/dto/response/CreateApplicantResponse.kt
+++ b/systems/application/application-adapter-in/src/main/kotlin/hs/kr/entrydsm/application/adapterin/web/dto/response/CreateApplicantResponse.kt
@@ -1,0 +1,6 @@
+package hs.kr.entrydsm.application.adapterin.web.dto.response
+
+data class CreateApplicantResponse(
+    val applicantId: Long,
+)
+

--- a/systems/application/application-adapter-in/src/main/kotlin/hs/kr/entrydsm/application/adapterin/web/dto/response/EvaluationResultResponse.kt
+++ b/systems/application/application-adapter-in/src/main/kotlin/hs/kr/entrydsm/application/adapterin/web/dto/response/EvaluationResultResponse.kt
@@ -1,0 +1,6 @@
+package hs.kr.entrydsm.application.adapterin.web.dto.response
+
+data class EvaluationResultResponse(
+    val scores: Map<String, Double>,
+)
+

--- a/systems/application/application-adapter-in/src/main/kotlin/hs/kr/entrydsm/application/adapterin/web/dto/response/EvaluationResultResponse.kt
+++ b/systems/application/application-adapter-in/src/main/kotlin/hs/kr/entrydsm/application/adapterin/web/dto/response/EvaluationResultResponse.kt
@@ -1,6 +1,0 @@
-package hs.kr.entrydsm.application.adapterin.web.dto.response
-
-data class EvaluationResultResponse(
-    val scores: Map<String, Double>,
-)
-

--- a/systems/application/application-adapter-in/src/main/kotlin/hs/kr/entrydsm/application/adapterin/web/dto/response/LandingResponse.kt
+++ b/systems/application/application-adapter-in/src/main/kotlin/hs/kr/entrydsm/application/adapterin/web/dto/response/LandingResponse.kt
@@ -1,0 +1,7 @@
+package hs.kr.entrydsm.application.adapterin.web.dto.response
+
+data class LandingResponse(
+    val applicantName: String?,
+    val schedule: ScheduleResponse,
+)
+

--- a/systems/application/application-adapter-in/src/main/kotlin/hs/kr/entrydsm/application/adapterin/web/dto/response/PeriodResponse.kt
+++ b/systems/application/application-adapter-in/src/main/kotlin/hs/kr/entrydsm/application/adapterin/web/dto/response/PeriodResponse.kt
@@ -1,0 +1,9 @@
+package hs.kr.entrydsm.application.adapterin.web.dto.response
+
+import java.time.LocalDateTime
+
+data class PeriodResponse(
+    val startAt: LocalDateTime,
+    val endAt: LocalDateTime,
+)
+

--- a/systems/application/application-adapter-in/src/main/kotlin/hs/kr/entrydsm/application/adapterin/web/dto/response/ScheduleResponse.kt
+++ b/systems/application/application-adapter-in/src/main/kotlin/hs/kr/entrydsm/application/adapterin/web/dto/response/ScheduleResponse.kt
@@ -1,0 +1,9 @@
+package hs.kr.entrydsm.application.adapterin.web.dto.response
+
+import java.time.LocalDateTime
+
+data class ScheduleResponse(
+    val applicationPeriod: PeriodResponse,
+    val resultAnnouncedAt: LocalDateTime,
+)
+

--- a/systems/application/application-adapter-in/src/main/kotlin/hs/kr/entrydsm/application/adapterin/web/exception/GlobalExceptionHandler.kt
+++ b/systems/application/application-adapter-in/src/main/kotlin/hs/kr/entrydsm/application/adapterin/web/exception/GlobalExceptionHandler.kt
@@ -2,6 +2,7 @@ package hs.kr.entrydsm.application.adapterin.web.exception
 
 import hs.kr.entrydsm.application.adapterin.web.dto.common.ErrorDetail
 import hs.kr.entrydsm.application.adapterin.web.dto.common.ErrorResponse
+import hs.kr.entrydsm.application.application.exception.ApplicantAccessDeniedException
 import hs.kr.entrydsm.application.application.exception.ApplicantNotFoundException
 import org.slf4j.LoggerFactory
 import org.slf4j.MDC
@@ -26,6 +27,14 @@ class GlobalExceptionHandler {
             status = HttpStatus.NOT_FOUND,
             code = "APPLICANT_NOT_FOUND",
             message = exception.message ?: "applicant not found",
+        )
+
+    @ExceptionHandler(ApplicantAccessDeniedException::class)
+    fun handleApplicantAccessDenied(exception: ApplicantAccessDeniedException): ResponseEntity<ErrorResponse> =
+        response(
+            status = HttpStatus.FORBIDDEN,
+            code = "APPLICANT_ACCESS_DENIED",
+            message = exception.message ?: "applicant access denied",
         )
 
     @ExceptionHandler(

--- a/systems/application/application-adapter-in/src/main/kotlin/hs/kr/entrydsm/application/adapterin/web/exception/GlobalExceptionHandler.kt
+++ b/systems/application/application-adapter-in/src/main/kotlin/hs/kr/entrydsm/application/adapterin/web/exception/GlobalExceptionHandler.kt
@@ -1,0 +1,78 @@
+package hs.kr.entrydsm.application.adapterin.web.exception
+
+import hs.kr.entrydsm.application.adapterin.web.dto.common.ErrorDetail
+import hs.kr.entrydsm.application.adapterin.web.dto.common.ErrorResponse
+import hs.kr.entrydsm.application.application.exception.ApplicantNotFoundException
+import org.slf4j.LoggerFactory
+import org.slf4j.MDC
+import org.springframework.http.HttpStatus
+import org.springframework.http.ResponseEntity
+import org.springframework.http.converter.HttpMessageNotReadableException
+import org.springframework.web.bind.MissingPathVariableException
+import org.springframework.web.bind.MissingServletRequestParameterException
+import org.springframework.web.bind.MethodArgumentNotValidException
+import org.springframework.web.bind.annotation.ExceptionHandler
+import org.springframework.web.bind.annotation.RestControllerAdvice
+import org.springframework.web.method.annotation.MethodArgumentTypeMismatchException
+import org.springframework.web.multipart.support.MissingServletRequestPartException
+
+@RestControllerAdvice
+class GlobalExceptionHandler {
+    private val logger = LoggerFactory.getLogger(javaClass)
+
+    @ExceptionHandler(ApplicantNotFoundException::class)
+    fun handleApplicantNotFound(exception: ApplicantNotFoundException): ResponseEntity<ErrorResponse> =
+        response(
+            status = HttpStatus.NOT_FOUND,
+            code = "APPLICANT_NOT_FOUND",
+            message = exception.message ?: "applicant not found",
+        )
+
+    @ExceptionHandler(
+        IllegalArgumentException::class,
+        HttpMessageNotReadableException::class,
+        MethodArgumentNotValidException::class,
+        MissingPathVariableException::class,
+        MissingServletRequestParameterException::class,
+        MissingServletRequestPartException::class,
+        MethodArgumentTypeMismatchException::class,
+    )
+    fun handleInvalidRequest(exception: Exception): ResponseEntity<ErrorResponse> =
+        response(
+            status = HttpStatus.BAD_REQUEST,
+            code = "INVALID_REQUEST",
+            message = exception.message ?: "invalid request",
+        )
+
+    @ExceptionHandler(Exception::class)
+    fun handleUnhandledException(exception: Exception): ResponseEntity<ErrorResponse> =
+        response(
+            status = HttpStatus.INTERNAL_SERVER_ERROR,
+            code = "INTERNAL_SERVER_ERROR",
+            message = "internal server error",
+        ).also {
+            logger.error(
+                "Unhandled exception [correlationId={}]",
+                MDC.get("correlationId") ?: "unknown",
+                exception,
+            )
+        }
+
+    private fun response(
+        status: HttpStatus,
+        code: String,
+        message: String,
+    ): ResponseEntity<ErrorResponse> =
+        ResponseEntity
+            .status(status)
+            .body(
+                ErrorResponse(
+                    error = ErrorDetail(
+                        code = code,
+                        message = message,
+                        status = status.value(),
+                    ),
+                ),
+            )
+}
+

--- a/systems/application/application-adapter-in/src/main/kotlin/hs/kr/entrydsm/application/adapterin/web/exception/GlobalExceptionHandler.kt
+++ b/systems/application/application-adapter-in/src/main/kotlin/hs/kr/entrydsm/application/adapterin/web/exception/GlobalExceptionHandler.kt
@@ -4,6 +4,7 @@ import hs.kr.entrydsm.application.adapterin.web.dto.common.ErrorDetail
 import hs.kr.entrydsm.application.adapterin.web.dto.common.ErrorResponse
 import hs.kr.entrydsm.application.application.exception.ApplicantAccessDeniedException
 import hs.kr.entrydsm.application.application.exception.ApplicantNotFoundException
+import hs.kr.entrydsm.application.application.exception.AuthenticationRequiredException
 import org.slf4j.LoggerFactory
 import org.slf4j.MDC
 import org.springframework.http.HttpStatus
@@ -35,6 +36,14 @@ class GlobalExceptionHandler {
             status = HttpStatus.FORBIDDEN,
             code = "APPLICANT_ACCESS_DENIED",
             message = exception.message ?: "applicant access denied",
+        )
+
+    @ExceptionHandler(AuthenticationRequiredException::class)
+    fun handleAuthenticationRequired(exception: AuthenticationRequiredException): ResponseEntity<ErrorResponse> =
+        response(
+            status = HttpStatus.UNAUTHORIZED,
+            code = "AUTHENTICATION_REQUIRED",
+            message = exception.message ?: "authentication is required",
         )
 
     @ExceptionHandler(

--- a/systems/application/application-adapter-in/src/test/kotlin/hs/kr/entrydsm/TestMain.kt
+++ b/systems/application/application-adapter-in/src/test/kotlin/hs/kr/entrydsm/TestMain.kt
@@ -1,11 +1,13 @@
 package hs.kr.entrydsm.application.adapterin
 
-import org.junit.Assert.assertTrue
-import org.junit.Test
+import hs.kr.entrydsm.application.adapterin.web.ApplicationControllerTest
+import hs.kr.entrydsm.application.adapterin.web.EvaluationControllerTest
+import org.junit.runner.RunWith
+import org.junit.runners.Suite
 
-class ApplicationAdapterInModuleTest {
-    @Test
-    fun moduleLoads() {
-        assertTrue(true)
-    }
-}
+@RunWith(Suite::class)
+@Suite.SuiteClasses(
+    ApplicationControllerTest::class,
+    EvaluationControllerTest::class,
+)
+class ApplicationAdapterInModuleTest

--- a/systems/application/application-adapter-in/src/test/kotlin/hs/kr/entrydsm/application/adapterin/web/ApplicationControllerTest.kt
+++ b/systems/application/application-adapter-in/src/test/kotlin/hs/kr/entrydsm/application/adapterin/web/ApplicationControllerTest.kt
@@ -1,7 +1,6 @@
 package hs.kr.entrydsm.application.adapterin.web
 
 import hs.kr.entrydsm.application.adapterin.web.config.LandingScheduleProperties
-import hs.kr.entrydsm.application.adapterin.web.dto.request.CreateApplicantRequest
 import hs.kr.entrydsm.application.application.port.`in`.ApplicationPort
 import hs.kr.entrydsm.application.application.port.`in`.command.CreateApplicantCommand
 import hs.kr.entrydsm.application.application.port.`in`.command.SubmitApplicationCommand
@@ -19,17 +18,15 @@ import org.junit.Test
 
 class ApplicationControllerTest {
     @Test
-    fun createApplicantPassesAccountId() {
+    fun createApplicantPassesAuthenticatedUser() {
         val applicationPort = FakeApplicationPort()
         val controller = ApplicationController(applicationPort, scheduleProperties())
 
         val response = controller.createApplicant(
             authorization = "Bearer access-token",
             userId = 10L,
-            request = CreateApplicantRequest(accountId = 10L),
         )
 
-        assertEquals(10L, applicationPort.createApplicantCommand?.accountId)
         assertEquals(10L, applicationPort.createApplicantCommand?.userId)
         assertEquals("Bearer access-token", applicationPort.createApplicantCommand?.authorization)
         assertEquals(1L, response.data?.applicantId)

--- a/systems/application/application-adapter-in/src/test/kotlin/hs/kr/entrydsm/application/adapterin/web/ApplicationControllerTest.kt
+++ b/systems/application/application-adapter-in/src/test/kotlin/hs/kr/entrydsm/application/adapterin/web/ApplicationControllerTest.kt
@@ -37,9 +37,9 @@ class ApplicationControllerTest {
         val response = controller.getLanding(10L)
 
         assertEquals("홍길동", response.data?.applicantName)
-        assertEquals(APPLICATION_START_AT, response.data?.schedule?.applicationPeriod?.startAt)
-        assertEquals(APPLICATION_END_AT, response.data?.schedule?.applicationPeriod?.endAt)
-        assertEquals(RESULT_ANNOUNCED_AT, response.data?.schedule?.resultAnnouncedAt)
+        assertEquals(applicationStartAt, response.data?.schedule?.applicationPeriod?.startAt)
+        assertEquals(applicationEndAt, response.data?.schedule?.applicationPeriod?.endAt)
+        assertEquals(resultAnnouncedAt, response.data?.schedule?.resultAnnouncedAt)
     }
 
     private class FakeApplicationPort : ApplicationPort {
@@ -61,15 +61,15 @@ class ApplicationControllerTest {
     }
 
     private companion object {
-        val APPLICATION_START_AT: LocalDateTime = LocalDateTime.parse("2026-04-01T09:00:00")
-        val APPLICATION_END_AT: LocalDateTime = LocalDateTime.parse("2026-04-30T17:00:00")
-        val RESULT_ANNOUNCED_AT: LocalDateTime = LocalDateTime.parse("2026-05-15T10:00:00")
+        val applicationStartAt: LocalDateTime = LocalDateTime.parse("2026-10-19T09:00:00")
+        val applicationEndAt: LocalDateTime = LocalDateTime.parse("2026-10-23T17:00:00")
+        val resultAnnouncedAt: LocalDateTime = LocalDateTime.parse("2026-10-30T10:00:00")
 
         fun scheduleProperties(): LandingScheduleProperties =
             LandingScheduleProperties(
-                applicationStartAt = APPLICATION_START_AT,
-                applicationEndAt = APPLICATION_END_AT,
-                resultAnnouncedAt = RESULT_ANNOUNCED_AT,
+                applicationStartAt = applicationStartAt,
+                applicationEndAt = applicationEndAt,
+                resultAnnouncedAt = resultAnnouncedAt,
             )
     }
 }

--- a/systems/application/application-adapter-in/src/test/kotlin/hs/kr/entrydsm/application/adapterin/web/ApplicationControllerTest.kt
+++ b/systems/application/application-adapter-in/src/test/kotlin/hs/kr/entrydsm/application/adapterin/web/ApplicationControllerTest.kt
@@ -1,0 +1,80 @@
+package hs.kr.entrydsm.application.adapterin.web
+
+import hs.kr.entrydsm.application.adapterin.web.config.LandingScheduleProperties
+import hs.kr.entrydsm.application.adapterin.web.dto.request.CreateApplicantRequest
+import hs.kr.entrydsm.application.application.port.`in`.ApplicationPort
+import hs.kr.entrydsm.application.application.port.`in`.command.CreateApplicantCommand
+import hs.kr.entrydsm.application.application.port.`in`.command.SubmitApplicationCommand
+import hs.kr.entrydsm.application.application.port.`in`.command.UpdateFamilyCommand
+import hs.kr.entrydsm.application.application.port.`in`.command.UpdateIntroductionCommand
+import hs.kr.entrydsm.application.application.port.`in`.command.UpdateMiddleSchoolCommand
+import hs.kr.entrydsm.application.application.port.`in`.command.UpdatePersonalCommand
+import hs.kr.entrydsm.application.application.port.`in`.command.UpdateStudyPlanCommand
+import hs.kr.entrydsm.application.application.port.`in`.command.UpdateTypeCommand
+import hs.kr.entrydsm.application.application.port.`in`.result.CreateApplicantResult
+import hs.kr.entrydsm.application.application.port.`in`.result.LandingResult
+import java.time.LocalDateTime
+import org.junit.Assert.assertEquals
+import org.junit.Test
+
+class ApplicationControllerTest {
+    @Test
+    fun createApplicantPassesAccountId() {
+        val applicationPort = FakeApplicationPort()
+        val controller = ApplicationController(applicationPort, scheduleProperties())
+
+        val response = controller.createApplicant(
+            authorization = "Bearer access-token",
+            userId = 10L,
+            request = CreateApplicantRequest(accountId = 10L),
+        )
+
+        assertEquals(10L, applicationPort.createApplicantCommand?.accountId)
+        assertEquals(10L, applicationPort.createApplicantCommand?.userId)
+        assertEquals("Bearer access-token", applicationPort.createApplicantCommand?.authorization)
+        assertEquals(1L, response.data?.applicantId)
+    }
+
+    @Test
+    fun getLandingReturnsConfiguredSchedule() {
+        val controller = ApplicationController(FakeApplicationPort(), scheduleProperties())
+
+        val response = controller.getLanding("Bearer access-token", 10L)
+
+        assertEquals("홍길동", response.data?.applicantName)
+        assertEquals(APPLICATION_START_AT, response.data?.schedule?.applicationPeriod?.startAt)
+        assertEquals(APPLICATION_END_AT, response.data?.schedule?.applicationPeriod?.endAt)
+        assertEquals(RESULT_ANNOUNCED_AT, response.data?.schedule?.resultAnnouncedAt)
+    }
+
+    private class FakeApplicationPort : ApplicationPort {
+        var createApplicantCommand: CreateApplicantCommand? = null
+
+        override fun createApplicant(command: CreateApplicantCommand): CreateApplicantResult {
+            createApplicantCommand = command
+            return CreateApplicantResult(applicantId = 1L)
+        }
+
+        override fun updateType(command: UpdateTypeCommand) = Unit
+        override fun updatePersonal(command: UpdatePersonalCommand) = Unit
+        override fun updateFamily(command: UpdateFamilyCommand) = Unit
+        override fun updateMiddleSchool(command: UpdateMiddleSchoolCommand) = Unit
+        override fun updateIntroduction(command: UpdateIntroductionCommand) = Unit
+        override fun updateStudyPlan(command: UpdateStudyPlanCommand) = Unit
+        override fun submit(command: SubmitApplicationCommand) = Unit
+        override fun getLanding(accountId: Long?): LandingResult = LandingResult(applicantName = "홍길동")
+    }
+
+    private companion object {
+        val APPLICATION_START_AT: LocalDateTime = LocalDateTime.parse("2026-04-01T09:00:00")
+        val APPLICATION_END_AT: LocalDateTime = LocalDateTime.parse("2026-04-30T17:00:00")
+        val RESULT_ANNOUNCED_AT: LocalDateTime = LocalDateTime.parse("2026-05-15T10:00:00")
+
+        fun scheduleProperties(): LandingScheduleProperties =
+            LandingScheduleProperties(
+                applicationStartAt = APPLICATION_START_AT,
+                applicationEndAt = APPLICATION_END_AT,
+                resultAnnouncedAt = RESULT_ANNOUNCED_AT,
+            )
+    }
+}

--- a/systems/application/application-adapter-in/src/test/kotlin/hs/kr/entrydsm/application/adapterin/web/ApplicationControllerTest.kt
+++ b/systems/application/application-adapter-in/src/test/kotlin/hs/kr/entrydsm/application/adapterin/web/ApplicationControllerTest.kt
@@ -23,12 +23,10 @@ class ApplicationControllerTest {
         val controller = ApplicationController(applicationPort, scheduleProperties())
 
         val response = controller.createApplicant(
-            authorization = "Bearer access-token",
             userId = 10L,
         )
 
         assertEquals(10L, applicationPort.createApplicantCommand?.userId)
-        assertEquals("Bearer access-token", applicationPort.createApplicantCommand?.authorization)
         assertEquals(1L, response.data?.applicantId)
     }
 
@@ -36,7 +34,7 @@ class ApplicationControllerTest {
     fun getLandingReturnsConfiguredSchedule() {
         val controller = ApplicationController(FakeApplicationPort(), scheduleProperties())
 
-        val response = controller.getLanding("Bearer access-token", 10L)
+        val response = controller.getLanding(10L)
 
         assertEquals("홍길동", response.data?.applicantName)
         assertEquals(APPLICATION_START_AT, response.data?.schedule?.applicationPeriod?.startAt)

--- a/systems/application/application-adapter-in/src/test/kotlin/hs/kr/entrydsm/application/adapterin/web/EvaluationControllerTest.kt
+++ b/systems/application/application-adapter-in/src/test/kotlin/hs/kr/entrydsm/application/adapterin/web/EvaluationControllerTest.kt
@@ -21,7 +21,6 @@ class EvaluationControllerTest {
         val controller = EvaluationController(evaluationPort)
 
         controller.saveExpectedGrades(
-            authorization = "Bearer access-token",
             userId = 10L,
             request = SaveSubjectGradesRequest(
                 schoolSemester = "3-1",
@@ -34,13 +33,11 @@ class EvaluationControllerTest {
             evaluationPort.saveSubjectGradesCommand?.schoolSemester,
         )
         assertEquals(10L, evaluationPort.saveSubjectGradesCommand?.userId)
-        assertEquals("Bearer access-token", evaluationPort.saveSubjectGradesCommand?.authorization)
     }
 
     @Test(expected = IllegalArgumentException::class)
     fun saveExpectedGradesRejectsInvalidSchoolSemester() {
         EvaluationController(FakeEvaluationPort()).saveExpectedGrades(
-            authorization = "Bearer access-token",
             userId = 10L,
             request = SaveSubjectGradesRequest(
                 schoolSemester = "1-1",
@@ -55,13 +52,11 @@ class EvaluationControllerTest {
         val controller = EvaluationController(evaluationPort)
 
         val response = controller.getResult(
-            authorization = "Bearer access-token",
             userId = 10L,
         )
 
         assertEquals(null, response.data)
         assertEquals(10L, evaluationPort.calculateEvaluationCommand?.userId)
-        assertEquals("Bearer access-token", evaluationPort.calculateEvaluationCommand?.authorization)
     }
 
     private class FakeEvaluationPort : EvaluationPort {

--- a/systems/application/application-adapter-in/src/test/kotlin/hs/kr/entrydsm/application/adapterin/web/EvaluationControllerTest.kt
+++ b/systems/application/application-adapter-in/src/test/kotlin/hs/kr/entrydsm/application/adapterin/web/EvaluationControllerTest.kt
@@ -1,0 +1,91 @@
+package hs.kr.entrydsm.application.adapterin.web
+
+import hs.kr.entrydsm.application.adapterin.web.dto.request.SaveSubjectGradesRequest
+import hs.kr.entrydsm.application.adapterin.web.dto.request.SubjectGradesRequest
+import hs.kr.entrydsm.application.application.port.`in`.EvaluationPort
+import hs.kr.entrydsm.application.application.port.`in`.command.CalculateEvaluationCommand
+import hs.kr.entrydsm.application.application.port.`in`.command.SaveAcademicRecordCommand
+import hs.kr.entrydsm.application.application.port.`in`.command.SaveCertificatesCommand
+import hs.kr.entrydsm.application.application.port.`in`.command.SaveGedScoresCommand
+import hs.kr.entrydsm.application.application.port.`in`.command.SaveSubjectGradesCommand
+import hs.kr.entrydsm.application.application.port.`in`.result.AcademicRecordResult
+import hs.kr.entrydsm.application.application.port.`in`.result.EvaluationResult
+import hs.kr.entrydsm.application.domain.enum.SchoolSemester
+import hs.kr.entrydsm.application.domain.enum.SubjectGrade
+import org.junit.Assert.assertEquals
+import org.junit.Test
+
+class EvaluationControllerTest {
+    @Test
+    fun saveExpectedGradesConvertsSchoolSemester() {
+        val evaluationPort = FakeEvaluationPort()
+        val controller = EvaluationController(evaluationPort)
+
+        controller.saveExpectedGrades(
+            authorization = "Bearer access-token",
+            userId = 10L,
+            request = SaveSubjectGradesRequest(
+                applicantId = 1L,
+                schoolSemester = "3-1",
+                subjects = subjectGradesRequest(),
+            ),
+        )
+
+        assertEquals(
+            SchoolSemester.THIRD_GRADE_FIRST_SEMESTER,
+            evaluationPort.saveSubjectGradesCommand?.schoolSemester,
+        )
+        assertEquals(10L, evaluationPort.saveSubjectGradesCommand?.userId)
+        assertEquals("Bearer access-token", evaluationPort.saveSubjectGradesCommand?.authorization)
+    }
+
+    @Test(expected = IllegalArgumentException::class)
+    fun saveExpectedGradesRejectsInvalidSchoolSemester() {
+        EvaluationController(FakeEvaluationPort()).saveExpectedGrades(
+            authorization = "Bearer access-token",
+            userId = 10L,
+            request = SaveSubjectGradesRequest(
+                applicantId = 1L,
+                schoolSemester = "1-1",
+                subjects = subjectGradesRequest(),
+            ),
+        )
+    }
+
+    private class FakeEvaluationPort : EvaluationPort {
+        var saveSubjectGradesCommand: SaveSubjectGradesCommand? = null
+
+        override fun saveSubjectGrades(command: SaveSubjectGradesCommand) {
+            saveSubjectGradesCommand = command
+        }
+
+        override fun saveGedScores(command: SaveGedScoresCommand) = Unit
+
+        override fun saveAcademicRecord(command: SaveAcademicRecordCommand): AcademicRecordResult =
+            AcademicRecordResult(
+                absentCount = 0,
+                earlyLeaveCount = 0,
+                lateCount = 0,
+                classAbsenceCount = 0,
+                volunteerTime = 0,
+            )
+
+        override fun saveCertificates(command: SaveCertificatesCommand) = Unit
+
+        override fun calculateResult(command: CalculateEvaluationCommand): EvaluationResult =
+            EvaluationResult(scores = emptyMap())
+    }
+
+    private companion object {
+        fun subjectGradesRequest(): SubjectGradesRequest =
+            SubjectGradesRequest(
+                koreanGrade = SubjectGrade.A,
+                societyGrade = SubjectGrade.A,
+                englishGrade = SubjectGrade.A,
+                historyGrade = SubjectGrade.A,
+                mathGrade = SubjectGrade.A,
+                scienceGrade = SubjectGrade.A,
+                technologyGrade = SubjectGrade.A,
+            )
+    }
+}

--- a/systems/application/application-adapter-in/src/test/kotlin/hs/kr/entrydsm/application/adapterin/web/EvaluationControllerTest.kt
+++ b/systems/application/application-adapter-in/src/test/kotlin/hs/kr/entrydsm/application/adapterin/web/EvaluationControllerTest.kt
@@ -16,6 +16,29 @@ import org.junit.Test
 
 class EvaluationControllerTest {
     @Test
+    fun subjectGradesRequestConvertsEverySubjectGrade() {
+        val request = SubjectGradesRequest(
+            koreanGrade = SubjectGrade.A,
+            societyGrade = SubjectGrade.B,
+            englishGrade = SubjectGrade.C,
+            historyGrade = SubjectGrade.D,
+            mathGrade = SubjectGrade.E,
+            scienceGrade = SubjectGrade.X,
+            technologyGrade = SubjectGrade.A,
+        )
+
+        val result = request.toDomain()
+
+        assertEquals(SubjectGrade.A, result.koreanGrade)
+        assertEquals(SubjectGrade.B, result.societyGrade)
+        assertEquals(SubjectGrade.C, result.englishGrade)
+        assertEquals(SubjectGrade.D, result.historyGrade)
+        assertEquals(SubjectGrade.E, result.mathGrade)
+        assertEquals(SubjectGrade.X, result.scienceGrade)
+        assertEquals(SubjectGrade.A, result.technologyGrade)
+    }
+
+    @Test
     fun saveExpectedGradesConvertsSchoolSemester() {
         val evaluationPort = FakeEvaluationPort()
         val controller = EvaluationController(evaluationPort)

--- a/systems/application/application-adapter-in/src/test/kotlin/hs/kr/entrydsm/application/adapterin/web/EvaluationControllerTest.kt
+++ b/systems/application/application-adapter-in/src/test/kotlin/hs/kr/entrydsm/application/adapterin/web/EvaluationControllerTest.kt
@@ -9,7 +9,6 @@ import hs.kr.entrydsm.application.application.port.`in`.command.SaveCertificates
 import hs.kr.entrydsm.application.application.port.`in`.command.SaveGedScoresCommand
 import hs.kr.entrydsm.application.application.port.`in`.command.SaveSubjectGradesCommand
 import hs.kr.entrydsm.application.application.port.`in`.result.AcademicRecordResult
-import hs.kr.entrydsm.application.application.port.`in`.result.EvaluationResult
 import hs.kr.entrydsm.application.domain.enum.SchoolSemester
 import hs.kr.entrydsm.application.domain.enum.SubjectGrade
 import org.junit.Assert.assertEquals
@@ -25,7 +24,6 @@ class EvaluationControllerTest {
             authorization = "Bearer access-token",
             userId = 10L,
             request = SaveSubjectGradesRequest(
-                applicantId = 1L,
                 schoolSemester = "3-1",
                 subjects = subjectGradesRequest(),
             ),
@@ -45,15 +43,30 @@ class EvaluationControllerTest {
             authorization = "Bearer access-token",
             userId = 10L,
             request = SaveSubjectGradesRequest(
-                applicantId = 1L,
                 schoolSemester = "1-1",
                 subjects = subjectGradesRequest(),
             ),
         )
     }
 
+    @Test
+    fun getResultCalculatesAndDoesNotExposeScores() {
+        val evaluationPort = FakeEvaluationPort()
+        val controller = EvaluationController(evaluationPort)
+
+        val response = controller.getResult(
+            authorization = "Bearer access-token",
+            userId = 10L,
+        )
+
+        assertEquals(null, response.data)
+        assertEquals(10L, evaluationPort.calculateEvaluationCommand?.userId)
+        assertEquals("Bearer access-token", evaluationPort.calculateEvaluationCommand?.authorization)
+    }
+
     private class FakeEvaluationPort : EvaluationPort {
         var saveSubjectGradesCommand: SaveSubjectGradesCommand? = null
+        var calculateEvaluationCommand: CalculateEvaluationCommand? = null
 
         override fun saveSubjectGrades(command: SaveSubjectGradesCommand) {
             saveSubjectGradesCommand = command
@@ -72,8 +85,9 @@ class EvaluationControllerTest {
 
         override fun saveCertificates(command: SaveCertificatesCommand) = Unit
 
-        override fun calculateResult(command: CalculateEvaluationCommand): EvaluationResult =
-            EvaluationResult(scores = emptyMap())
+        override fun calculateResult(command: CalculateEvaluationCommand) {
+            calculateEvaluationCommand = command
+        }
     }
 
     private companion object {

--- a/systems/application/application-adapter-out/BUILD.bazel
+++ b/systems/application/application-adapter-out/BUILD.bazel
@@ -17,5 +17,5 @@ kt_jvm_test(
     javac_opts = "//:javac_options",
     kotlinc_opts = "//:kotlinc_options",
     test_class = "hs.kr.entrydsm.application.adapterout.ApplicationAdapterOutModuleTest",
-    deps = MODULE_DEPS + TEST_DEPS,
+    deps = [":main"] + MODULE_DEPS + TEST_DEPS,
 )

--- a/systems/application/application-adapter-out/deps.bzl
+++ b/systems/application/application-adapter-out/deps.bzl
@@ -1,4 +1,9 @@
-KOTLIN_DEPS = []
+KOTLIN_DEPS = [
+    "@maven//:org_springframework_boot_spring_boot_starter_data_jpa",
+    "@maven//:com_mysql_mysql_connector_j",
+    "//systems/application/application-application:main",
+    "//systems/application/application-domain:main",
+]
 
 TEST_DEPS = [
     "@maven//:junit_junit",

--- a/systems/application/application-adapter-out/src/main/kotlin/hs/kr/entrydsm/application/adapterout/entity/AcademicRecordJpaEntity.kt
+++ b/systems/application/application-adapter-out/src/main/kotlin/hs/kr/entrydsm/application/adapterout/entity/AcademicRecordJpaEntity.kt
@@ -23,7 +23,7 @@ open class AcademicRecordJpaEntity(
 
     @OneToOne(fetch = FetchType.LAZY)
     @JoinColumn(name = "applicant_id", nullable = false, unique = true)
-    var applicant: ApplicantJpaEntity? = null,
+    open var applicant: ApplicantJpaEntity? = null,
 
     @Column(name = "absent_count", nullable = false)
     var absentCount: Int = 0,
@@ -46,11 +46,11 @@ open class AcademicRecordJpaEntity(
     @Column(name = "is_programming_certified", nullable = false)
     var isProgrammingCertified: Boolean = false,
 
-    @OneToMany(mappedBy = "academicRecord", cascade = [CascadeType.ALL], orphanRemoval = true, fetch = FetchType.EAGER)
-    var subjectGrades: MutableList<SubjectGradeJpaEntity> = mutableListOf(),
+    @OneToMany(mappedBy = "academicRecord", cascade = [CascadeType.ALL], orphanRemoval = true, fetch = FetchType.LAZY)
+    open var subjectGrades: MutableList<SubjectGradeJpaEntity> = mutableListOf(),
 
-    @OneToOne(mappedBy = "academicRecord", cascade = [CascadeType.ALL], orphanRemoval = true, fetch = FetchType.EAGER)
-    var gedScores: GedScoreJpaEntity? = null,
+    @OneToOne(mappedBy = "academicRecord", cascade = [CascadeType.ALL], orphanRemoval = true, fetch = FetchType.LAZY)
+    open var gedScores: GedScoreJpaEntity? = null,
 ) {
     fun updateFrom(domain: AcademicRecord) {
         absentCount = domain.absentCount
@@ -60,17 +60,22 @@ open class AcademicRecordJpaEntity(
         volunteerTime = domain.volunteerTime
         isDsmAlgorithmAwarded = domain.isDsmAlgorithmAwarded
         isProgrammingCertified = domain.isProgrammingCertified
-        subjectGrades.clear()
-        subjectGrades.addAll(
-            domain.subjectGrades.map { (semester, grades) ->
-                SubjectGradeJpaEntity(
+        val domainSemesters = domain.subjectGrades.keys
+        subjectGrades.removeIf { it.id.schoolSemester !in domainSemesters }
+        domain.subjectGrades.forEach { (semester, grades) ->
+            val entity = subjectGrades.firstOrNull { it.id.schoolSemester == semester }
+                ?: SubjectGradeJpaEntity(
                     id = SubjectGradeId(schoolSemester = semester),
                     academicRecord = this,
-                ).apply { updateFrom(grades) }
-            },
-        )
+                ).also(subjectGrades::add)
+            entity.academicRecord = this
+            entity.updateFrom(grades)
+        }
         gedScores = domain.gedScores?.let {
-            GedScoreJpaEntity(academicRecord = this).apply { updateFrom(it) }
+            (gedScores ?: GedScoreJpaEntity(academicRecord = this)).apply {
+                academicRecord = this@AcademicRecordJpaEntity
+                updateFrom(it)
+            }
         }
     }
 

--- a/systems/application/application-adapter-out/src/main/kotlin/hs/kr/entrydsm/application/adapterout/entity/AcademicRecordJpaEntity.kt
+++ b/systems/application/application-adapter-out/src/main/kotlin/hs/kr/entrydsm/application/adapterout/entity/AcademicRecordJpaEntity.kt
@@ -1,0 +1,91 @@
+package hs.kr.entrydsm.application.adapterout.entity
+
+import hs.kr.entrydsm.application.domain.model.AcademicRecord
+import jakarta.persistence.CascadeType
+import jakarta.persistence.Column
+import jakarta.persistence.Entity
+import jakarta.persistence.FetchType
+import jakarta.persistence.GeneratedValue
+import jakarta.persistence.GenerationType
+import jakarta.persistence.Id
+import jakarta.persistence.JoinColumn
+import jakarta.persistence.OneToMany
+import jakarta.persistence.OneToOne
+import jakarta.persistence.Table
+
+@Entity
+@Table(name = "academic_records")
+open class AcademicRecordJpaEntity(
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    @Column(name = "id")
+    var id: Long? = null,
+
+    @OneToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "applicant_id", nullable = false, unique = true)
+    var applicant: ApplicantJpaEntity? = null,
+
+    @Column(name = "absent_count", nullable = false)
+    var absentCount: Int = 0,
+
+    @Column(name = "late_count", nullable = false)
+    var lateCount: Int = 0,
+
+    @Column(name = "early_leave_count", nullable = false)
+    var earlyLeaveCount: Int = 0,
+
+    @Column(name = "class_absence_count", nullable = false)
+    var classAbsenceCount: Int = 0,
+
+    @Column(name = "volunteer_time", nullable = false)
+    var volunteerTime: Int = 0,
+
+    @Column(name = "is_dsm_algorithm_awarded", nullable = false)
+    var isDsmAlgorithmAwarded: Boolean = false,
+
+    @Column(name = "is_programming_certified", nullable = false)
+    var isProgrammingCertified: Boolean = false,
+
+    @OneToMany(mappedBy = "academicRecord", cascade = [CascadeType.ALL], orphanRemoval = true, fetch = FetchType.EAGER)
+    var subjectGrades: MutableList<SubjectGradeJpaEntity> = mutableListOf(),
+
+    @OneToOne(mappedBy = "academicRecord", cascade = [CascadeType.ALL], orphanRemoval = true, fetch = FetchType.EAGER)
+    var gedScores: GedScoreJpaEntity? = null,
+) {
+    fun updateFrom(domain: AcademicRecord) {
+        absentCount = domain.absentCount
+        lateCount = domain.lateCount
+        earlyLeaveCount = domain.earlyLeaveCount
+        classAbsenceCount = domain.classAbsenceCount
+        volunteerTime = domain.volunteerTime
+        isDsmAlgorithmAwarded = domain.isDsmAlgorithmAwarded
+        isProgrammingCertified = domain.isProgrammingCertified
+        subjectGrades.clear()
+        subjectGrades.addAll(
+            domain.subjectGrades.map { (semester, grades) ->
+                SubjectGradeJpaEntity(
+                    id = SubjectGradeId(schoolSemester = semester),
+                    academicRecord = this,
+                ).apply { updateFrom(grades) }
+            },
+        )
+        gedScores = domain.gedScores?.let {
+            GedScoreJpaEntity(academicRecord = this).apply { updateFrom(it) }
+        }
+    }
+
+    fun toDomain(): AcademicRecord =
+        AcademicRecord(
+            absentCount = absentCount,
+            lateCount = lateCount,
+            earlyLeaveCount = earlyLeaveCount,
+            classAbsenceCount = classAbsenceCount,
+            volunteerTime = volunteerTime,
+            isDsmAlgorithmAwarded = isDsmAlgorithmAwarded,
+            isProgrammingCertified = isProgrammingCertified,
+            subjectGrades = subjectGrades
+                .associate { requireNotNull(it.id.schoolSemester) to it.toDomain() }
+                .toMutableMap(),
+            gedScores = gedScores?.toDomain(),
+        )
+}

--- a/systems/application/application-adapter-out/src/main/kotlin/hs/kr/entrydsm/application/adapterout/entity/ApplicantJpaEntity.kt
+++ b/systems/application/application-adapter-out/src/main/kotlin/hs/kr/entrydsm/application/adapterout/entity/ApplicantJpaEntity.kt
@@ -1,0 +1,207 @@
+package hs.kr.entrydsm.application.adapterout.entity
+
+import hs.kr.entrydsm.application.domain.enum.AdmissionType
+import hs.kr.entrydsm.application.domain.enum.Gender
+import hs.kr.entrydsm.application.domain.enum.GraduationType
+import hs.kr.entrydsm.application.domain.enum.GuardianRelation
+import hs.kr.entrydsm.application.domain.enum.Region
+import hs.kr.entrydsm.application.domain.enum.SpecialAdmissionType
+import hs.kr.entrydsm.application.domain.model.Applicant
+import hs.kr.entrydsm.application.domain.model.MiddleSchoolInfo
+import jakarta.persistence.CascadeType
+import jakarta.persistence.Column
+import jakarta.persistence.Entity
+import jakarta.persistence.EnumType
+import jakarta.persistence.Enumerated
+import jakarta.persistence.FetchType
+import jakarta.persistence.GeneratedValue
+import jakarta.persistence.GenerationType
+import jakarta.persistence.Id
+import jakarta.persistence.OneToMany
+import jakarta.persistence.OneToOne
+import jakarta.persistence.Table
+import java.time.LocalDate
+import java.time.LocalDateTime
+import java.time.YearMonth
+
+@Entity
+@Table(name = "applicants")
+open class ApplicantJpaEntity(
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    @Column(name = "id")
+    var id: Long? = null,
+
+    @Column(name = "account_id", nullable = false)
+    var accountId: Long = 0,
+
+    @Column(name = "photo_file_id")
+    var photoFileId: Long? = null,
+
+    @Column(name = "name", length = 20)
+    var name: String? = null,
+
+    @Column(name = "phone_number", length = 16)
+    var phoneNumber: String? = null,
+
+    @Enumerated(EnumType.STRING)
+    @Column(name = "gender", length = 10)
+    var gender: Gender? = null,
+
+    @Column(name = "birthdate")
+    var birthdate: LocalDate? = null,
+
+    @Enumerated(EnumType.STRING)
+    @Column(name = "special_admission_type", nullable = false, length = 32)
+    var specialAdmissionType: SpecialAdmissionType = SpecialAdmissionType.NONE,
+
+    @Enumerated(EnumType.STRING)
+    @Column(name = "admission_type", length = 16)
+    var admissionType: AdmissionType? = null,
+
+    @Enumerated(EnumType.STRING)
+    @Column(name = "region", length = 16)
+    var region: Region? = null,
+
+    @Enumerated(EnumType.STRING)
+    @Column(name = "graduation_type", length = 16)
+    var graduationType: GraduationType? = null,
+
+    @Column(name = "graduation_date")
+    var graduationDate: LocalDate? = null,
+
+    @Column(name = "guardian_name", length = 20)
+    var guardianName: String? = null,
+
+    @Column(name = "guardian_phone_number", length = 16)
+    var guardianPhoneNumber: String? = null,
+
+    @Enumerated(EnumType.STRING)
+    @Column(name = "guardian_gender", length = 10)
+    var guardianGender: Gender? = null,
+
+    @Enumerated(EnumType.STRING)
+    @Column(name = "guardian_relation", length = 10)
+    var guardianRelation: GuardianRelation? = null,
+
+    @Column(name = "address_base", length = 255)
+    var addressBase: String? = null,
+
+    @Column(name = "address_detail", length = 255)
+    var addressDetail: String? = null,
+
+    @Column(name = "zip_code", length = 10)
+    var zipCode: String? = null,
+
+    @Column(name = "introduction", columnDefinition = "TEXT")
+    var introduction: String? = null,
+
+    @Column(name = "study_plan", columnDefinition = "TEXT")
+    var studyPlan: String? = null,
+
+    @Column(name = "total_score")
+    var totalScore: Double? = null,
+
+    @Column(name = "total_score_updated_at")
+    var totalScoreUpdatedAt: LocalDateTime? = null,
+
+    @Column(name = "created_at", nullable = false)
+    var createdAt: LocalDateTime = LocalDateTime.now(),
+
+    @Column(name = "updated_at", nullable = false)
+    var updatedAt: LocalDateTime = LocalDateTime.now(),
+
+    @OneToOne(mappedBy = "applicant", cascade = [CascadeType.ALL], orphanRemoval = true, fetch = FetchType.EAGER)
+    var middleSchoolInfo: MiddleSchoolInfoJpaEntity? = null,
+
+    @OneToOne(mappedBy = "applicant", cascade = [CascadeType.ALL], orphanRemoval = true, fetch = FetchType.EAGER)
+    var academicRecord: AcademicRecordJpaEntity? = null,
+
+    @OneToMany(mappedBy = "applicant", cascade = [CascadeType.ALL], orphanRemoval = true)
+    var passResults: MutableList<PassResultJpaEntity> = mutableListOf(),
+) {
+    fun toDomain(): Applicant =
+        Applicant(
+            id = requireNotNull(id),
+            accountId = accountId,
+            photoFileId = photoFileId,
+            name = name,
+            phoneNumber = phoneNumber,
+            gender = gender,
+            birthdate = birthdate,
+            specialAdmissionType = specialAdmissionType,
+            admissionType = admissionType,
+            region = region,
+            graduationType = graduationType,
+            graduationDate = graduationDate?.let { YearMonth.from(it) },
+            guardianName = guardianName,
+            guardianPhoneNumber = guardianPhoneNumber,
+            guardianGender = guardianGender,
+            guardianRelation = guardianRelation,
+            addressBase = addressBase,
+            addressDetail = addressDetail,
+            zipCode = zipCode,
+            introduction = introduction,
+            studyPlan = studyPlan,
+            middleSchoolInfo = middleSchoolInfo?.toDomain(),
+            academicRecord = academicRecord?.toDomain(),
+            totalScore = totalScore,
+            totalScoreUpdatedAt = totalScoreUpdatedAt,
+            createdAt = createdAt,
+            updatedAt = updatedAt,
+        )
+
+    fun updateFrom(domain: Applicant) {
+        accountId = domain.accountId
+        photoFileId = domain.photoFileId
+        name = domain.name
+        phoneNumber = domain.phoneNumber
+        gender = domain.gender
+        birthdate = domain.birthdate
+        specialAdmissionType = domain.specialAdmissionType
+        admissionType = domain.admissionType
+        region = domain.region
+        graduationType = domain.graduationType
+        graduationDate = domain.graduationDate?.atDay(1)
+        guardianName = domain.guardianName
+        guardianPhoneNumber = domain.guardianPhoneNumber
+        guardianGender = domain.guardianGender
+        guardianRelation = domain.guardianRelation
+        addressBase = domain.addressBase
+        addressDetail = domain.addressDetail
+        zipCode = domain.zipCode
+        introduction = domain.introduction
+        studyPlan = domain.studyPlan
+        totalScore = domain.totalScore
+        totalScoreUpdatedAt = domain.totalScoreUpdatedAt
+        createdAt = domain.createdAt
+        updatedAt = domain.updatedAt
+        updateMiddleSchoolInfo(domain.middleSchoolInfo)
+        updateAcademicRecord(domain.academicRecord)
+    }
+
+    private fun updateMiddleSchoolInfo(domain: MiddleSchoolInfo?) {
+        middleSchoolInfo = domain?.let {
+            (middleSchoolInfo ?: MiddleSchoolInfoJpaEntity(applicant = this)).apply {
+                updateFrom(it)
+                applicant = this@ApplicantJpaEntity
+            }
+        }
+    }
+
+    private fun updateAcademicRecord(domain: hs.kr.entrydsm.application.domain.model.AcademicRecord?) {
+        academicRecord = domain?.let {
+            (academicRecord ?: AcademicRecordJpaEntity(applicant = this)).apply {
+                updateFrom(it)
+                applicant = this@ApplicantJpaEntity
+            }
+        }
+    }
+
+    companion object {
+        fun from(domain: Applicant): ApplicantJpaEntity =
+            ApplicantJpaEntity(id = domain.id.takeIf { it > 0 }).apply {
+                updateFrom(domain)
+            }
+    }
+}

--- a/systems/application/application-adapter-out/src/main/kotlin/hs/kr/entrydsm/application/adapterout/entity/ApplicantJpaEntity.kt
+++ b/systems/application/application-adapter-out/src/main/kotlin/hs/kr/entrydsm/application/adapterout/entity/ApplicantJpaEntity.kt
@@ -6,6 +6,7 @@ import hs.kr.entrydsm.application.domain.enum.GraduationType
 import hs.kr.entrydsm.application.domain.enum.GuardianRelation
 import hs.kr.entrydsm.application.domain.enum.Region
 import hs.kr.entrydsm.application.domain.enum.SpecialAdmissionType
+import hs.kr.entrydsm.application.domain.model.AcademicRecord
 import hs.kr.entrydsm.application.domain.model.Applicant
 import hs.kr.entrydsm.application.domain.model.MiddleSchoolInfo
 import jakarta.persistence.CascadeType
@@ -111,14 +112,14 @@ open class ApplicantJpaEntity(
     @Column(name = "updated_at", nullable = false)
     var updatedAt: LocalDateTime = LocalDateTime.now(),
 
-    @OneToOne(mappedBy = "applicant", cascade = [CascadeType.ALL], orphanRemoval = true, fetch = FetchType.EAGER)
-    var middleSchoolInfo: MiddleSchoolInfoJpaEntity? = null,
+    @OneToOne(mappedBy = "applicant", cascade = [CascadeType.ALL], orphanRemoval = true, fetch = FetchType.LAZY)
+    open var middleSchoolInfo: MiddleSchoolInfoJpaEntity? = null,
 
-    @OneToOne(mappedBy = "applicant", cascade = [CascadeType.ALL], orphanRemoval = true, fetch = FetchType.EAGER)
-    var academicRecord: AcademicRecordJpaEntity? = null,
+    @OneToOne(mappedBy = "applicant", cascade = [CascadeType.ALL], orphanRemoval = true, fetch = FetchType.LAZY)
+    open var academicRecord: AcademicRecordJpaEntity? = null,
 
     @OneToMany(mappedBy = "applicant", cascade = [CascadeType.ALL], orphanRemoval = true)
-    var passResults: MutableList<PassResultJpaEntity> = mutableListOf(),
+    open var passResults: MutableList<PassResultJpaEntity> = mutableListOf(),
 ) {
     fun toDomain(): Applicant =
         Applicant(
@@ -174,7 +175,6 @@ open class ApplicantJpaEntity(
         studyPlan = domain.studyPlan
         totalScore = domain.totalScore
         totalScoreUpdatedAt = domain.totalScoreUpdatedAt
-        createdAt = domain.createdAt
         updatedAt = domain.updatedAt
         updateMiddleSchoolInfo(domain.middleSchoolInfo)
         updateAcademicRecord(domain.academicRecord)
@@ -189,7 +189,7 @@ open class ApplicantJpaEntity(
         }
     }
 
-    private fun updateAcademicRecord(domain: hs.kr.entrydsm.application.domain.model.AcademicRecord?) {
+    private fun updateAcademicRecord(domain: AcademicRecord?) {
         academicRecord = domain?.let {
             (academicRecord ?: AcademicRecordJpaEntity(applicant = this)).apply {
                 updateFrom(it)
@@ -200,8 +200,9 @@ open class ApplicantJpaEntity(
 
     companion object {
         fun from(domain: Applicant): ApplicantJpaEntity =
-            ApplicantJpaEntity(id = domain.id.takeIf { it > 0 }).apply {
+            ApplicantJpaEntity().apply {
                 updateFrom(domain)
+                createdAt = domain.createdAt
             }
     }
 }

--- a/systems/application/application-adapter-out/src/main/kotlin/hs/kr/entrydsm/application/adapterout/entity/GedScoreJpaEntity.kt
+++ b/systems/application/application-adapter-out/src/main/kotlin/hs/kr/entrydsm/application/adapterout/entity/GedScoreJpaEntity.kt
@@ -20,7 +20,7 @@ open class GedScoreJpaEntity(
     @MapsId
     @OneToOne(fetch = FetchType.LAZY)
     @JoinColumn(name = "academic_record_id")
-    var academicRecord: AcademicRecordJpaEntity? = null,
+    open var academicRecord: AcademicRecordJpaEntity? = null,
 
     @Column(name = "korean_score", nullable = false)
     var koreanScore: Int = 0,

--- a/systems/application/application-adapter-out/src/main/kotlin/hs/kr/entrydsm/application/adapterout/entity/GedScoreJpaEntity.kt
+++ b/systems/application/application-adapter-out/src/main/kotlin/hs/kr/entrydsm/application/adapterout/entity/GedScoreJpaEntity.kt
@@ -1,0 +1,66 @@
+package hs.kr.entrydsm.application.adapterout.entity
+
+import hs.kr.entrydsm.application.domain.model.GedScores
+import jakarta.persistence.Column
+import jakarta.persistence.Entity
+import jakarta.persistence.FetchType
+import jakarta.persistence.Id
+import jakarta.persistence.JoinColumn
+import jakarta.persistence.MapsId
+import jakarta.persistence.OneToOne
+import jakarta.persistence.Table
+
+@Entity
+@Table(name = "ged_scores")
+open class GedScoreJpaEntity(
+    @Id
+    @Column(name = "academic_record_id")
+    var academicRecordId: Long? = null,
+
+    @MapsId
+    @OneToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "academic_record_id")
+    var academicRecord: AcademicRecordJpaEntity? = null,
+
+    @Column(name = "korean_score", nullable = false)
+    var koreanScore: Int = 0,
+
+    @Column(name = "math_score", nullable = false)
+    var mathScore: Int = 0,
+
+    @Column(name = "english_score", nullable = false)
+    var englishScore: Int = 0,
+
+    @Column(name = "science_score", nullable = false)
+    var scienceScore: Int = 0,
+
+    @Column(name = "society_score", nullable = false)
+    var societyScore: Int = 0,
+
+    @Column(name = "technology_score", nullable = false)
+    var technologyScore: Int = 0,
+
+    @Column(name = "history_score", nullable = false)
+    var historyScore: Int = 0,
+) {
+    fun updateFrom(domain: GedScores) {
+        koreanScore = domain.koreanScore
+        mathScore = domain.mathScore
+        englishScore = domain.englishScore
+        scienceScore = domain.scienceScore
+        societyScore = domain.societyScore
+        technologyScore = domain.technologyScore
+        historyScore = domain.historyScore
+    }
+
+    fun toDomain(): GedScores =
+        GedScores(
+            koreanScore = koreanScore,
+            mathScore = mathScore,
+            englishScore = englishScore,
+            scienceScore = scienceScore,
+            societyScore = societyScore,
+            technologyScore = technologyScore,
+            historyScore = historyScore,
+        )
+}

--- a/systems/application/application-adapter-out/src/main/kotlin/hs/kr/entrydsm/application/adapterout/entity/MiddleSchoolInfoJpaEntity.kt
+++ b/systems/application/application-adapter-out/src/main/kotlin/hs/kr/entrydsm/application/adapterout/entity/MiddleSchoolInfoJpaEntity.kt
@@ -1,0 +1,51 @@
+package hs.kr.entrydsm.application.adapterout.entity
+
+import hs.kr.entrydsm.application.domain.model.MiddleSchoolInfo
+import jakarta.persistence.Column
+import jakarta.persistence.Entity
+import jakarta.persistence.FetchType
+import jakarta.persistence.Id
+import jakarta.persistence.JoinColumn
+import jakarta.persistence.MapsId
+import jakarta.persistence.OneToOne
+import jakarta.persistence.Table
+
+@Entity
+@Table(name = "middle_school_infos")
+open class MiddleSchoolInfoJpaEntity(
+    @Id
+    @Column(name = "applicant_id")
+    var applicantId: Long? = null,
+
+    @MapsId
+    @OneToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "applicant_id")
+    var applicant: ApplicantJpaEntity? = null,
+
+    @Column(name = "school_name", nullable = false, length = 50)
+    var schoolName: String = "",
+
+    @Column(name = "student_number", nullable = false, length = 8)
+    var studentNumber: String = "",
+
+    @Column(name = "school_phone", nullable = false, length = 16)
+    var schoolPhone: String = "",
+
+    @Column(name = "teacher_name", nullable = false, length = 20)
+    var teacherName: String = "",
+) {
+    fun updateFrom(domain: MiddleSchoolInfo) {
+        schoolName = domain.schoolName
+        studentNumber = domain.studentNumber
+        schoolPhone = domain.schoolPhone
+        teacherName = domain.teacherName
+    }
+
+    fun toDomain(): MiddleSchoolInfo =
+        MiddleSchoolInfo(
+            schoolName = schoolName,
+            studentNumber = studentNumber,
+            schoolPhone = schoolPhone,
+            teacherName = teacherName,
+        )
+}

--- a/systems/application/application-adapter-out/src/main/kotlin/hs/kr/entrydsm/application/adapterout/entity/PassResultId.kt
+++ b/systems/application/application-adapter-out/src/main/kotlin/hs/kr/entrydsm/application/adapterout/entity/PassResultId.kt
@@ -1,0 +1,18 @@
+package hs.kr.entrydsm.application.adapterout.entity
+
+import hs.kr.entrydsm.application.domain.enum.ResultType
+import jakarta.persistence.Column
+import jakarta.persistence.Embeddable
+import jakarta.persistence.EnumType
+import jakarta.persistence.Enumerated
+import java.io.Serializable
+
+@Embeddable
+data class PassResultId(
+    @Column(name = "applicant_id")
+    var applicantId: Long? = null,
+
+    @Enumerated(EnumType.STRING)
+    @Column(name = "result_type", length = 16)
+    var resultType: ResultType? = null,
+) : Serializable

--- a/systems/application/application-adapter-out/src/main/kotlin/hs/kr/entrydsm/application/adapterout/entity/PassResultJpaEntity.kt
+++ b/systems/application/application-adapter-out/src/main/kotlin/hs/kr/entrydsm/application/adapterout/entity/PassResultJpaEntity.kt
@@ -1,0 +1,36 @@
+package hs.kr.entrydsm.application.adapterout.entity
+
+import hs.kr.entrydsm.application.domain.enum.PassResultStatus
+import jakarta.persistence.Column
+import jakarta.persistence.EmbeddedId
+import jakarta.persistence.Entity
+import jakarta.persistence.EnumType
+import jakarta.persistence.Enumerated
+import jakarta.persistence.FetchType
+import jakarta.persistence.JoinColumn
+import jakarta.persistence.ManyToOne
+import jakarta.persistence.MapsId
+import jakarta.persistence.Table
+import java.time.LocalDateTime
+
+@Entity
+@Table(name = "pass_results")
+open class PassResultJpaEntity(
+    @EmbeddedId
+    var id: PassResultId = PassResultId(),
+
+    @MapsId("applicantId")
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "applicant_id")
+    var applicant: ApplicantJpaEntity? = null,
+
+    @Column(name = "processed_by")
+    var processedBy: Long? = null,
+
+    @Enumerated(EnumType.STRING)
+    @Column(name = "result", nullable = false, length = 16)
+    var result: PassResultStatus = PassResultStatus.PENDING,
+
+    @Column(name = "processed_at")
+    var processedAt: LocalDateTime? = null,
+)

--- a/systems/application/application-adapter-out/src/main/kotlin/hs/kr/entrydsm/application/adapterout/entity/SubjectGradeId.kt
+++ b/systems/application/application-adapter-out/src/main/kotlin/hs/kr/entrydsm/application/adapterout/entity/SubjectGradeId.kt
@@ -1,0 +1,18 @@
+package hs.kr.entrydsm.application.adapterout.entity
+
+import hs.kr.entrydsm.application.domain.enum.SchoolSemester
+import jakarta.persistence.Column
+import jakarta.persistence.Embeddable
+import jakarta.persistence.EnumType
+import jakarta.persistence.Enumerated
+import java.io.Serializable
+
+@Embeddable
+data class SubjectGradeId(
+    @Column(name = "academic_record_id")
+    var academicRecordId: Long? = null,
+
+    @Enumerated(EnumType.STRING)
+    @Column(name = "school_semester", length = 20)
+    var schoolSemester: SchoolSemester? = null,
+) : Serializable

--- a/systems/application/application-adapter-out/src/main/kotlin/hs/kr/entrydsm/application/adapterout/entity/SubjectGradeJpaEntity.kt
+++ b/systems/application/application-adapter-out/src/main/kotlin/hs/kr/entrydsm/application/adapterout/entity/SubjectGradeJpaEntity.kt
@@ -22,7 +22,7 @@ open class SubjectGradeJpaEntity(
     @MapsId("academicRecordId")
     @ManyToOne(fetch = FetchType.LAZY)
     @JoinColumn(name = "academic_record_id")
-    var academicRecord: AcademicRecordJpaEntity? = null,
+    open var academicRecord: AcademicRecordJpaEntity? = null,
 
     @Enumerated(EnumType.STRING)
     @Column(name = "korean_grade", nullable = false, length = 2)

--- a/systems/application/application-adapter-out/src/main/kotlin/hs/kr/entrydsm/application/adapterout/entity/SubjectGradeJpaEntity.kt
+++ b/systems/application/application-adapter-out/src/main/kotlin/hs/kr/entrydsm/application/adapterout/entity/SubjectGradeJpaEntity.kt
@@ -1,0 +1,75 @@
+package hs.kr.entrydsm.application.adapterout.entity
+
+import hs.kr.entrydsm.application.domain.enum.SubjectGrade
+import hs.kr.entrydsm.application.domain.model.SubjectGrades
+import jakarta.persistence.Column
+import jakarta.persistence.EmbeddedId
+import jakarta.persistence.Entity
+import jakarta.persistence.EnumType
+import jakarta.persistence.Enumerated
+import jakarta.persistence.FetchType
+import jakarta.persistence.JoinColumn
+import jakarta.persistence.ManyToOne
+import jakarta.persistence.MapsId
+import jakarta.persistence.Table
+
+@Entity
+@Table(name = "subject_grades")
+open class SubjectGradeJpaEntity(
+    @EmbeddedId
+    var id: SubjectGradeId = SubjectGradeId(),
+
+    @MapsId("academicRecordId")
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "academic_record_id")
+    var academicRecord: AcademicRecordJpaEntity? = null,
+
+    @Enumerated(EnumType.STRING)
+    @Column(name = "korean_grade", nullable = false, length = 2)
+    var koreanGrade: SubjectGrade = SubjectGrade.X,
+
+    @Enumerated(EnumType.STRING)
+    @Column(name = "math_grade", nullable = false, length = 2)
+    var mathGrade: SubjectGrade = SubjectGrade.X,
+
+    @Enumerated(EnumType.STRING)
+    @Column(name = "english_grade", nullable = false, length = 2)
+    var englishGrade: SubjectGrade = SubjectGrade.X,
+
+    @Enumerated(EnumType.STRING)
+    @Column(name = "science_grade", nullable = false, length = 2)
+    var scienceGrade: SubjectGrade = SubjectGrade.X,
+
+    @Enumerated(EnumType.STRING)
+    @Column(name = "society_grade", nullable = false, length = 2)
+    var societyGrade: SubjectGrade = SubjectGrade.X,
+
+    @Enumerated(EnumType.STRING)
+    @Column(name = "technology_grade", nullable = false, length = 2)
+    var technologyGrade: SubjectGrade = SubjectGrade.X,
+
+    @Enumerated(EnumType.STRING)
+    @Column(name = "history_grade", nullable = false, length = 2)
+    var historyGrade: SubjectGrade = SubjectGrade.X,
+) {
+    fun updateFrom(domain: SubjectGrades) {
+        koreanGrade = domain.koreanGrade
+        mathGrade = domain.mathGrade
+        englishGrade = domain.englishGrade
+        scienceGrade = domain.scienceGrade
+        societyGrade = domain.societyGrade
+        technologyGrade = domain.technologyGrade
+        historyGrade = domain.historyGrade
+    }
+
+    fun toDomain(): SubjectGrades =
+        SubjectGrades(
+            koreanGrade = koreanGrade,
+            mathGrade = mathGrade,
+            englishGrade = englishGrade,
+            scienceGrade = scienceGrade,
+            societyGrade = societyGrade,
+            technologyGrade = technologyGrade,
+            historyGrade = historyGrade,
+        )
+}

--- a/systems/application/application-adapter-out/src/main/kotlin/hs/kr/entrydsm/application/adapterout/repository/ApplicantJpaRepository.kt
+++ b/systems/application/application-adapter-out/src/main/kotlin/hs/kr/entrydsm/application/adapterout/repository/ApplicantJpaRepository.kt
@@ -3,4 +3,6 @@ package hs.kr.entrydsm.application.adapterout.repository
 import hs.kr.entrydsm.application.adapterout.entity.ApplicantJpaEntity
 import org.springframework.data.jpa.repository.JpaRepository
 
-interface ApplicantJpaRepository : JpaRepository<ApplicantJpaEntity, Long>
+interface ApplicantJpaRepository : JpaRepository<ApplicantJpaEntity, Long> {
+    fun findByAccountId(accountId: Long): ApplicantJpaEntity?
+}

--- a/systems/application/application-adapter-out/src/main/kotlin/hs/kr/entrydsm/application/adapterout/repository/ApplicantJpaRepository.kt
+++ b/systems/application/application-adapter-out/src/main/kotlin/hs/kr/entrydsm/application/adapterout/repository/ApplicantJpaRepository.kt
@@ -1,0 +1,6 @@
+package hs.kr.entrydsm.application.adapterout.repository
+
+import hs.kr.entrydsm.application.adapterout.entity.ApplicantJpaEntity
+import org.springframework.data.jpa.repository.JpaRepository
+
+interface ApplicantJpaRepository : JpaRepository<ApplicantJpaEntity, Long>

--- a/systems/application/application-adapter-out/src/main/kotlin/hs/kr/entrydsm/application/adapterout/repository/ApplicantPersistenceAdapter.kt
+++ b/systems/application/application-adapter-out/src/main/kotlin/hs/kr/entrydsm/application/adapterout/repository/ApplicantPersistenceAdapter.kt
@@ -1,0 +1,26 @@
+package hs.kr.entrydsm.application.adapterout.repository
+
+import hs.kr.entrydsm.application.adapterout.entity.ApplicantJpaEntity
+import hs.kr.entrydsm.application.application.port.out.ApplicantRepository
+import hs.kr.entrydsm.application.domain.model.Applicant
+import org.springframework.stereotype.Repository
+import org.springframework.transaction.annotation.Transactional
+
+@Repository
+@Transactional
+class ApplicantPersistenceAdapter(
+    private val applicantJpaRepository: ApplicantJpaRepository,
+) : ApplicantRepository {
+    override fun save(applicant: Applicant): Applicant {
+        val entity = applicant.id.takeIf { it > 0 }
+            ?.let { applicantJpaRepository.findById(it).orElse(null) }
+            ?.apply { updateFrom(applicant) }
+            ?: ApplicantJpaEntity.from(applicant)
+
+        return applicantJpaRepository.saveAndFlush(entity).toDomain()
+    }
+
+    @Transactional(readOnly = true)
+    override fun findById(id: Long): Applicant? =
+        applicantJpaRepository.findById(id).orElse(null)?.toDomain()
+}

--- a/systems/application/application-adapter-out/src/main/kotlin/hs/kr/entrydsm/application/adapterout/repository/ApplicantPersistenceAdapter.kt
+++ b/systems/application/application-adapter-out/src/main/kotlin/hs/kr/entrydsm/application/adapterout/repository/ApplicantPersistenceAdapter.kt
@@ -23,4 +23,8 @@ class ApplicantPersistenceAdapter(
     @Transactional(readOnly = true)
     override fun findById(id: Long): Applicant? =
         applicantJpaRepository.findById(id).orElse(null)?.toDomain()
+
+    @Transactional(readOnly = true)
+    override fun findByAccountId(accountId: Long): Applicant? =
+        applicantJpaRepository.findByAccountId(accountId)?.toDomain()
 }

--- a/systems/application/application-adapter-out/src/main/kotlin/hs/kr/entrydsm/application/adapterout/repository/ApplicantPersistenceAdapter.kt
+++ b/systems/application/application-adapter-out/src/main/kotlin/hs/kr/entrydsm/application/adapterout/repository/ApplicantPersistenceAdapter.kt
@@ -1,6 +1,7 @@
 package hs.kr.entrydsm.application.adapterout.repository
 
 import hs.kr.entrydsm.application.adapterout.entity.ApplicantJpaEntity
+import hs.kr.entrydsm.application.application.exception.ApplicantNotFoundException
 import hs.kr.entrydsm.application.application.port.out.ApplicantRepository
 import hs.kr.entrydsm.application.domain.model.Applicant
 import org.springframework.stereotype.Repository
@@ -12,10 +13,13 @@ class ApplicantPersistenceAdapter(
     private val applicantJpaRepository: ApplicantJpaRepository,
 ) : ApplicantRepository {
     override fun save(applicant: Applicant): Applicant {
-        val entity = applicant.id.takeIf { it > 0 }
-            ?.let { applicantJpaRepository.findById(it).orElse(null) }
-            ?.apply { updateFrom(applicant) }
-            ?: ApplicantJpaEntity.from(applicant)
+        val entity = if (applicant.id > 0) {
+            applicantJpaRepository.findById(applicant.id)
+                .orElseThrow { ApplicantNotFoundException(applicant.id) }
+                .apply { updateFrom(applicant) }
+        } else {
+            ApplicantJpaEntity.from(applicant)
+        }
 
         return applicantJpaRepository.saveAndFlush(entity).toDomain()
     }

--- a/systems/application/application-adapter-out/src/test/kotlin/hs/kr/entrydsm/TestMain.kt
+++ b/systems/application/application-adapter-out/src/test/kotlin/hs/kr/entrydsm/TestMain.kt
@@ -1,11 +1,13 @@
 package hs.kr.entrydsm.application.adapterout
 
-import org.junit.Assert.assertTrue
-import org.junit.Test
+import hs.kr.entrydsm.application.adapterout.entity.ApplicantJpaEntityTest
+import hs.kr.entrydsm.application.adapterout.entity.AcademicRecordJpaEntityTest
+import org.junit.runner.RunWith
+import org.junit.runners.Suite
 
-class ApplicationAdapterOutModuleTest {
-    @Test
-    fun moduleLoads() {
-        assertTrue(true)
-    }
-}
+@RunWith(Suite::class)
+@Suite.SuiteClasses(
+    AcademicRecordJpaEntityTest::class,
+    ApplicantJpaEntityTest::class,
+)
+class ApplicationAdapterOutModuleTest

--- a/systems/application/application-adapter-out/src/test/kotlin/hs/kr/entrydsm/application/adapterout/entity/AcademicRecordJpaEntityTest.kt
+++ b/systems/application/application-adapter-out/src/test/kotlin/hs/kr/entrydsm/application/adapterout/entity/AcademicRecordJpaEntityTest.kt
@@ -1,0 +1,109 @@
+package hs.kr.entrydsm.application.adapterout.entity
+
+import hs.kr.entrydsm.application.domain.enum.SchoolSemester
+import hs.kr.entrydsm.application.domain.enum.SubjectGrade
+import hs.kr.entrydsm.application.domain.model.AcademicRecord
+import hs.kr.entrydsm.application.domain.model.GedScores
+import hs.kr.entrydsm.application.domain.model.SubjectGrades
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertNull
+import org.junit.Assert.assertSame
+import org.junit.Test
+
+class AcademicRecordJpaEntityTest {
+    @Test
+    fun updateFromUpdatesSubjectGradeEntityInPlace() {
+        val entity = AcademicRecordJpaEntity()
+        entity.updateFrom(
+            AcademicRecord(
+                subjectGrades = linkedMapOf(
+                    SchoolSemester.SECOND_GRADE_FIRST_SEMESTER to subjectGrades(SubjectGrade.B),
+                ),
+            ),
+        )
+        val savedGrade = entity.subjectGrades.single()
+
+        entity.updateFrom(
+            AcademicRecord(
+                subjectGrades = linkedMapOf(
+                    SchoolSemester.SECOND_GRADE_FIRST_SEMESTER to subjectGrades(SubjectGrade.A),
+                ),
+            ),
+        )
+
+        assertSame(savedGrade, entity.subjectGrades.single())
+        assertEquals(SubjectGrade.A, entity.subjectGrades.single().koreanGrade)
+        assertSame(entity, entity.subjectGrades.single().academicRecord)
+    }
+
+    @Test
+    fun updateFromRemovesStaleSubjectGrades() {
+        val entity = AcademicRecordJpaEntity()
+        entity.updateFrom(
+            AcademicRecord(
+                subjectGrades = linkedMapOf(
+                    SchoolSemester.SECOND_GRADE_FIRST_SEMESTER to subjectGrades(SubjectGrade.A),
+                    SchoolSemester.SECOND_GRADE_SECOND_SEMESTER to subjectGrades(SubjectGrade.B),
+                ),
+            ),
+        )
+
+        entity.updateFrom(
+            AcademicRecord(
+                subjectGrades = linkedMapOf(
+                    SchoolSemester.SECOND_GRADE_SECOND_SEMESTER to subjectGrades(SubjectGrade.C),
+                ),
+            ),
+        )
+
+        assertEquals(
+            listOf(SchoolSemester.SECOND_GRADE_SECOND_SEMESTER),
+            entity.subjectGrades.map { it.id.schoolSemester },
+        )
+    }
+
+    @Test
+    fun updateFromUpdatesGedScoreEntityInPlace() {
+        val entity = AcademicRecordJpaEntity()
+        entity.updateFrom(AcademicRecord(gedScores = gedScores(80)))
+        val savedGedScores = entity.gedScores
+
+        entity.updateFrom(AcademicRecord(gedScores = gedScores(90)))
+
+        assertSame(savedGedScores, entity.gedScores)
+        assertEquals(90, entity.gedScores?.koreanScore)
+        assertSame(entity, entity.gedScores?.academicRecord)
+    }
+
+    @Test
+    fun updateFromRemovesGedScoresWhenDomainDoesNotHaveGedScores() {
+        val entity = AcademicRecordJpaEntity()
+        entity.updateFrom(AcademicRecord(gedScores = gedScores(80)))
+
+        entity.updateFrom(AcademicRecord())
+
+        assertNull(entity.gedScores)
+    }
+
+    private fun subjectGrades(grade: SubjectGrade): SubjectGrades =
+        SubjectGrades(
+            koreanGrade = grade,
+            mathGrade = grade,
+            englishGrade = grade,
+            scienceGrade = grade,
+            societyGrade = grade,
+            technologyGrade = grade,
+            historyGrade = grade,
+        )
+
+    private fun gedScores(score: Int): GedScores =
+        GedScores(
+            koreanScore = score,
+            mathScore = score,
+            englishScore = score,
+            scienceScore = score,
+            societyScore = score,
+            technologyScore = score,
+            historyScore = score,
+        )
+}

--- a/systems/application/application-adapter-out/src/test/kotlin/hs/kr/entrydsm/application/adapterout/entity/ApplicantJpaEntityTest.kt
+++ b/systems/application/application-adapter-out/src/test/kotlin/hs/kr/entrydsm/application/adapterout/entity/ApplicantJpaEntityTest.kt
@@ -1,0 +1,59 @@
+package hs.kr.entrydsm.application.adapterout.entity
+
+import hs.kr.entrydsm.application.domain.model.Applicant
+import java.time.LocalDateTime
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertNull
+import org.junit.Test
+
+class ApplicantJpaEntityTest {
+    @Test
+    fun fromCreatesNewEntityWithoutCarryingPositiveDomainId() {
+        val entity = ApplicantJpaEntity.from(
+            Applicant(
+                id = 100L,
+                accountId = 1L,
+            ),
+        )
+
+        assertNull(entity.id)
+        assertEquals(1L, entity.accountId)
+    }
+
+    @Test
+    fun updateFromDoesNotOverwriteCreatedAt() {
+        val originalCreatedAt = LocalDateTime.of(2026, 1, 1, 0, 0)
+        val domainCreatedAt = LocalDateTime.of(2026, 2, 1, 0, 0)
+        val entity = ApplicantJpaEntity(
+            id = 1L,
+            accountId = 1L,
+            createdAt = originalCreatedAt,
+        )
+
+        entity.updateFrom(
+            Applicant(
+                id = 1L,
+                accountId = 2L,
+                createdAt = domainCreatedAt,
+            ),
+        )
+
+        assertEquals(originalCreatedAt, entity.createdAt)
+        assertEquals(2L, entity.accountId)
+    }
+
+    @Test
+    fun fromUsesDomainCreatedAtForNewEntity() {
+        val createdAt = LocalDateTime.of(2026, 3, 1, 0, 0)
+
+        val entity = ApplicantJpaEntity.from(
+            Applicant(
+                id = 0L,
+                accountId = 1L,
+                createdAt = createdAt,
+            ),
+        )
+
+        assertEquals(createdAt, entity.createdAt)
+    }
+}

--- a/systems/application/application-application/BUILD.bazel
+++ b/systems/application/application-application/BUILD.bazel
@@ -17,5 +17,5 @@ kt_jvm_test(
     javac_opts = "//:javac_options",
     kotlinc_opts = "//:kotlinc_options",
     test_class = "hs.kr.entrydsm.application.application.ApplicationApplicationModuleTest",
-    deps = MODULE_DEPS + TEST_DEPS,
+    deps = [":main"] + MODULE_DEPS + TEST_DEPS,
 )

--- a/systems/application/application-application/src/main/kotlin/hs/kr/entrydsm/application/application/service/ApplicationCommandService.kt
+++ b/systems/application/application-application/src/main/kotlin/hs/kr/entrydsm/application/application/service/ApplicationCommandService.kt
@@ -129,6 +129,10 @@ class ApplicationCommandService(
         applicant.region = region
         applicant.graduationType = graduationType
         applicant.graduationDate = graduationDate
+        if (graduationType == GraduationType.GED) {
+            applicant.middleSchoolInfo = null
+            applicant.academicRecord?.subjectGrades?.clear()
+        }
         saveTouched(applicant)
     }
 

--- a/systems/application/application-application/src/test/kotlin/hs/kr/entrydsm/TestMain.kt
+++ b/systems/application/application-application/src/test/kotlin/hs/kr/entrydsm/TestMain.kt
@@ -1,11 +1,13 @@
 package hs.kr.entrydsm.application.application
 
-import org.junit.Assert.assertTrue
-import org.junit.Test
+import hs.kr.entrydsm.application.application.service.ApplicationCommandServiceTest
+import hs.kr.entrydsm.application.application.service.EvaluationCommandServiceTest
+import org.junit.runner.RunWith
+import org.junit.runners.Suite
 
-class ApplicationApplicationModuleTest {
-    @Test
-    fun moduleLoads() {
-        assertTrue(true)
-    }
-}
+@RunWith(Suite::class)
+@Suite.SuiteClasses(
+    ApplicationCommandServiceTest::class,
+    EvaluationCommandServiceTest::class,
+)
+class ApplicationApplicationModuleTest

--- a/systems/application/application-application/src/test/kotlin/hs/kr/entrydsm/application/application/service/ApplicationCommandServiceTest.kt
+++ b/systems/application/application-application/src/test/kotlin/hs/kr/entrydsm/application/application/service/ApplicationCommandServiceTest.kt
@@ -1,0 +1,84 @@
+package hs.kr.entrydsm.application.application.service
+
+import hs.kr.entrydsm.application.application.port.out.ApplicantRepository
+import hs.kr.entrydsm.application.domain.enum.AdmissionType
+import hs.kr.entrydsm.application.domain.enum.GraduationType
+import hs.kr.entrydsm.application.domain.enum.Region
+import hs.kr.entrydsm.application.domain.enum.SchoolSemester
+import hs.kr.entrydsm.application.domain.enum.SubjectGrade
+import hs.kr.entrydsm.application.domain.model.AcademicRecord
+import hs.kr.entrydsm.application.domain.model.Applicant
+import hs.kr.entrydsm.application.domain.model.MiddleSchoolInfo
+import hs.kr.entrydsm.application.domain.model.SubjectGrades
+import org.junit.Assert.assertNull
+import org.junit.Assert.assertTrue
+import org.junit.Test
+
+class ApplicationCommandServiceTest {
+    @Test
+    fun updateTypeClearsMiddleSchoolInfoAndSubjectGradesWhenChangedToGed() {
+        val repository = FakeApplicantRepository(
+            Applicant(
+                id = 1L,
+                accountId = 10L,
+                graduationType = GraduationType.PROSPECTIVE,
+                middleSchoolInfo = MiddleSchoolInfo(
+                    schoolName = "대덕중학교",
+                    studentNumber = "30101",
+                    schoolPhone = "042-000-0000",
+                    teacherName = "담임",
+                ),
+                academicRecord = AcademicRecord(
+                    subjectGrades = linkedMapOf(
+                        SchoolSemester.THIRD_GRADE_FIRST_SEMESTER to all(SubjectGrade.A),
+                    ),
+                ),
+            ),
+        )
+        val service = ApplicationCommandService(repository)
+
+        service.updateType(
+            applicantId = 1L,
+            userId = 10L,
+            admissionType = AdmissionType.REGULAR,
+            region = Region.DAEJEON,
+            graduationType = GraduationType.GED,
+            graduationDate = null,
+        )
+
+        val savedApplicant = requireNotNull(repository.savedApplicant)
+        assertNull(savedApplicant.middleSchoolInfo)
+        assertTrue(savedApplicant.academicRecord?.subjectGrades?.isEmpty() == true)
+    }
+
+    private class FakeApplicantRepository(
+        private var applicant: Applicant,
+    ) : ApplicantRepository {
+        var savedApplicant: Applicant? = null
+
+        override fun save(applicant: Applicant): Applicant {
+            savedApplicant = applicant
+            this.applicant = applicant
+            return applicant
+        }
+
+        override fun findById(id: Long): Applicant? =
+            applicant.takeIf { it.id == id }
+
+        override fun findByAccountId(accountId: Long): Applicant? =
+            applicant.takeIf { it.accountId == accountId }
+    }
+
+    private companion object {
+        fun all(grade: SubjectGrade): SubjectGrades =
+            SubjectGrades(
+                koreanGrade = grade,
+                mathGrade = grade,
+                englishGrade = grade,
+                scienceGrade = grade,
+                societyGrade = grade,
+                technologyGrade = grade,
+                historyGrade = grade,
+            )
+    }
+}

--- a/systems/application/application-application/src/test/kotlin/hs/kr/entrydsm/application/application/service/EvaluationCommandServiceTest.kt
+++ b/systems/application/application-application/src/test/kotlin/hs/kr/entrydsm/application/application/service/EvaluationCommandServiceTest.kt
@@ -1,0 +1,75 @@
+package hs.kr.entrydsm.application.application.service
+
+import hs.kr.entrydsm.application.application.port.out.ApplicantRepository
+import hs.kr.entrydsm.application.domain.enum.AdmissionType
+import hs.kr.entrydsm.application.domain.enum.GraduationType
+import hs.kr.entrydsm.application.domain.enum.SchoolSemester
+import hs.kr.entrydsm.application.domain.enum.SubjectGrade
+import hs.kr.entrydsm.application.domain.model.AcademicRecord
+import hs.kr.entrydsm.application.domain.model.Applicant
+import hs.kr.entrydsm.application.domain.model.SubjectGrades
+import hs.kr.entrydsm.application.domain.service.ScoreCalculator
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertNotNull
+import org.junit.Test
+
+class EvaluationCommandServiceTest {
+    @Test
+    fun calculateResultSavesScoreForApplicantsAdmissionType() {
+        val repository = FakeApplicantRepository(
+            Applicant(
+                id = 1L,
+                accountId = 10L,
+                admissionType = AdmissionType.REGULAR,
+                graduationType = GraduationType.PROSPECTIVE,
+                academicRecord = AcademicRecord(
+                    volunteerTime = 15,
+                    isDsmAlgorithmAwarded = true,
+                    subjectGrades = linkedMapOf(
+                        SchoolSemester.THIRD_GRADE_FIRST_SEMESTER to all(SubjectGrade.A),
+                        SchoolSemester.SECOND_GRADE_SECOND_SEMESTER to all(SubjectGrade.A),
+                        SchoolSemester.SECOND_GRADE_FIRST_SEMESTER to all(SubjectGrade.A),
+                    ),
+                ),
+            ),
+        )
+        val service = EvaluationCommandService(repository, ScoreCalculator())
+
+        service.calculateResult(userId = 10L)
+
+        val savedApplicant = requireNotNull(repository.savedApplicant)
+        assertEquals(173.0, savedApplicant.totalScore ?: 0.0, 0.0)
+        assertNotNull(savedApplicant.totalScoreUpdatedAt)
+    }
+
+    private class FakeApplicantRepository(
+        private var applicant: Applicant,
+    ) : ApplicantRepository {
+        var savedApplicant: Applicant? = null
+
+        override fun save(applicant: Applicant): Applicant {
+            savedApplicant = applicant
+            this.applicant = applicant
+            return applicant
+        }
+
+        override fun findById(id: Long): Applicant? =
+            applicant.takeIf { it.id == id }
+
+        override fun findByAccountId(accountId: Long): Applicant? =
+            applicant.takeIf { it.accountId == accountId }
+    }
+
+    private companion object {
+        fun all(grade: SubjectGrade): SubjectGrades =
+            SubjectGrades(
+                koreanGrade = grade,
+                mathGrade = grade,
+                englishGrade = grade,
+                scienceGrade = grade,
+                societyGrade = grade,
+                technologyGrade = grade,
+                historyGrade = grade,
+            )
+    }
+}

--- a/systems/application/application-bootstrap/BUILD.bazel
+++ b/systems/application/application-bootstrap/BUILD.bazel
@@ -8,7 +8,7 @@ kt_jvm_binary(
     srcs = glob(["src/main/kotlin/**/*.kt"]),
     javac_opts = "//:javac_options",
     kotlinc_opts = "//:kotlinc_options",
-    main_class = "hs.kr.entrydsm.application.ApplicationBootstrapApplicationKt",
+    main_class = "hs.kr.entrydsm.application.ExampleApplicationKt",
     plugins = ["//:spring_allopen"],
     resources = glob(["src/main/resources/**"]),
     deps = MODULE_DEPS + [

--- a/systems/application/application-bootstrap/deps.bzl
+++ b/systems/application/application-bootstrap/deps.bzl
@@ -1,11 +1,13 @@
 SPRING_DEPS = [
     "@maven//:org_springframework_boot_spring_boot_starter_web",
     "@maven//:org_springframework_boot_spring_boot_starter_actuator",
+    "@maven//:org_springframework_boot_spring_boot_starter_data_jpa",
 ]
 
 KOTLIN_DEPS = [
     "@maven//:org_jetbrains_kotlin_kotlin_reflect",
     "@maven//:com_fasterxml_jackson_module_jackson_module_kotlin",
+    "@maven//:com_mysql_mysql_connector_j",
 ]
 
 TEST_DEPS = [

--- a/systems/application/application-bootstrap/src/main/kotlin/hs/kr/entrydsm/application/config/ApplicationUseCaseConfig.kt
+++ b/systems/application/application-bootstrap/src/main/kotlin/hs/kr/entrydsm/application/config/ApplicationUseCaseConfig.kt
@@ -1,0 +1,22 @@
+package hs.kr.entrydsm.application.config
+
+import hs.kr.entrydsm.application.application.port.`in`.ApplicationPort
+import hs.kr.entrydsm.application.application.port.`in`.EvaluationPort
+import hs.kr.entrydsm.application.application.port.out.ApplicantRepository
+import hs.kr.entrydsm.application.application.service.ApplicationCommandService
+import hs.kr.entrydsm.application.application.service.EvaluationCommandService
+import org.springframework.context.annotation.Bean
+import org.springframework.context.annotation.Configuration
+
+@Configuration(proxyBeanMethods = false)
+class ApplicationUseCaseConfig {
+    @Bean
+    fun applicationService(
+        applicantRepository: ApplicantRepository,
+    ): ApplicationPort = ApplicationCommandService(applicantRepository)
+
+    @Bean
+    fun evaluationService(
+        applicantRepository: ApplicantRepository,
+    ): EvaluationPort = EvaluationCommandService(applicantRepository)
+}

--- a/systems/application/application-bootstrap/src/main/kotlin/hs/kr/entrydsm/application/config/ApplicationUseCaseConfig.kt
+++ b/systems/application/application-bootstrap/src/main/kotlin/hs/kr/entrydsm/application/config/ApplicationUseCaseConfig.kt
@@ -5,11 +5,15 @@ import hs.kr.entrydsm.application.application.port.`in`.EvaluationPort
 import hs.kr.entrydsm.application.application.port.out.ApplicantRepository
 import hs.kr.entrydsm.application.application.service.ApplicationCommandService
 import hs.kr.entrydsm.application.application.service.EvaluationCommandService
+import hs.kr.entrydsm.application.domain.service.ScoreCalculator
 import org.springframework.context.annotation.Bean
 import org.springframework.context.annotation.Configuration
 
 @Configuration(proxyBeanMethods = false)
 class ApplicationUseCaseConfig {
+    @Bean
+    fun scoreCalculator(): ScoreCalculator = ScoreCalculator()
+
     @Bean
     fun applicationService(
         applicantRepository: ApplicantRepository,
@@ -18,5 +22,6 @@ class ApplicationUseCaseConfig {
     @Bean
     fun evaluationService(
         applicantRepository: ApplicantRepository,
-    ): EvaluationPort = EvaluationCommandService(applicantRepository)
+        scoreCalculator: ScoreCalculator,
+    ): EvaluationPort = EvaluationCommandService(applicantRepository, scoreCalculator)
 }

--- a/systems/application/application-bootstrap/src/main/resources/application-dev.yaml
+++ b/systems/application/application-bootstrap/src/main/resources/application-dev.yaml
@@ -15,3 +15,10 @@ spring:
     properties:
       hibernate:
         dialect: org.hibernate.dialect.MySQLDialect
+
+entrydsm:
+  application:
+    schedule:
+      application-start-at: ${APPLICATION_START_AT}
+      application-end-at: ${APPLICATION_END_AT}
+      result-announced-at: ${RESULT_ANNOUNCED_AT}

--- a/systems/application/application-bootstrap/src/main/resources/application-dev.yaml
+++ b/systems/application/application-bootstrap/src/main/resources/application-dev.yaml
@@ -1,0 +1,17 @@
+spring:
+  config:
+    activate:
+      on-profile: dev
+  datasource:
+    url: ${DB_URL}
+    username: ${DB_USERNAME}
+    password: ${DB_PASSWORD}
+    driver-class-name: com.mysql.cj.jdbc.Driver
+  jpa:
+    hibernate:
+      ddl-auto: update
+    open-in-view: false
+    show-sql: false
+    properties:
+      hibernate:
+        dialect: org.hibernate.dialect.MySQLDialect

--- a/systems/application/application-bootstrap/src/main/resources/application-prod.yaml
+++ b/systems/application/application-bootstrap/src/main/resources/application-prod.yaml
@@ -1,0 +1,17 @@
+spring:
+  config:
+    activate:
+      on-profile: prod
+  datasource:
+    url: ${DB_URL}
+    username: ${DB_USERNAME}
+    password: ${DB_PASSWORD}
+    driver-class-name: com.mysql.cj.jdbc.Driver
+  jpa:
+    hibernate:
+      ddl-auto: validate
+    open-in-view: false
+    show-sql: false
+    properties:
+      hibernate:
+        dialect: org.hibernate.dialect.MySQLDialect

--- a/systems/application/application-bootstrap/src/main/resources/application-prod.yaml
+++ b/systems/application/application-bootstrap/src/main/resources/application-prod.yaml
@@ -15,3 +15,10 @@ spring:
     properties:
       hibernate:
         dialect: org.hibernate.dialect.MySQLDialect
+
+entrydsm:
+  application:
+    schedule:
+      application-start-at: ${APPLICATION_START_AT}
+      application-end-at: ${APPLICATION_END_AT}
+      result-announced-at: ${RESULT_ANNOUNCED_AT}

--- a/systems/application/application-bootstrap/src/main/resources/application.yaml
+++ b/systems/application/application-bootstrap/src/main/resources/application.yaml
@@ -2,11 +2,16 @@ spring:
   application:
     name: application
   profiles:
-    default: local
+    default: dev
   main:
     lazy-initialization: true
+
 server:
   shutdown: graceful
+
+grpc:
+  port: ${GRPC_PORT:9090}
+
 management:
   endpoints:
     web:
@@ -16,6 +21,14 @@ management:
     health:
       probes:
         enabled: true
+
 logging:
   level:
     root: INFO
+
+entrydsm:
+  application:
+    schedule:
+      application-start-at: "${APPLICATION_START_AT:2026-04-01T09:00:00}"
+      application-end-at: "${APPLICATION_END_AT:2026-04-30T17:00:00}"
+      result-announced-at: "${RESULT_ANNOUNCED_AT:2026-05-15T10:00:00}"

--- a/systems/application/application-bootstrap/src/main/resources/application.yaml
+++ b/systems/application/application-bootstrap/src/main/resources/application.yaml
@@ -25,10 +25,3 @@ management:
 logging:
   level:
     root: INFO
-
-entrydsm:
-  application:
-    schedule:
-      application-start-at: "${APPLICATION_START_AT:2026-04-01T09:00:00}"
-      application-end-at: "${APPLICATION_END_AT:2026-04-30T17:00:00}"
-      result-announced-at: "${RESULT_ANNOUNCED_AT:2026-05-15T10:00:00}"

--- a/systems/application/application-domain/src/main/kotlin/hs/kr/entrydsm/application/domain/service/ScoreCalculator.kt
+++ b/systems/application/application-domain/src/main/kotlin/hs/kr/entrydsm/application/domain/service/ScoreCalculator.kt
@@ -67,13 +67,12 @@ class ScoreCalculator {
             GraduationType.GRADUATED -> GRADUATED_SEMESTER_WEIGHTS
             else -> PROSPECTIVE_GRADUATION_SEMESTER_WEIGHTS
         }
-        val weightedScores = semesterWeights.mapNotNull { (semester, weight) ->
-            record.subjectGrades[semester]
-                ?.let(::calculateSemesterAveragePoint)
-                ?.let { averagePoint -> (averagePoint / MAX_GRADE_POINT) * weight to weight }
-        }
-        if (weightedScores.isEmpty()) {
-            return EMPTY_SCORE
+        val weightedScores = semesterWeights.map { (semester, weight) ->
+            val subjectGrades = requireNotNull(record.subjectGrades[semester]) {
+                "subject grades are incomplete"
+            }
+            val averagePoint = calculateSemesterAveragePoint(subjectGrades)
+            (averagePoint / MAX_GRADE_POINT) * weight to weight
         }
 
         val earnedScore = weightedScores.sumOf { it.first }

--- a/systems/application/application-domain/src/main/kotlin/hs/kr/entrydsm/application/domain/service/ScoreCalculator.kt
+++ b/systems/application/application-domain/src/main/kotlin/hs/kr/entrydsm/application/domain/service/ScoreCalculator.kt
@@ -117,15 +117,16 @@ class ScoreCalculator {
             return EMPTY_SCORE
         }
 
-        val convertedAbsences = record.absentCount + floor(
+        val convertedAbsences = record.absentCount.toLong() + floor(
             (
-                record.lateCount +
-                    record.earlyLeaveCount +
-                    record.classAbsenceCount
+                record.lateCount.toLong() +
+                    record.earlyLeaveCount.toLong() +
+                    record.classAbsenceCount.toLong()
                 ) / ATTENDANCE_CONVERSION_UNIT.toDouble(),
-        ).toInt()
+        ).toLong()
 
-        return (ATTENDANCE_MAX_SCORE - convertedAbsences).coerceAtLeast(EMPTY_SCORE)
+        return (ATTENDANCE_MAX_SCORE - convertedAbsences)
+            .coerceIn(EMPTY_SCORE, ATTENDANCE_MAX_SCORE)
     }
 
     private fun calculateVolunteerScore(

--- a/systems/application/application-domain/src/test/kotlin/hs/kr/entrydsm/application/domain/service/ScoreCalculatorTest.kt
+++ b/systems/application/application-domain/src/test/kotlin/hs/kr/entrydsm/application/domain/service/ScoreCalculatorTest.kt
@@ -105,6 +105,32 @@ class ScoreCalculatorTest {
     }
 
     @Test
+    fun clampsAttendanceScoreWhenAttendanceCountsAreTooLarge() {
+        val applicant = Applicant(
+            id = 1L,
+            accountId = 1L,
+            graduationType = GraduationType.PROSPECTIVE,
+            academicRecord = AcademicRecord(
+                absentCount = Int.MAX_VALUE,
+                lateCount = Int.MAX_VALUE,
+                earlyLeaveCount = Int.MAX_VALUE,
+                classAbsenceCount = Int.MAX_VALUE,
+                subjectGrades = linkedMapOf(
+                    SchoolSemester.THIRD_GRADE_FIRST_SEMESTER to all(SubjectGrade.A),
+                    SchoolSemester.SECOND_GRADE_SECOND_SEMESTER to all(SubjectGrade.A),
+                    SchoolSemester.SECOND_GRADE_FIRST_SEMESTER to all(SubjectGrade.A),
+                ),
+            ),
+        )
+
+        val result = calculator.calculate(applicant)
+
+        assertEquals(140.0, result.getValue(AdmissionType.REGULAR), 0.0)
+        assertEquals(80.0, result.getValue(AdmissionType.SOCIAL), 0.0)
+        assertEquals(80.0, result.getValue(AdmissionType.MEISTER), 0.0)
+    }
+
+    @Test
     fun returnsZeroWhenAcademicRecordDoesNotExist() {
         val result = calculator.calculate(Applicant(id = 1L, accountId = 1L))
 

--- a/systems/application/application-domain/src/test/kotlin/hs/kr/entrydsm/application/domain/service/ScoreCalculatorTest.kt
+++ b/systems/application/application-domain/src/test/kotlin/hs/kr/entrydsm/application/domain/service/ScoreCalculatorTest.kt
@@ -70,6 +70,40 @@ class ScoreCalculatorTest {
         assertEquals(80.0, result.getValue(AdmissionType.MEISTER), 0.0)
     }
 
+    @Test(expected = IllegalArgumentException::class)
+    fun rejectsIncompleteProspectiveSubjectGrades() {
+        calculator.calculate(
+            Applicant(
+                id = 1L,
+                accountId = 1L,
+                graduationType = GraduationType.PROSPECTIVE,
+                academicRecord = AcademicRecord(
+                    subjectGrades = linkedMapOf(
+                        SchoolSemester.THIRD_GRADE_FIRST_SEMESTER to all(SubjectGrade.A),
+                    ),
+                ),
+            ),
+        )
+    }
+
+    @Test(expected = IllegalArgumentException::class)
+    fun rejectsIncompleteGraduatedSubjectGrades() {
+        calculator.calculate(
+            Applicant(
+                id = 1L,
+                accountId = 1L,
+                graduationType = GraduationType.GRADUATED,
+                academicRecord = AcademicRecord(
+                    subjectGrades = linkedMapOf(
+                        SchoolSemester.THIRD_GRADE_SECOND_SEMESTER to all(SubjectGrade.A),
+                        SchoolSemester.THIRD_GRADE_FIRST_SEMESTER to all(SubjectGrade.A),
+                        SchoolSemester.SECOND_GRADE_SECOND_SEMESTER to all(SubjectGrade.A),
+                    ),
+                ),
+            ),
+        )
+    }
+
     @Test
     fun returnsZeroWhenAcademicRecordDoesNotExist() {
         val result = calculator.calculate(Applicant(id = 1L, accountId = 1L))


### PR DESCRIPTION
## Summary
원서작성, 성적산출, 랜딩 조회 REST API를 구성했습니다.
Controller, request/response DTO, response mapper, exception handler를 추가했습니다.
랜딩 일정 값은 yml/env 기반 properties로 주입받도록 구성했습니다.

## Related Issue
Related to #24 

## Scope
In scope:
- ApplicationController
- EvaluationController
- 원서작성 request/response DTO
- 성적산출 request/response DTO
- 공통 ApiResponse
- GlobalExceptionHandler
- LandingScheduleProperties
- adapter-in Bazel 의존성

Out of scope:
- JPA 저장소 구현
- bootstrap profile 설정
- 실제 DB schema
- 인증/인가 연동
- admin 합격/불합격 처리

## Implementation
ApplicationController는 원서 생성, 조회, 수정, 랜딩 조회 API를 제공합니다.
EvaluationController는 지원자의 성적산출 결과 조회 API를 제공합니다.
Controller는 application port에 command를 전달하고, mapper를 통해 명세에 맞는 response로 변환합니다.
예외는 GlobalExceptionHandler에서 공통 응답 형식으로 변환합니다.
랜딩 일정은 프론트 하드코딩 대신 서버 설정값으로 응답하되, API 필드는 기존 명세를 유지했습니다.

## Testing
- Unit test code: 후속 테스트 PR에서 추가
- Integration tests: 후속 테스트 PR에서 추가
- Manual verification: 후속 PR에서 build/test 수행 예정

## Deployment Notes
Feature flag: 없음  
Migration required: 없음  
Rollout considerations:
- 실제 데이터 반환은 후속 persistence PR의 ApplicantRepository 구현에 의존합니다.
- 인증 유저 정보 연동 전까지 accountId는 request 기반으로 처리합니다.

## Checklist
- [x] Matches product/tech requirements
- [x] Backward compatibility considered
- [x] API schema compatibility considered
- [ ] API success flow verified in a running environment
- [ ] Real persistence adapter connected