### PR TITLE
feat(application): Application JPA 저장소 구성 #24

### DIFF
--- a/systems/application/application-adapter-in/src/test/kotlin/hs/kr/entrydsm/application/adapterin/web/ApplicationControllerTest.kt
+++ b/systems/application/application-adapter-in/src/test/kotlin/hs/kr/entrydsm/application/adapterin/web/ApplicationControllerTest.kt
@@ -37,9 +37,9 @@ class ApplicationControllerTest {
         val response = controller.getLanding(10L)
 
         assertEquals("홍길동", response.data?.applicantName)
-        assertEquals(APPLICATION_START_AT, response.data?.schedule?.applicationPeriod?.startAt)
-        assertEquals(APPLICATION_END_AT, response.data?.schedule?.applicationPeriod?.endAt)
-        assertEquals(RESULT_ANNOUNCED_AT, response.data?.schedule?.resultAnnouncedAt)
+        assertEquals(applicationStartAt, response.data?.schedule?.applicationPeriod?.startAt)
+        assertEquals(applicationEndAt, response.data?.schedule?.applicationPeriod?.endAt)
+        assertEquals(resultAnnouncedAt, response.data?.schedule?.resultAnnouncedAt)
     }
 
     private class FakeApplicationPort : ApplicationPort {
@@ -61,15 +61,15 @@ class ApplicationControllerTest {
     }
 
     private companion object {
-        val APPLICATION_START_AT: LocalDateTime = LocalDateTime.parse("2026-04-01T09:00:00")
-        val APPLICATION_END_AT: LocalDateTime = LocalDateTime.parse("2026-04-30T17:00:00")
-        val RESULT_ANNOUNCED_AT: LocalDateTime = LocalDateTime.parse("2026-05-15T10:00:00")
+        val applicationStartAt: LocalDateTime = LocalDateTime.parse("2026-10-19T09:00:00")
+        val applicationEndAt: LocalDateTime = LocalDateTime.parse("2026-10-23T17:00:00")
+        val resultAnnouncedAt: LocalDateTime = LocalDateTime.parse("2026-10-30T10:00:00")
 
         fun scheduleProperties(): LandingScheduleProperties =
             LandingScheduleProperties(
-                applicationStartAt = APPLICATION_START_AT,
-                applicationEndAt = APPLICATION_END_AT,
-                resultAnnouncedAt = RESULT_ANNOUNCED_AT,
+                applicationStartAt = applicationStartAt,
+                applicationEndAt = applicationEndAt,
+                resultAnnouncedAt = resultAnnouncedAt,
             )
     }
 }

--- a/systems/application/application-adapter-out/BUILD.bazel
+++ b/systems/application/application-adapter-out/BUILD.bazel
@@ -17,5 +17,5 @@ kt_jvm_test(
     javac_opts = "//:javac_options",
     kotlinc_opts = "//:kotlinc_options",
     test_class = "hs.kr.entrydsm.application.adapterout.ApplicationAdapterOutModuleTest",
-    deps = MODULE_DEPS + TEST_DEPS,
+    deps = [":main"] + MODULE_DEPS + TEST_DEPS,
 )

--- a/systems/application/application-adapter-out/deps.bzl
+++ b/systems/application/application-adapter-out/deps.bzl
@@ -1,4 +1,9 @@
-KOTLIN_DEPS = []
+KOTLIN_DEPS = [
+    "@maven//:org_springframework_boot_spring_boot_starter_data_jpa",
+    "@maven//:com_mysql_mysql_connector_j",
+    "//systems/application/application-application:main",
+    "//systems/application/application-domain:main",
+]
 
 TEST_DEPS = [
     "@maven//:junit_junit",

--- a/systems/application/application-adapter-out/src/main/kotlin/hs/kr/entrydsm/application/adapterout/entity/AcademicRecordJpaEntity.kt
+++ b/systems/application/application-adapter-out/src/main/kotlin/hs/kr/entrydsm/application/adapterout/entity/AcademicRecordJpaEntity.kt
@@ -23,7 +23,7 @@ open class AcademicRecordJpaEntity(
 
     @OneToOne(fetch = FetchType.LAZY)
     @JoinColumn(name = "applicant_id", nullable = false, unique = true)
-    var applicant: ApplicantJpaEntity? = null,
+    open var applicant: ApplicantJpaEntity? = null,
 
     @Column(name = "absent_count", nullable = false)
     var absentCount: Int = 0,
@@ -46,11 +46,11 @@ open class AcademicRecordJpaEntity(
     @Column(name = "is_programming_certified", nullable = false)
     var isProgrammingCertified: Boolean = false,
 
-    @OneToMany(mappedBy = "academicRecord", cascade = [CascadeType.ALL], orphanRemoval = true, fetch = FetchType.EAGER)
-    var subjectGrades: MutableList<SubjectGradeJpaEntity> = mutableListOf(),
+    @OneToMany(mappedBy = "academicRecord", cascade = [CascadeType.ALL], orphanRemoval = true, fetch = FetchType.LAZY)
+    open var subjectGrades: MutableList<SubjectGradeJpaEntity> = mutableListOf(),
 
-    @OneToOne(mappedBy = "academicRecord", cascade = [CascadeType.ALL], orphanRemoval = true, fetch = FetchType.EAGER)
-    var gedScores: GedScoreJpaEntity? = null,
+    @OneToOne(mappedBy = "academicRecord", cascade = [CascadeType.ALL], orphanRemoval = true, fetch = FetchType.LAZY)
+    open var gedScores: GedScoreJpaEntity? = null,
 ) {
     fun updateFrom(domain: AcademicRecord) {
         absentCount = domain.absentCount
@@ -60,17 +60,22 @@ open class AcademicRecordJpaEntity(
         volunteerTime = domain.volunteerTime
         isDsmAlgorithmAwarded = domain.isDsmAlgorithmAwarded
         isProgrammingCertified = domain.isProgrammingCertified
-        subjectGrades.clear()
-        subjectGrades.addAll(
-            domain.subjectGrades.map { (semester, grades) ->
-                SubjectGradeJpaEntity(
+        val domainSemesters = domain.subjectGrades.keys
+        subjectGrades.removeIf { it.id.schoolSemester !in domainSemesters }
+        domain.subjectGrades.forEach { (semester, grades) ->
+            val entity = subjectGrades.firstOrNull { it.id.schoolSemester == semester }
+                ?: SubjectGradeJpaEntity(
                     id = SubjectGradeId(schoolSemester = semester),
                     academicRecord = this,
-                ).apply { updateFrom(grades) }
-            },
-        )
+                ).also(subjectGrades::add)
+            entity.academicRecord = this
+            entity.updateFrom(grades)
+        }
         gedScores = domain.gedScores?.let {
-            GedScoreJpaEntity(academicRecord = this).apply { updateFrom(it) }
+            (gedScores ?: GedScoreJpaEntity(academicRecord = this)).apply {
+                academicRecord = this@AcademicRecordJpaEntity
+                updateFrom(it)
+            }
         }
     }
 

--- a/systems/application/application-adapter-out/src/main/kotlin/hs/kr/entrydsm/application/adapterout/entity/AcademicRecordJpaEntity.kt
+++ b/systems/application/application-adapter-out/src/main/kotlin/hs/kr/entrydsm/application/adapterout/entity/AcademicRecordJpaEntity.kt
@@ -1,0 +1,91 @@
+package hs.kr.entrydsm.application.adapterout.entity
+
+import hs.kr.entrydsm.application.domain.model.AcademicRecord
+import jakarta.persistence.CascadeType
+import jakarta.persistence.Column
+import jakarta.persistence.Entity
+import jakarta.persistence.FetchType
+import jakarta.persistence.GeneratedValue
+import jakarta.persistence.GenerationType
+import jakarta.persistence.Id
+import jakarta.persistence.JoinColumn
+import jakarta.persistence.OneToMany
+import jakarta.persistence.OneToOne
+import jakarta.persistence.Table
+
+@Entity
+@Table(name = "academic_records")
+open class AcademicRecordJpaEntity(
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    @Column(name = "id")
+    var id: Long? = null,
+
+    @OneToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "applicant_id", nullable = false, unique = true)
+    var applicant: ApplicantJpaEntity? = null,
+
+    @Column(name = "absent_count", nullable = false)
+    var absentCount: Int = 0,
+
+    @Column(name = "late_count", nullable = false)
+    var lateCount: Int = 0,
+
+    @Column(name = "early_leave_count", nullable = false)
+    var earlyLeaveCount: Int = 0,
+
+    @Column(name = "class_absence_count", nullable = false)
+    var classAbsenceCount: Int = 0,
+
+    @Column(name = "volunteer_time", nullable = false)
+    var volunteerTime: Int = 0,
+
+    @Column(name = "is_dsm_algorithm_awarded", nullable = false)
+    var isDsmAlgorithmAwarded: Boolean = false,
+
+    @Column(name = "is_programming_certified", nullable = false)
+    var isProgrammingCertified: Boolean = false,
+
+    @OneToMany(mappedBy = "academicRecord", cascade = [CascadeType.ALL], orphanRemoval = true, fetch = FetchType.EAGER)
+    var subjectGrades: MutableList<SubjectGradeJpaEntity> = mutableListOf(),
+
+    @OneToOne(mappedBy = "academicRecord", cascade = [CascadeType.ALL], orphanRemoval = true, fetch = FetchType.EAGER)
+    var gedScores: GedScoreJpaEntity? = null,
+) {
+    fun updateFrom(domain: AcademicRecord) {
+        absentCount = domain.absentCount
+        lateCount = domain.lateCount
+        earlyLeaveCount = domain.earlyLeaveCount
+        classAbsenceCount = domain.classAbsenceCount
+        volunteerTime = domain.volunteerTime
+        isDsmAlgorithmAwarded = domain.isDsmAlgorithmAwarded
+        isProgrammingCertified = domain.isProgrammingCertified
+        subjectGrades.clear()
+        subjectGrades.addAll(
+            domain.subjectGrades.map { (semester, grades) ->
+                SubjectGradeJpaEntity(
+                    id = SubjectGradeId(schoolSemester = semester),
+                    academicRecord = this,
+                ).apply { updateFrom(grades) }
+            },
+        )
+        gedScores = domain.gedScores?.let {
+            GedScoreJpaEntity(academicRecord = this).apply { updateFrom(it) }
+        }
+    }
+
+    fun toDomain(): AcademicRecord =
+        AcademicRecord(
+            absentCount = absentCount,
+            lateCount = lateCount,
+            earlyLeaveCount = earlyLeaveCount,
+            classAbsenceCount = classAbsenceCount,
+            volunteerTime = volunteerTime,
+            isDsmAlgorithmAwarded = isDsmAlgorithmAwarded,
+            isProgrammingCertified = isProgrammingCertified,
+            subjectGrades = subjectGrades
+                .associate { requireNotNull(it.id.schoolSemester) to it.toDomain() }
+                .toMutableMap(),
+            gedScores = gedScores?.toDomain(),
+        )
+}

--- a/systems/application/application-adapter-out/src/main/kotlin/hs/kr/entrydsm/application/adapterout/entity/ApplicantJpaEntity.kt
+++ b/systems/application/application-adapter-out/src/main/kotlin/hs/kr/entrydsm/application/adapterout/entity/ApplicantJpaEntity.kt
@@ -1,0 +1,207 @@
+package hs.kr.entrydsm.application.adapterout.entity
+
+import hs.kr.entrydsm.application.domain.enum.AdmissionType
+import hs.kr.entrydsm.application.domain.enum.Gender
+import hs.kr.entrydsm.application.domain.enum.GraduationType
+import hs.kr.entrydsm.application.domain.enum.GuardianRelation
+import hs.kr.entrydsm.application.domain.enum.Region
+import hs.kr.entrydsm.application.domain.enum.SpecialAdmissionType
+import hs.kr.entrydsm.application.domain.model.Applicant
+import hs.kr.entrydsm.application.domain.model.MiddleSchoolInfo
+import jakarta.persistence.CascadeType
+import jakarta.persistence.Column
+import jakarta.persistence.Entity
+import jakarta.persistence.EnumType
+import jakarta.persistence.Enumerated
+import jakarta.persistence.FetchType
+import jakarta.persistence.GeneratedValue
+import jakarta.persistence.GenerationType
+import jakarta.persistence.Id
+import jakarta.persistence.OneToMany
+import jakarta.persistence.OneToOne
+import jakarta.persistence.Table
+import java.time.LocalDate
+import java.time.LocalDateTime
+import java.time.YearMonth
+
+@Entity
+@Table(name = "applicants")
+open class ApplicantJpaEntity(
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    @Column(name = "id")
+    var id: Long? = null,
+
+    @Column(name = "account_id", nullable = false)
+    var accountId: Long = 0,
+
+    @Column(name = "photo_file_id")
+    var photoFileId: Long? = null,
+
+    @Column(name = "name", length = 20)
+    var name: String? = null,
+
+    @Column(name = "phone_number", length = 16)
+    var phoneNumber: String? = null,
+
+    @Enumerated(EnumType.STRING)
+    @Column(name = "gender", length = 10)
+    var gender: Gender? = null,
+
+    @Column(name = "birthdate")
+    var birthdate: LocalDate? = null,
+
+    @Enumerated(EnumType.STRING)
+    @Column(name = "special_admission_type", nullable = false, length = 32)
+    var specialAdmissionType: SpecialAdmissionType = SpecialAdmissionType.NONE,
+
+    @Enumerated(EnumType.STRING)
+    @Column(name = "admission_type", length = 16)
+    var admissionType: AdmissionType? = null,
+
+    @Enumerated(EnumType.STRING)
+    @Column(name = "region", length = 16)
+    var region: Region? = null,
+
+    @Enumerated(EnumType.STRING)
+    @Column(name = "graduation_type", length = 16)
+    var graduationType: GraduationType? = null,
+
+    @Column(name = "graduation_date")
+    var graduationDate: LocalDate? = null,
+
+    @Column(name = "guardian_name", length = 20)
+    var guardianName: String? = null,
+
+    @Column(name = "guardian_phone_number", length = 16)
+    var guardianPhoneNumber: String? = null,
+
+    @Enumerated(EnumType.STRING)
+    @Column(name = "guardian_gender", length = 10)
+    var guardianGender: Gender? = null,
+
+    @Enumerated(EnumType.STRING)
+    @Column(name = "guardian_relation", length = 10)
+    var guardianRelation: GuardianRelation? = null,
+
+    @Column(name = "address_base", length = 255)
+    var addressBase: String? = null,
+
+    @Column(name = "address_detail", length = 255)
+    var addressDetail: String? = null,
+
+    @Column(name = "zip_code", length = 10)
+    var zipCode: String? = null,
+
+    @Column(name = "introduction", columnDefinition = "TEXT")
+    var introduction: String? = null,
+
+    @Column(name = "study_plan", columnDefinition = "TEXT")
+    var studyPlan: String? = null,
+
+    @Column(name = "total_score")
+    var totalScore: Double? = null,
+
+    @Column(name = "total_score_updated_at")
+    var totalScoreUpdatedAt: LocalDateTime? = null,
+
+    @Column(name = "created_at", nullable = false)
+    var createdAt: LocalDateTime = LocalDateTime.now(),
+
+    @Column(name = "updated_at", nullable = false)
+    var updatedAt: LocalDateTime = LocalDateTime.now(),
+
+    @OneToOne(mappedBy = "applicant", cascade = [CascadeType.ALL], orphanRemoval = true, fetch = FetchType.EAGER)
+    var middleSchoolInfo: MiddleSchoolInfoJpaEntity? = null,
+
+    @OneToOne(mappedBy = "applicant", cascade = [CascadeType.ALL], orphanRemoval = true, fetch = FetchType.EAGER)
+    var academicRecord: AcademicRecordJpaEntity? = null,
+
+    @OneToMany(mappedBy = "applicant", cascade = [CascadeType.ALL], orphanRemoval = true)
+    var passResults: MutableList<PassResultJpaEntity> = mutableListOf(),
+) {
+    fun toDomain(): Applicant =
+        Applicant(
+            id = requireNotNull(id),
+            accountId = accountId,
+            photoFileId = photoFileId,
+            name = name,
+            phoneNumber = phoneNumber,
+            gender = gender,
+            birthdate = birthdate,
+            specialAdmissionType = specialAdmissionType,
+            admissionType = admissionType,
+            region = region,
+            graduationType = graduationType,
+            graduationDate = graduationDate?.let { YearMonth.from(it) },
+            guardianName = guardianName,
+            guardianPhoneNumber = guardianPhoneNumber,
+            guardianGender = guardianGender,
+            guardianRelation = guardianRelation,
+            addressBase = addressBase,
+            addressDetail = addressDetail,
+            zipCode = zipCode,
+            introduction = introduction,
+            studyPlan = studyPlan,
+            middleSchoolInfo = middleSchoolInfo?.toDomain(),
+            academicRecord = academicRecord?.toDomain(),
+            totalScore = totalScore,
+            totalScoreUpdatedAt = totalScoreUpdatedAt,
+            createdAt = createdAt,
+            updatedAt = updatedAt,
+        )
+
+    fun updateFrom(domain: Applicant) {
+        accountId = domain.accountId
+        photoFileId = domain.photoFileId
+        name = domain.name
+        phoneNumber = domain.phoneNumber
+        gender = domain.gender
+        birthdate = domain.birthdate
+        specialAdmissionType = domain.specialAdmissionType
+        admissionType = domain.admissionType
+        region = domain.region
+        graduationType = domain.graduationType
+        graduationDate = domain.graduationDate?.atDay(1)
+        guardianName = domain.guardianName
+        guardianPhoneNumber = domain.guardianPhoneNumber
+        guardianGender = domain.guardianGender
+        guardianRelation = domain.guardianRelation
+        addressBase = domain.addressBase
+        addressDetail = domain.addressDetail
+        zipCode = domain.zipCode
+        introduction = domain.introduction
+        studyPlan = domain.studyPlan
+        totalScore = domain.totalScore
+        totalScoreUpdatedAt = domain.totalScoreUpdatedAt
+        createdAt = domain.createdAt
+        updatedAt = domain.updatedAt
+        updateMiddleSchoolInfo(domain.middleSchoolInfo)
+        updateAcademicRecord(domain.academicRecord)
+    }
+
+    private fun updateMiddleSchoolInfo(domain: MiddleSchoolInfo?) {
+        middleSchoolInfo = domain?.let {
+            (middleSchoolInfo ?: MiddleSchoolInfoJpaEntity(applicant = this)).apply {
+                updateFrom(it)
+                applicant = this@ApplicantJpaEntity
+            }
+        }
+    }
+
+    private fun updateAcademicRecord(domain: hs.kr.entrydsm.application.domain.model.AcademicRecord?) {
+        academicRecord = domain?.let {
+            (academicRecord ?: AcademicRecordJpaEntity(applicant = this)).apply {
+                updateFrom(it)
+                applicant = this@ApplicantJpaEntity
+            }
+        }
+    }
+
+    companion object {
+        fun from(domain: Applicant): ApplicantJpaEntity =
+            ApplicantJpaEntity(id = domain.id.takeIf { it > 0 }).apply {
+                updateFrom(domain)
+            }
+    }
+}

--- a/systems/application/application-adapter-out/src/main/kotlin/hs/kr/entrydsm/application/adapterout/entity/ApplicantJpaEntity.kt
+++ b/systems/application/application-adapter-out/src/main/kotlin/hs/kr/entrydsm/application/adapterout/entity/ApplicantJpaEntity.kt
@@ -6,6 +6,7 @@ import hs.kr.entrydsm.application.domain.enum.GraduationType
 import hs.kr.entrydsm.application.domain.enum.GuardianRelation
 import hs.kr.entrydsm.application.domain.enum.Region
 import hs.kr.entrydsm.application.domain.enum.SpecialAdmissionType
+import hs.kr.entrydsm.application.domain.model.AcademicRecord
 import hs.kr.entrydsm.application.domain.model.Applicant
 import hs.kr.entrydsm.application.domain.model.MiddleSchoolInfo
 import jakarta.persistence.CascadeType
@@ -111,14 +112,14 @@ open class ApplicantJpaEntity(
     @Column(name = "updated_at", nullable = false)
     var updatedAt: LocalDateTime = LocalDateTime.now(),
 
-    @OneToOne(mappedBy = "applicant", cascade = [CascadeType.ALL], orphanRemoval = true, fetch = FetchType.EAGER)
-    var middleSchoolInfo: MiddleSchoolInfoJpaEntity? = null,
+    @OneToOne(mappedBy = "applicant", cascade = [CascadeType.ALL], orphanRemoval = true, fetch = FetchType.LAZY)
+    open var middleSchoolInfo: MiddleSchoolInfoJpaEntity? = null,
 
-    @OneToOne(mappedBy = "applicant", cascade = [CascadeType.ALL], orphanRemoval = true, fetch = FetchType.EAGER)
-    var academicRecord: AcademicRecordJpaEntity? = null,
+    @OneToOne(mappedBy = "applicant", cascade = [CascadeType.ALL], orphanRemoval = true, fetch = FetchType.LAZY)
+    open var academicRecord: AcademicRecordJpaEntity? = null,
 
     @OneToMany(mappedBy = "applicant", cascade = [CascadeType.ALL], orphanRemoval = true)
-    var passResults: MutableList<PassResultJpaEntity> = mutableListOf(),
+    open var passResults: MutableList<PassResultJpaEntity> = mutableListOf(),
 ) {
     fun toDomain(): Applicant =
         Applicant(
@@ -174,7 +175,6 @@ open class ApplicantJpaEntity(
         studyPlan = domain.studyPlan
         totalScore = domain.totalScore
         totalScoreUpdatedAt = domain.totalScoreUpdatedAt
-        createdAt = domain.createdAt
         updatedAt = domain.updatedAt
         updateMiddleSchoolInfo(domain.middleSchoolInfo)
         updateAcademicRecord(domain.academicRecord)
@@ -189,7 +189,7 @@ open class ApplicantJpaEntity(
         }
     }
 
-    private fun updateAcademicRecord(domain: hs.kr.entrydsm.application.domain.model.AcademicRecord?) {
+    private fun updateAcademicRecord(domain: AcademicRecord?) {
         academicRecord = domain?.let {
             (academicRecord ?: AcademicRecordJpaEntity(applicant = this)).apply {
                 updateFrom(it)
@@ -200,8 +200,9 @@ open class ApplicantJpaEntity(
 
     companion object {
         fun from(domain: Applicant): ApplicantJpaEntity =
-            ApplicantJpaEntity(id = domain.id.takeIf { it > 0 }).apply {
+            ApplicantJpaEntity().apply {
                 updateFrom(domain)
+                createdAt = domain.createdAt
             }
     }
 }

--- a/systems/application/application-adapter-out/src/main/kotlin/hs/kr/entrydsm/application/adapterout/entity/GedScoreJpaEntity.kt
+++ b/systems/application/application-adapter-out/src/main/kotlin/hs/kr/entrydsm/application/adapterout/entity/GedScoreJpaEntity.kt
@@ -20,7 +20,7 @@ open class GedScoreJpaEntity(
     @MapsId
     @OneToOne(fetch = FetchType.LAZY)
     @JoinColumn(name = "academic_record_id")
-    var academicRecord: AcademicRecordJpaEntity? = null,
+    open var academicRecord: AcademicRecordJpaEntity? = null,
 
     @Column(name = "korean_score", nullable = false)
     var koreanScore: Int = 0,

--- a/systems/application/application-adapter-out/src/main/kotlin/hs/kr/entrydsm/application/adapterout/entity/GedScoreJpaEntity.kt
+++ b/systems/application/application-adapter-out/src/main/kotlin/hs/kr/entrydsm/application/adapterout/entity/GedScoreJpaEntity.kt
@@ -1,0 +1,66 @@
+package hs.kr.entrydsm.application.adapterout.entity
+
+import hs.kr.entrydsm.application.domain.model.GedScores
+import jakarta.persistence.Column
+import jakarta.persistence.Entity
+import jakarta.persistence.FetchType
+import jakarta.persistence.Id
+import jakarta.persistence.JoinColumn
+import jakarta.persistence.MapsId
+import jakarta.persistence.OneToOne
+import jakarta.persistence.Table
+
+@Entity
+@Table(name = "ged_scores")
+open class GedScoreJpaEntity(
+    @Id
+    @Column(name = "academic_record_id")
+    var academicRecordId: Long? = null,
+
+    @MapsId
+    @OneToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "academic_record_id")
+    var academicRecord: AcademicRecordJpaEntity? = null,
+
+    @Column(name = "korean_score", nullable = false)
+    var koreanScore: Int = 0,
+
+    @Column(name = "math_score", nullable = false)
+    var mathScore: Int = 0,
+
+    @Column(name = "english_score", nullable = false)
+    var englishScore: Int = 0,
+
+    @Column(name = "science_score", nullable = false)
+    var scienceScore: Int = 0,
+
+    @Column(name = "society_score", nullable = false)
+    var societyScore: Int = 0,
+
+    @Column(name = "technology_score", nullable = false)
+    var technologyScore: Int = 0,
+
+    @Column(name = "history_score", nullable = false)
+    var historyScore: Int = 0,
+) {
+    fun updateFrom(domain: GedScores) {
+        koreanScore = domain.koreanScore
+        mathScore = domain.mathScore
+        englishScore = domain.englishScore
+        scienceScore = domain.scienceScore
+        societyScore = domain.societyScore
+        technologyScore = domain.technologyScore
+        historyScore = domain.historyScore
+    }
+
+    fun toDomain(): GedScores =
+        GedScores(
+            koreanScore = koreanScore,
+            mathScore = mathScore,
+            englishScore = englishScore,
+            scienceScore = scienceScore,
+            societyScore = societyScore,
+            technologyScore = technologyScore,
+            historyScore = historyScore,
+        )
+}

--- a/systems/application/application-adapter-out/src/main/kotlin/hs/kr/entrydsm/application/adapterout/entity/MiddleSchoolInfoJpaEntity.kt
+++ b/systems/application/application-adapter-out/src/main/kotlin/hs/kr/entrydsm/application/adapterout/entity/MiddleSchoolInfoJpaEntity.kt
@@ -1,0 +1,51 @@
+package hs.kr.entrydsm.application.adapterout.entity
+
+import hs.kr.entrydsm.application.domain.model.MiddleSchoolInfo
+import jakarta.persistence.Column
+import jakarta.persistence.Entity
+import jakarta.persistence.FetchType
+import jakarta.persistence.Id
+import jakarta.persistence.JoinColumn
+import jakarta.persistence.MapsId
+import jakarta.persistence.OneToOne
+import jakarta.persistence.Table
+
+@Entity
+@Table(name = "middle_school_infos")
+open class MiddleSchoolInfoJpaEntity(
+    @Id
+    @Column(name = "applicant_id")
+    var applicantId: Long? = null,
+
+    @MapsId
+    @OneToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "applicant_id")
+    var applicant: ApplicantJpaEntity? = null,
+
+    @Column(name = "school_name", nullable = false, length = 50)
+    var schoolName: String = "",
+
+    @Column(name = "student_number", nullable = false, length = 8)
+    var studentNumber: String = "",
+
+    @Column(name = "school_phone", nullable = false, length = 16)
+    var schoolPhone: String = "",
+
+    @Column(name = "teacher_name", nullable = false, length = 20)
+    var teacherName: String = "",
+) {
+    fun updateFrom(domain: MiddleSchoolInfo) {
+        schoolName = domain.schoolName
+        studentNumber = domain.studentNumber
+        schoolPhone = domain.schoolPhone
+        teacherName = domain.teacherName
+    }
+
+    fun toDomain(): MiddleSchoolInfo =
+        MiddleSchoolInfo(
+            schoolName = schoolName,
+            studentNumber = studentNumber,
+            schoolPhone = schoolPhone,
+            teacherName = teacherName,
+        )
+}

--- a/systems/application/application-adapter-out/src/main/kotlin/hs/kr/entrydsm/application/adapterout/entity/PassResultId.kt
+++ b/systems/application/application-adapter-out/src/main/kotlin/hs/kr/entrydsm/application/adapterout/entity/PassResultId.kt
@@ -1,0 +1,18 @@
+package hs.kr.entrydsm.application.adapterout.entity
+
+import hs.kr.entrydsm.application.domain.enum.ResultType
+import jakarta.persistence.Column
+import jakarta.persistence.Embeddable
+import jakarta.persistence.EnumType
+import jakarta.persistence.Enumerated
+import java.io.Serializable
+
+@Embeddable
+data class PassResultId(
+    @Column(name = "applicant_id")
+    var applicantId: Long? = null,
+
+    @Enumerated(EnumType.STRING)
+    @Column(name = "result_type", length = 16)
+    var resultType: ResultType? = null,
+) : Serializable

--- a/systems/application/application-adapter-out/src/main/kotlin/hs/kr/entrydsm/application/adapterout/entity/PassResultJpaEntity.kt
+++ b/systems/application/application-adapter-out/src/main/kotlin/hs/kr/entrydsm/application/adapterout/entity/PassResultJpaEntity.kt
@@ -1,0 +1,36 @@
+package hs.kr.entrydsm.application.adapterout.entity
+
+import hs.kr.entrydsm.application.domain.enum.PassResultStatus
+import jakarta.persistence.Column
+import jakarta.persistence.EmbeddedId
+import jakarta.persistence.Entity
+import jakarta.persistence.EnumType
+import jakarta.persistence.Enumerated
+import jakarta.persistence.FetchType
+import jakarta.persistence.JoinColumn
+import jakarta.persistence.ManyToOne
+import jakarta.persistence.MapsId
+import jakarta.persistence.Table
+import java.time.LocalDateTime
+
+@Entity
+@Table(name = "pass_results")
+open class PassResultJpaEntity(
+    @EmbeddedId
+    var id: PassResultId = PassResultId(),
+
+    @MapsId("applicantId")
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "applicant_id")
+    var applicant: ApplicantJpaEntity? = null,
+
+    @Column(name = "processed_by")
+    var processedBy: Long? = null,
+
+    @Enumerated(EnumType.STRING)
+    @Column(name = "result", nullable = false, length = 16)
+    var result: PassResultStatus = PassResultStatus.PENDING,
+
+    @Column(name = "processed_at")
+    var processedAt: LocalDateTime? = null,
+)

--- a/systems/application/application-adapter-out/src/main/kotlin/hs/kr/entrydsm/application/adapterout/entity/SubjectGradeId.kt
+++ b/systems/application/application-adapter-out/src/main/kotlin/hs/kr/entrydsm/application/adapterout/entity/SubjectGradeId.kt
@@ -1,0 +1,18 @@
+package hs.kr.entrydsm.application.adapterout.entity
+
+import hs.kr.entrydsm.application.domain.enum.SchoolSemester
+import jakarta.persistence.Column
+import jakarta.persistence.Embeddable
+import jakarta.persistence.EnumType
+import jakarta.persistence.Enumerated
+import java.io.Serializable
+
+@Embeddable
+data class SubjectGradeId(
+    @Column(name = "academic_record_id")
+    var academicRecordId: Long? = null,
+
+    @Enumerated(EnumType.STRING)
+    @Column(name = "school_semester", length = 20)
+    var schoolSemester: SchoolSemester? = null,
+) : Serializable

--- a/systems/application/application-adapter-out/src/main/kotlin/hs/kr/entrydsm/application/adapterout/entity/SubjectGradeJpaEntity.kt
+++ b/systems/application/application-adapter-out/src/main/kotlin/hs/kr/entrydsm/application/adapterout/entity/SubjectGradeJpaEntity.kt
@@ -22,7 +22,7 @@ open class SubjectGradeJpaEntity(
     @MapsId("academicRecordId")
     @ManyToOne(fetch = FetchType.LAZY)
     @JoinColumn(name = "academic_record_id")
-    var academicRecord: AcademicRecordJpaEntity? = null,
+    open var academicRecord: AcademicRecordJpaEntity? = null,
 
     @Enumerated(EnumType.STRING)
     @Column(name = "korean_grade", nullable = false, length = 2)

--- a/systems/application/application-adapter-out/src/main/kotlin/hs/kr/entrydsm/application/adapterout/entity/SubjectGradeJpaEntity.kt
+++ b/systems/application/application-adapter-out/src/main/kotlin/hs/kr/entrydsm/application/adapterout/entity/SubjectGradeJpaEntity.kt
@@ -1,0 +1,75 @@
+package hs.kr.entrydsm.application.adapterout.entity
+
+import hs.kr.entrydsm.application.domain.enum.SubjectGrade
+import hs.kr.entrydsm.application.domain.model.SubjectGrades
+import jakarta.persistence.Column
+import jakarta.persistence.EmbeddedId
+import jakarta.persistence.Entity
+import jakarta.persistence.EnumType
+import jakarta.persistence.Enumerated
+import jakarta.persistence.FetchType
+import jakarta.persistence.JoinColumn
+import jakarta.persistence.ManyToOne
+import jakarta.persistence.MapsId
+import jakarta.persistence.Table
+
+@Entity
+@Table(name = "subject_grades")
+open class SubjectGradeJpaEntity(
+    @EmbeddedId
+    var id: SubjectGradeId = SubjectGradeId(),
+
+    @MapsId("academicRecordId")
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "academic_record_id")
+    var academicRecord: AcademicRecordJpaEntity? = null,
+
+    @Enumerated(EnumType.STRING)
+    @Column(name = "korean_grade", nullable = false, length = 2)
+    var koreanGrade: SubjectGrade = SubjectGrade.X,
+
+    @Enumerated(EnumType.STRING)
+    @Column(name = "math_grade", nullable = false, length = 2)
+    var mathGrade: SubjectGrade = SubjectGrade.X,
+
+    @Enumerated(EnumType.STRING)
+    @Column(name = "english_grade", nullable = false, length = 2)
+    var englishGrade: SubjectGrade = SubjectGrade.X,
+
+    @Enumerated(EnumType.STRING)
+    @Column(name = "science_grade", nullable = false, length = 2)
+    var scienceGrade: SubjectGrade = SubjectGrade.X,
+
+    @Enumerated(EnumType.STRING)
+    @Column(name = "society_grade", nullable = false, length = 2)
+    var societyGrade: SubjectGrade = SubjectGrade.X,
+
+    @Enumerated(EnumType.STRING)
+    @Column(name = "technology_grade", nullable = false, length = 2)
+    var technologyGrade: SubjectGrade = SubjectGrade.X,
+
+    @Enumerated(EnumType.STRING)
+    @Column(name = "history_grade", nullable = false, length = 2)
+    var historyGrade: SubjectGrade = SubjectGrade.X,
+) {
+    fun updateFrom(domain: SubjectGrades) {
+        koreanGrade = domain.koreanGrade
+        mathGrade = domain.mathGrade
+        englishGrade = domain.englishGrade
+        scienceGrade = domain.scienceGrade
+        societyGrade = domain.societyGrade
+        technologyGrade = domain.technologyGrade
+        historyGrade = domain.historyGrade
+    }
+
+    fun toDomain(): SubjectGrades =
+        SubjectGrades(
+            koreanGrade = koreanGrade,
+            mathGrade = mathGrade,
+            englishGrade = englishGrade,
+            scienceGrade = scienceGrade,
+            societyGrade = societyGrade,
+            technologyGrade = technologyGrade,
+            historyGrade = historyGrade,
+        )
+}

--- a/systems/application/application-adapter-out/src/main/kotlin/hs/kr/entrydsm/application/adapterout/repository/ApplicantJpaRepository.kt
+++ b/systems/application/application-adapter-out/src/main/kotlin/hs/kr/entrydsm/application/adapterout/repository/ApplicantJpaRepository.kt
@@ -3,4 +3,6 @@ package hs.kr.entrydsm.application.adapterout.repository
 import hs.kr.entrydsm.application.adapterout.entity.ApplicantJpaEntity
 import org.springframework.data.jpa.repository.JpaRepository
 
-interface ApplicantJpaRepository : JpaRepository<ApplicantJpaEntity, Long>
+interface ApplicantJpaRepository : JpaRepository<ApplicantJpaEntity, Long> {
+    fun findByAccountId(accountId: Long): ApplicantJpaEntity?
+}

--- a/systems/application/application-adapter-out/src/main/kotlin/hs/kr/entrydsm/application/adapterout/repository/ApplicantJpaRepository.kt
+++ b/systems/application/application-adapter-out/src/main/kotlin/hs/kr/entrydsm/application/adapterout/repository/ApplicantJpaRepository.kt
@@ -1,0 +1,6 @@
+package hs.kr.entrydsm.application.adapterout.repository
+
+import hs.kr.entrydsm.application.adapterout.entity.ApplicantJpaEntity
+import org.springframework.data.jpa.repository.JpaRepository
+
+interface ApplicantJpaRepository : JpaRepository<ApplicantJpaEntity, Long>

--- a/systems/application/application-adapter-out/src/main/kotlin/hs/kr/entrydsm/application/adapterout/repository/ApplicantPersistenceAdapter.kt
+++ b/systems/application/application-adapter-out/src/main/kotlin/hs/kr/entrydsm/application/adapterout/repository/ApplicantPersistenceAdapter.kt
@@ -1,0 +1,26 @@
+package hs.kr.entrydsm.application.adapterout.repository
+
+import hs.kr.entrydsm.application.adapterout.entity.ApplicantJpaEntity
+import hs.kr.entrydsm.application.application.port.out.ApplicantRepository
+import hs.kr.entrydsm.application.domain.model.Applicant
+import org.springframework.stereotype.Repository
+import org.springframework.transaction.annotation.Transactional
+
+@Repository
+@Transactional
+class ApplicantPersistenceAdapter(
+    private val applicantJpaRepository: ApplicantJpaRepository,
+) : ApplicantRepository {
+    override fun save(applicant: Applicant): Applicant {
+        val entity = applicant.id.takeIf { it > 0 }
+            ?.let { applicantJpaRepository.findById(it).orElse(null) }
+            ?.apply { updateFrom(applicant) }
+            ?: ApplicantJpaEntity.from(applicant)
+
+        return applicantJpaRepository.saveAndFlush(entity).toDomain()
+    }
+
+    @Transactional(readOnly = true)
+    override fun findById(id: Long): Applicant? =
+        applicantJpaRepository.findById(id).orElse(null)?.toDomain()
+}

--- a/systems/application/application-adapter-out/src/main/kotlin/hs/kr/entrydsm/application/adapterout/repository/ApplicantPersistenceAdapter.kt
+++ b/systems/application/application-adapter-out/src/main/kotlin/hs/kr/entrydsm/application/adapterout/repository/ApplicantPersistenceAdapter.kt
@@ -23,4 +23,8 @@ class ApplicantPersistenceAdapter(
     @Transactional(readOnly = true)
     override fun findById(id: Long): Applicant? =
         applicantJpaRepository.findById(id).orElse(null)?.toDomain()
+
+    @Transactional(readOnly = true)
+    override fun findByAccountId(accountId: Long): Applicant? =
+        applicantJpaRepository.findByAccountId(accountId)?.toDomain()
 }

--- a/systems/application/application-adapter-out/src/main/kotlin/hs/kr/entrydsm/application/adapterout/repository/ApplicantPersistenceAdapter.kt
+++ b/systems/application/application-adapter-out/src/main/kotlin/hs/kr/entrydsm/application/adapterout/repository/ApplicantPersistenceAdapter.kt
@@ -1,6 +1,7 @@
 package hs.kr.entrydsm.application.adapterout.repository
 
 import hs.kr.entrydsm.application.adapterout.entity.ApplicantJpaEntity
+import hs.kr.entrydsm.application.application.exception.ApplicantNotFoundException
 import hs.kr.entrydsm.application.application.port.out.ApplicantRepository
 import hs.kr.entrydsm.application.domain.model.Applicant
 import org.springframework.stereotype.Repository
@@ -12,10 +13,13 @@ class ApplicantPersistenceAdapter(
     private val applicantJpaRepository: ApplicantJpaRepository,
 ) : ApplicantRepository {
     override fun save(applicant: Applicant): Applicant {
-        val entity = applicant.id.takeIf { it > 0 }
-            ?.let { applicantJpaRepository.findById(it).orElse(null) }
-            ?.apply { updateFrom(applicant) }
-            ?: ApplicantJpaEntity.from(applicant)
+        val entity = if (applicant.id > 0) {
+            applicantJpaRepository.findById(applicant.id)
+                .orElseThrow { ApplicantNotFoundException(applicant.id) }
+                .apply { updateFrom(applicant) }
+        } else {
+            ApplicantJpaEntity.from(applicant)
+        }
 
         return applicantJpaRepository.saveAndFlush(entity).toDomain()
     }

--- a/systems/application/application-adapter-out/src/test/kotlin/hs/kr/entrydsm/TestMain.kt
+++ b/systems/application/application-adapter-out/src/test/kotlin/hs/kr/entrydsm/TestMain.kt
@@ -1,11 +1,13 @@
 package hs.kr.entrydsm.application.adapterout
 
-import org.junit.Assert.assertTrue
-import org.junit.Test
+import hs.kr.entrydsm.application.adapterout.entity.ApplicantJpaEntityTest
+import hs.kr.entrydsm.application.adapterout.entity.AcademicRecordJpaEntityTest
+import org.junit.runner.RunWith
+import org.junit.runners.Suite
 
-class ApplicationAdapterOutModuleTest {
-    @Test
-    fun moduleLoads() {
-        assertTrue(true)
-    }
-}
+@RunWith(Suite::class)
+@Suite.SuiteClasses(
+    AcademicRecordJpaEntityTest::class,
+    ApplicantJpaEntityTest::class,
+)
+class ApplicationAdapterOutModuleTest

--- a/systems/application/application-adapter-out/src/test/kotlin/hs/kr/entrydsm/application/adapterout/entity/AcademicRecordJpaEntityTest.kt
+++ b/systems/application/application-adapter-out/src/test/kotlin/hs/kr/entrydsm/application/adapterout/entity/AcademicRecordJpaEntityTest.kt
@@ -1,0 +1,109 @@
+package hs.kr.entrydsm.application.adapterout.entity
+
+import hs.kr.entrydsm.application.domain.enum.SchoolSemester
+import hs.kr.entrydsm.application.domain.enum.SubjectGrade
+import hs.kr.entrydsm.application.domain.model.AcademicRecord
+import hs.kr.entrydsm.application.domain.model.GedScores
+import hs.kr.entrydsm.application.domain.model.SubjectGrades
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertNull
+import org.junit.Assert.assertSame
+import org.junit.Test
+
+class AcademicRecordJpaEntityTest {
+    @Test
+    fun updateFromUpdatesSubjectGradeEntityInPlace() {
+        val entity = AcademicRecordJpaEntity()
+        entity.updateFrom(
+            AcademicRecord(
+                subjectGrades = linkedMapOf(
+                    SchoolSemester.SECOND_GRADE_FIRST_SEMESTER to subjectGrades(SubjectGrade.B),
+                ),
+            ),
+        )
+        val savedGrade = entity.subjectGrades.single()
+
+        entity.updateFrom(
+            AcademicRecord(
+                subjectGrades = linkedMapOf(
+                    SchoolSemester.SECOND_GRADE_FIRST_SEMESTER to subjectGrades(SubjectGrade.A),
+                ),
+            ),
+        )
+
+        assertSame(savedGrade, entity.subjectGrades.single())
+        assertEquals(SubjectGrade.A, entity.subjectGrades.single().koreanGrade)
+        assertSame(entity, entity.subjectGrades.single().academicRecord)
+    }
+
+    @Test
+    fun updateFromRemovesStaleSubjectGrades() {
+        val entity = AcademicRecordJpaEntity()
+        entity.updateFrom(
+            AcademicRecord(
+                subjectGrades = linkedMapOf(
+                    SchoolSemester.SECOND_GRADE_FIRST_SEMESTER to subjectGrades(SubjectGrade.A),
+                    SchoolSemester.SECOND_GRADE_SECOND_SEMESTER to subjectGrades(SubjectGrade.B),
+                ),
+            ),
+        )
+
+        entity.updateFrom(
+            AcademicRecord(
+                subjectGrades = linkedMapOf(
+                    SchoolSemester.SECOND_GRADE_SECOND_SEMESTER to subjectGrades(SubjectGrade.C),
+                ),
+            ),
+        )
+
+        assertEquals(
+            listOf(SchoolSemester.SECOND_GRADE_SECOND_SEMESTER),
+            entity.subjectGrades.map { it.id.schoolSemester },
+        )
+    }
+
+    @Test
+    fun updateFromUpdatesGedScoreEntityInPlace() {
+        val entity = AcademicRecordJpaEntity()
+        entity.updateFrom(AcademicRecord(gedScores = gedScores(80)))
+        val savedGedScores = entity.gedScores
+
+        entity.updateFrom(AcademicRecord(gedScores = gedScores(90)))
+
+        assertSame(savedGedScores, entity.gedScores)
+        assertEquals(90, entity.gedScores?.koreanScore)
+        assertSame(entity, entity.gedScores?.academicRecord)
+    }
+
+    @Test
+    fun updateFromRemovesGedScoresWhenDomainDoesNotHaveGedScores() {
+        val entity = AcademicRecordJpaEntity()
+        entity.updateFrom(AcademicRecord(gedScores = gedScores(80)))
+
+        entity.updateFrom(AcademicRecord())
+
+        assertNull(entity.gedScores)
+    }
+
+    private fun subjectGrades(grade: SubjectGrade): SubjectGrades =
+        SubjectGrades(
+            koreanGrade = grade,
+            mathGrade = grade,
+            englishGrade = grade,
+            scienceGrade = grade,
+            societyGrade = grade,
+            technologyGrade = grade,
+            historyGrade = grade,
+        )
+
+    private fun gedScores(score: Int): GedScores =
+        GedScores(
+            koreanScore = score,
+            mathScore = score,
+            englishScore = score,
+            scienceScore = score,
+            societyScore = score,
+            technologyScore = score,
+            historyScore = score,
+        )
+}

--- a/systems/application/application-adapter-out/src/test/kotlin/hs/kr/entrydsm/application/adapterout/entity/ApplicantJpaEntityTest.kt
+++ b/systems/application/application-adapter-out/src/test/kotlin/hs/kr/entrydsm/application/adapterout/entity/ApplicantJpaEntityTest.kt
@@ -1,0 +1,59 @@
+package hs.kr.entrydsm.application.adapterout.entity
+
+import hs.kr.entrydsm.application.domain.model.Applicant
+import java.time.LocalDateTime
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertNull
+import org.junit.Test
+
+class ApplicantJpaEntityTest {
+    @Test
+    fun fromCreatesNewEntityWithoutCarryingPositiveDomainId() {
+        val entity = ApplicantJpaEntity.from(
+            Applicant(
+                id = 100L,
+                accountId = 1L,
+            ),
+        )
+
+        assertNull(entity.id)
+        assertEquals(1L, entity.accountId)
+    }
+
+    @Test
+    fun updateFromDoesNotOverwriteCreatedAt() {
+        val originalCreatedAt = LocalDateTime.of(2026, 1, 1, 0, 0)
+        val domainCreatedAt = LocalDateTime.of(2026, 2, 1, 0, 0)
+        val entity = ApplicantJpaEntity(
+            id = 1L,
+            accountId = 1L,
+            createdAt = originalCreatedAt,
+        )
+
+        entity.updateFrom(
+            Applicant(
+                id = 1L,
+                accountId = 2L,
+                createdAt = domainCreatedAt,
+            ),
+        )
+
+        assertEquals(originalCreatedAt, entity.createdAt)
+        assertEquals(2L, entity.accountId)
+    }
+
+    @Test
+    fun fromUsesDomainCreatedAtForNewEntity() {
+        val createdAt = LocalDateTime.of(2026, 3, 1, 0, 0)
+
+        val entity = ApplicantJpaEntity.from(
+            Applicant(
+                id = 0L,
+                accountId = 1L,
+                createdAt = createdAt,
+            ),
+        )
+
+        assertEquals(createdAt, entity.createdAt)
+    }
+}

--- a/systems/application/application-application/BUILD.bazel
+++ b/systems/application/application-application/BUILD.bazel
@@ -17,5 +17,5 @@ kt_jvm_test(
     javac_opts = "//:javac_options",
     kotlinc_opts = "//:kotlinc_options",
     test_class = "hs.kr.entrydsm.application.application.ApplicationApplicationModuleTest",
-    deps = MODULE_DEPS + TEST_DEPS,
+    deps = [":main"] + MODULE_DEPS + TEST_DEPS,
 )

--- a/systems/application/application-application/src/main/kotlin/hs/kr/entrydsm/application/application/service/ApplicationCommandService.kt
+++ b/systems/application/application-application/src/main/kotlin/hs/kr/entrydsm/application/application/service/ApplicationCommandService.kt
@@ -129,6 +129,10 @@ class ApplicationCommandService(
         applicant.region = region
         applicant.graduationType = graduationType
         applicant.graduationDate = graduationDate
+        if (graduationType == GraduationType.GED) {
+            applicant.middleSchoolInfo = null
+            applicant.academicRecord?.subjectGrades?.clear()
+        }
         saveTouched(applicant)
     }
 

--- a/systems/application/application-application/src/test/kotlin/hs/kr/entrydsm/TestMain.kt
+++ b/systems/application/application-application/src/test/kotlin/hs/kr/entrydsm/TestMain.kt
@@ -1,11 +1,13 @@
 package hs.kr.entrydsm.application.application
 
-import org.junit.Assert.assertTrue
-import org.junit.Test
+import hs.kr.entrydsm.application.application.service.ApplicationCommandServiceTest
+import hs.kr.entrydsm.application.application.service.EvaluationCommandServiceTest
+import org.junit.runner.RunWith
+import org.junit.runners.Suite
 
-class ApplicationApplicationModuleTest {
-    @Test
-    fun moduleLoads() {
-        assertTrue(true)
-    }
-}
+@RunWith(Suite::class)
+@Suite.SuiteClasses(
+    ApplicationCommandServiceTest::class,
+    EvaluationCommandServiceTest::class,
+)
+class ApplicationApplicationModuleTest

--- a/systems/application/application-application/src/test/kotlin/hs/kr/entrydsm/application/application/service/ApplicationCommandServiceTest.kt
+++ b/systems/application/application-application/src/test/kotlin/hs/kr/entrydsm/application/application/service/ApplicationCommandServiceTest.kt
@@ -1,0 +1,84 @@
+package hs.kr.entrydsm.application.application.service
+
+import hs.kr.entrydsm.application.application.port.out.ApplicantRepository
+import hs.kr.entrydsm.application.domain.enum.AdmissionType
+import hs.kr.entrydsm.application.domain.enum.GraduationType
+import hs.kr.entrydsm.application.domain.enum.Region
+import hs.kr.entrydsm.application.domain.enum.SchoolSemester
+import hs.kr.entrydsm.application.domain.enum.SubjectGrade
+import hs.kr.entrydsm.application.domain.model.AcademicRecord
+import hs.kr.entrydsm.application.domain.model.Applicant
+import hs.kr.entrydsm.application.domain.model.MiddleSchoolInfo
+import hs.kr.entrydsm.application.domain.model.SubjectGrades
+import org.junit.Assert.assertNull
+import org.junit.Assert.assertTrue
+import org.junit.Test
+
+class ApplicationCommandServiceTest {
+    @Test
+    fun updateTypeClearsMiddleSchoolInfoAndSubjectGradesWhenChangedToGed() {
+        val repository = FakeApplicantRepository(
+            Applicant(
+                id = 1L,
+                accountId = 10L,
+                graduationType = GraduationType.PROSPECTIVE,
+                middleSchoolInfo = MiddleSchoolInfo(
+                    schoolName = "대덕중학교",
+                    studentNumber = "30101",
+                    schoolPhone = "042-000-0000",
+                    teacherName = "담임",
+                ),
+                academicRecord = AcademicRecord(
+                    subjectGrades = linkedMapOf(
+                        SchoolSemester.THIRD_GRADE_FIRST_SEMESTER to all(SubjectGrade.A),
+                    ),
+                ),
+            ),
+        )
+        val service = ApplicationCommandService(repository)
+
+        service.updateType(
+            applicantId = 1L,
+            userId = 10L,
+            admissionType = AdmissionType.REGULAR,
+            region = Region.DAEJEON,
+            graduationType = GraduationType.GED,
+            graduationDate = null,
+        )
+
+        val savedApplicant = requireNotNull(repository.savedApplicant)
+        assertNull(savedApplicant.middleSchoolInfo)
+        assertTrue(savedApplicant.academicRecord?.subjectGrades?.isEmpty() == true)
+    }
+
+    private class FakeApplicantRepository(
+        private var applicant: Applicant,
+    ) : ApplicantRepository {
+        var savedApplicant: Applicant? = null
+
+        override fun save(applicant: Applicant): Applicant {
+            savedApplicant = applicant
+            this.applicant = applicant
+            return applicant
+        }
+
+        override fun findById(id: Long): Applicant? =
+            applicant.takeIf { it.id == id }
+
+        override fun findByAccountId(accountId: Long): Applicant? =
+            applicant.takeIf { it.accountId == accountId }
+    }
+
+    private companion object {
+        fun all(grade: SubjectGrade): SubjectGrades =
+            SubjectGrades(
+                koreanGrade = grade,
+                mathGrade = grade,
+                englishGrade = grade,
+                scienceGrade = grade,
+                societyGrade = grade,
+                technologyGrade = grade,
+                historyGrade = grade,
+            )
+    }
+}

--- a/systems/application/application-application/src/test/kotlin/hs/kr/entrydsm/application/application/service/EvaluationCommandServiceTest.kt
+++ b/systems/application/application-application/src/test/kotlin/hs/kr/entrydsm/application/application/service/EvaluationCommandServiceTest.kt
@@ -1,0 +1,75 @@
+package hs.kr.entrydsm.application.application.service
+
+import hs.kr.entrydsm.application.application.port.out.ApplicantRepository
+import hs.kr.entrydsm.application.domain.enum.AdmissionType
+import hs.kr.entrydsm.application.domain.enum.GraduationType
+import hs.kr.entrydsm.application.domain.enum.SchoolSemester
+import hs.kr.entrydsm.application.domain.enum.SubjectGrade
+import hs.kr.entrydsm.application.domain.model.AcademicRecord
+import hs.kr.entrydsm.application.domain.model.Applicant
+import hs.kr.entrydsm.application.domain.model.SubjectGrades
+import hs.kr.entrydsm.application.domain.service.ScoreCalculator
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertNotNull
+import org.junit.Test
+
+class EvaluationCommandServiceTest {
+    @Test
+    fun calculateResultSavesScoreForApplicantsAdmissionType() {
+        val repository = FakeApplicantRepository(
+            Applicant(
+                id = 1L,
+                accountId = 10L,
+                admissionType = AdmissionType.REGULAR,
+                graduationType = GraduationType.PROSPECTIVE,
+                academicRecord = AcademicRecord(
+                    volunteerTime = 15,
+                    isDsmAlgorithmAwarded = true,
+                    subjectGrades = linkedMapOf(
+                        SchoolSemester.THIRD_GRADE_FIRST_SEMESTER to all(SubjectGrade.A),
+                        SchoolSemester.SECOND_GRADE_SECOND_SEMESTER to all(SubjectGrade.A),
+                        SchoolSemester.SECOND_GRADE_FIRST_SEMESTER to all(SubjectGrade.A),
+                    ),
+                ),
+            ),
+        )
+        val service = EvaluationCommandService(repository, ScoreCalculator())
+
+        service.calculateResult(userId = 10L)
+
+        val savedApplicant = requireNotNull(repository.savedApplicant)
+        assertEquals(173.0, savedApplicant.totalScore ?: 0.0, 0.0)
+        assertNotNull(savedApplicant.totalScoreUpdatedAt)
+    }
+
+    private class FakeApplicantRepository(
+        private var applicant: Applicant,
+    ) : ApplicantRepository {
+        var savedApplicant: Applicant? = null
+
+        override fun save(applicant: Applicant): Applicant {
+            savedApplicant = applicant
+            this.applicant = applicant
+            return applicant
+        }
+
+        override fun findById(id: Long): Applicant? =
+            applicant.takeIf { it.id == id }
+
+        override fun findByAccountId(accountId: Long): Applicant? =
+            applicant.takeIf { it.accountId == accountId }
+    }
+
+    private companion object {
+        fun all(grade: SubjectGrade): SubjectGrades =
+            SubjectGrades(
+                koreanGrade = grade,
+                mathGrade = grade,
+                englishGrade = grade,
+                scienceGrade = grade,
+                societyGrade = grade,
+                technologyGrade = grade,
+                historyGrade = grade,
+            )
+    }
+}

--- a/systems/application/application-bootstrap/BUILD.bazel
+++ b/systems/application/application-bootstrap/BUILD.bazel
@@ -8,7 +8,7 @@ kt_jvm_binary(
     srcs = glob(["src/main/kotlin/**/*.kt"]),
     javac_opts = "//:javac_options",
     kotlinc_opts = "//:kotlinc_options",
-    main_class = "hs.kr.entrydsm.application.ApplicationBootstrapApplicationKt",
+    main_class = "hs.kr.entrydsm.application.ExampleApplicationKt",
     plugins = ["//:spring_allopen"],
     resources = glob(["src/main/resources/**"]),
     deps = MODULE_DEPS + [

--- a/systems/application/application-bootstrap/deps.bzl
+++ b/systems/application/application-bootstrap/deps.bzl
@@ -1,11 +1,13 @@
 SPRING_DEPS = [
     "@maven//:org_springframework_boot_spring_boot_starter_web",
     "@maven//:org_springframework_boot_spring_boot_starter_actuator",
+    "@maven//:org_springframework_boot_spring_boot_starter_data_jpa",
 ]
 
 KOTLIN_DEPS = [
     "@maven//:org_jetbrains_kotlin_kotlin_reflect",
     "@maven//:com_fasterxml_jackson_module_jackson_module_kotlin",
+    "@maven//:com_mysql_mysql_connector_j",
 ]
 
 TEST_DEPS = [

--- a/systems/application/application-bootstrap/src/main/kotlin/hs/kr/entrydsm/application/config/ApplicationUseCaseConfig.kt
+++ b/systems/application/application-bootstrap/src/main/kotlin/hs/kr/entrydsm/application/config/ApplicationUseCaseConfig.kt
@@ -1,0 +1,22 @@
+package hs.kr.entrydsm.application.config
+
+import hs.kr.entrydsm.application.application.port.`in`.ApplicationPort
+import hs.kr.entrydsm.application.application.port.`in`.EvaluationPort
+import hs.kr.entrydsm.application.application.port.out.ApplicantRepository
+import hs.kr.entrydsm.application.application.service.ApplicationCommandService
+import hs.kr.entrydsm.application.application.service.EvaluationCommandService
+import org.springframework.context.annotation.Bean
+import org.springframework.context.annotation.Configuration
+
+@Configuration(proxyBeanMethods = false)
+class ApplicationUseCaseConfig {
+    @Bean
+    fun applicationService(
+        applicantRepository: ApplicantRepository,
+    ): ApplicationPort = ApplicationCommandService(applicantRepository)
+
+    @Bean
+    fun evaluationService(
+        applicantRepository: ApplicantRepository,
+    ): EvaluationPort = EvaluationCommandService(applicantRepository)
+}

--- a/systems/application/application-bootstrap/src/main/kotlin/hs/kr/entrydsm/application/config/ApplicationUseCaseConfig.kt
+++ b/systems/application/application-bootstrap/src/main/kotlin/hs/kr/entrydsm/application/config/ApplicationUseCaseConfig.kt
@@ -5,11 +5,15 @@ import hs.kr.entrydsm.application.application.port.`in`.EvaluationPort
 import hs.kr.entrydsm.application.application.port.out.ApplicantRepository
 import hs.kr.entrydsm.application.application.service.ApplicationCommandService
 import hs.kr.entrydsm.application.application.service.EvaluationCommandService
+import hs.kr.entrydsm.application.domain.service.ScoreCalculator
 import org.springframework.context.annotation.Bean
 import org.springframework.context.annotation.Configuration
 
 @Configuration(proxyBeanMethods = false)
 class ApplicationUseCaseConfig {
+    @Bean
+    fun scoreCalculator(): ScoreCalculator = ScoreCalculator()
+
     @Bean
     fun applicationService(
         applicantRepository: ApplicantRepository,
@@ -18,5 +22,6 @@ class ApplicationUseCaseConfig {
     @Bean
     fun evaluationService(
         applicantRepository: ApplicantRepository,
-    ): EvaluationPort = EvaluationCommandService(applicantRepository)
+        scoreCalculator: ScoreCalculator,
+    ): EvaluationPort = EvaluationCommandService(applicantRepository, scoreCalculator)
 }

--- a/systems/application/application-bootstrap/src/main/resources/application-dev.yaml
+++ b/systems/application/application-bootstrap/src/main/resources/application-dev.yaml
@@ -15,3 +15,10 @@ spring:
     properties:
       hibernate:
         dialect: org.hibernate.dialect.MySQLDialect
+
+entrydsm:
+  application:
+    schedule:
+      application-start-at: ${APPLICATION_START_AT}
+      application-end-at: ${APPLICATION_END_AT}
+      result-announced-at: ${RESULT_ANNOUNCED_AT}

--- a/systems/application/application-bootstrap/src/main/resources/application-dev.yaml
+++ b/systems/application/application-bootstrap/src/main/resources/application-dev.yaml
@@ -1,0 +1,17 @@
+spring:
+  config:
+    activate:
+      on-profile: dev
+  datasource:
+    url: ${DB_URL}
+    username: ${DB_USERNAME}
+    password: ${DB_PASSWORD}
+    driver-class-name: com.mysql.cj.jdbc.Driver
+  jpa:
+    hibernate:
+      ddl-auto: update
+    open-in-view: false
+    show-sql: false
+    properties:
+      hibernate:
+        dialect: org.hibernate.dialect.MySQLDialect

--- a/systems/application/application-bootstrap/src/main/resources/application-prod.yaml
+++ b/systems/application/application-bootstrap/src/main/resources/application-prod.yaml
@@ -1,0 +1,17 @@
+spring:
+  config:
+    activate:
+      on-profile: prod
+  datasource:
+    url: ${DB_URL}
+    username: ${DB_USERNAME}
+    password: ${DB_PASSWORD}
+    driver-class-name: com.mysql.cj.jdbc.Driver
+  jpa:
+    hibernate:
+      ddl-auto: validate
+    open-in-view: false
+    show-sql: false
+    properties:
+      hibernate:
+        dialect: org.hibernate.dialect.MySQLDialect

--- a/systems/application/application-bootstrap/src/main/resources/application-prod.yaml
+++ b/systems/application/application-bootstrap/src/main/resources/application-prod.yaml
@@ -15,3 +15,10 @@ spring:
     properties:
       hibernate:
         dialect: org.hibernate.dialect.MySQLDialect
+
+entrydsm:
+  application:
+    schedule:
+      application-start-at: ${APPLICATION_START_AT}
+      application-end-at: ${APPLICATION_END_AT}
+      result-announced-at: ${RESULT_ANNOUNCED_AT}

--- a/systems/application/application-bootstrap/src/main/resources/application.yaml
+++ b/systems/application/application-bootstrap/src/main/resources/application.yaml
@@ -2,11 +2,16 @@ spring:
   application:
     name: application
   profiles:
-    default: local
+    default: dev
   main:
     lazy-initialization: true
+
 server:
   shutdown: graceful
+
+grpc:
+  port: ${GRPC_PORT:9090}
+
 management:
   endpoints:
     web:
@@ -16,6 +21,14 @@ management:
     health:
       probes:
         enabled: true
+
 logging:
   level:
     root: INFO
+
+entrydsm:
+  application:
+    schedule:
+      application-start-at: "${APPLICATION_START_AT:2026-04-01T09:00:00}"
+      application-end-at: "${APPLICATION_END_AT:2026-04-30T17:00:00}"
+      result-announced-at: "${RESULT_ANNOUNCED_AT:2026-05-15T10:00:00}"

--- a/systems/application/application-bootstrap/src/main/resources/application.yaml
+++ b/systems/application/application-bootstrap/src/main/resources/application.yaml
@@ -25,10 +25,3 @@ management:
 logging:
   level:
     root: INFO
-
-entrydsm:
-  application:
-    schedule:
-      application-start-at: "${APPLICATION_START_AT:2026-04-01T09:00:00}"
-      application-end-at: "${APPLICATION_END_AT:2026-04-30T17:00:00}"
-      result-announced-at: "${RESULT_ANNOUNCED_AT:2026-05-15T10:00:00}"

--- a/systems/application/application-domain/src/main/kotlin/hs/kr/entrydsm/application/domain/service/ScoreCalculator.kt
+++ b/systems/application/application-domain/src/main/kotlin/hs/kr/entrydsm/application/domain/service/ScoreCalculator.kt
@@ -67,13 +67,12 @@ class ScoreCalculator {
             GraduationType.GRADUATED -> GRADUATED_SEMESTER_WEIGHTS
             else -> PROSPECTIVE_GRADUATION_SEMESTER_WEIGHTS
         }
-        val weightedScores = semesterWeights.mapNotNull { (semester, weight) ->
-            record.subjectGrades[semester]
-                ?.let(::calculateSemesterAveragePoint)
-                ?.let { averagePoint -> (averagePoint / MAX_GRADE_POINT) * weight to weight }
-        }
-        if (weightedScores.isEmpty()) {
-            return EMPTY_SCORE
+        val weightedScores = semesterWeights.map { (semester, weight) ->
+            val subjectGrades = requireNotNull(record.subjectGrades[semester]) {
+                "subject grades are incomplete"
+            }
+            val averagePoint = calculateSemesterAveragePoint(subjectGrades)
+            (averagePoint / MAX_GRADE_POINT) * weight to weight
         }
 
         val earnedScore = weightedScores.sumOf { it.first }

--- a/systems/application/application-domain/src/main/kotlin/hs/kr/entrydsm/application/domain/service/ScoreCalculator.kt
+++ b/systems/application/application-domain/src/main/kotlin/hs/kr/entrydsm/application/domain/service/ScoreCalculator.kt
@@ -117,15 +117,16 @@ class ScoreCalculator {
             return EMPTY_SCORE
         }
 
-        val convertedAbsences = record.absentCount + floor(
+        val convertedAbsences = record.absentCount.toLong() + floor(
             (
-                record.lateCount +
-                    record.earlyLeaveCount +
-                    record.classAbsenceCount
+                record.lateCount.toLong() +
+                    record.earlyLeaveCount.toLong() +
+                    record.classAbsenceCount.toLong()
                 ) / ATTENDANCE_CONVERSION_UNIT.toDouble(),
-        ).toInt()
+        ).toLong()
 
-        return (ATTENDANCE_MAX_SCORE - convertedAbsences).coerceAtLeast(EMPTY_SCORE)
+        return (ATTENDANCE_MAX_SCORE - convertedAbsences)
+            .coerceIn(EMPTY_SCORE, ATTENDANCE_MAX_SCORE)
     }
 
     private fun calculateVolunteerScore(

--- a/systems/application/application-domain/src/test/kotlin/hs/kr/entrydsm/application/domain/service/ScoreCalculatorTest.kt
+++ b/systems/application/application-domain/src/test/kotlin/hs/kr/entrydsm/application/domain/service/ScoreCalculatorTest.kt
@@ -105,6 +105,32 @@ class ScoreCalculatorTest {
     }
 
     @Test
+    fun clampsAttendanceScoreWhenAttendanceCountsAreTooLarge() {
+        val applicant = Applicant(
+            id = 1L,
+            accountId = 1L,
+            graduationType = GraduationType.PROSPECTIVE,
+            academicRecord = AcademicRecord(
+                absentCount = Int.MAX_VALUE,
+                lateCount = Int.MAX_VALUE,
+                earlyLeaveCount = Int.MAX_VALUE,
+                classAbsenceCount = Int.MAX_VALUE,
+                subjectGrades = linkedMapOf(
+                    SchoolSemester.THIRD_GRADE_FIRST_SEMESTER to all(SubjectGrade.A),
+                    SchoolSemester.SECOND_GRADE_SECOND_SEMESTER to all(SubjectGrade.A),
+                    SchoolSemester.SECOND_GRADE_FIRST_SEMESTER to all(SubjectGrade.A),
+                ),
+            ),
+        )
+
+        val result = calculator.calculate(applicant)
+
+        assertEquals(140.0, result.getValue(AdmissionType.REGULAR), 0.0)
+        assertEquals(80.0, result.getValue(AdmissionType.SOCIAL), 0.0)
+        assertEquals(80.0, result.getValue(AdmissionType.MEISTER), 0.0)
+    }
+
+    @Test
     fun returnsZeroWhenAcademicRecordDoesNotExist() {
         val result = calculator.calculate(Applicant(id = 1L, accountId = 1L))
 

--- a/systems/application/application-domain/src/test/kotlin/hs/kr/entrydsm/application/domain/service/ScoreCalculatorTest.kt
+++ b/systems/application/application-domain/src/test/kotlin/hs/kr/entrydsm/application/domain/service/ScoreCalculatorTest.kt
@@ -70,6 +70,40 @@ class ScoreCalculatorTest {
         assertEquals(80.0, result.getValue(AdmissionType.MEISTER), 0.0)
     }
 
+    @Test(expected = IllegalArgumentException::class)
+    fun rejectsIncompleteProspectiveSubjectGrades() {
+        calculator.calculate(
+            Applicant(
+                id = 1L,
+                accountId = 1L,
+                graduationType = GraduationType.PROSPECTIVE,
+                academicRecord = AcademicRecord(
+                    subjectGrades = linkedMapOf(
+                        SchoolSemester.THIRD_GRADE_FIRST_SEMESTER to all(SubjectGrade.A),
+                    ),
+                ),
+            ),
+        )
+    }
+
+    @Test(expected = IllegalArgumentException::class)
+    fun rejectsIncompleteGraduatedSubjectGrades() {
+        calculator.calculate(
+            Applicant(
+                id = 1L,
+                accountId = 1L,
+                graduationType = GraduationType.GRADUATED,
+                academicRecord = AcademicRecord(
+                    subjectGrades = linkedMapOf(
+                        SchoolSemester.THIRD_GRADE_SECOND_SEMESTER to all(SubjectGrade.A),
+                        SchoolSemester.THIRD_GRADE_FIRST_SEMESTER to all(SubjectGrade.A),
+                        SchoolSemester.SECOND_GRADE_SECOND_SEMESTER to all(SubjectGrade.A),
+                    ),
+                ),
+            ),
+        )
+    }
+
     @Test
     fun returnsZeroWhenAcademicRecordDoesNotExist() {
         val result = calculator.calculate(Applicant(id = 1L, accountId = 1L))


### PR DESCRIPTION
## Summary
원서작성 및 성적산출 기능의 MySQL JPA 저장소를 구성했습니다.
ERD 기준으로 applicants, middle_school_infos, academic_records, subject_grades, ged_scores, pass_results entity를 분리했습니다.
Spring Data repository와 ApplicantRepository persistence adapter를 추가했습니다.

## Related Issue
Related to #24 

## Scope
In scope:
- ApplicantJpaEntity
- MiddleSchoolInfoJpaEntity
- AcademicRecordJpaEntity
- SubjectGradeJpaEntity
- GedScoreJpaEntity
- PassResultJpaEntity
- Spring Data JPA repository
- ApplicantRepository persistence adapter
- adapter-out Bazel 의존성

Out of scope:
- migration script
- admin 합격/불합격 처리
- 2차 전형 점수 계산
- 외부 identity 서비스 연동

## Implementation
데이터 모델링 기준에 맞춰 지원자, 중학교 정보, 생활기록/성적, 검정고시 성적, 합격 결과를 별도 entity로 분리했습니다.
SubjectGrade와 PassResult는 복합키를 사용해 ERD의 PK 구조를 반영했습니다.
ApplicantPersistenceAdapter는 application 계층의 ApplicantRepository port를 구현합니다.
지원자 생성, 조회, 수정, 성적 정보 저장 흐름을 JPA repository로 처리합니다.

## Testing
- Unit test code: 후속 테스트 PR에서 추가
- Integration tests: 후속 이슈에서 보완 필요
- Manual verification: 후속 PR에서 build/test 수행 예정

## Deployment Notes
Feature flag: 없음  
Migration required: 예, application DB schema 필요  
Rollout considerations:
- dev profile에서는 Hibernate ddl-auto update로 로컬 확인 가능합니다.
- prod profile에서는 ddl-auto validate 기준으로 운영 schema가 선행되어야 합니다.
- 합격 결과 처리는 admin 기능과 연동될 예정입니다.

## Checklist
- [x] Matches product/tech requirements
- [x] Backward compatibility considered
- [x] Data modeling compatibility considered
- [ ] API success flow verified in a running environment
- [x] Real persistence adapter connected