### PR TITLE
feat(application): Application 테스트 및 실행 설정 정리 #24

### DIFF
--- a/systems/application/application-adapter-in/src/test/kotlin/hs/kr/entrydsm/application/adapterin/web/ApplicationControllerTest.kt
+++ b/systems/application/application-adapter-in/src/test/kotlin/hs/kr/entrydsm/application/adapterin/web/ApplicationControllerTest.kt
@@ -37,9 +37,9 @@ class ApplicationControllerTest {
         val response = controller.getLanding(10L)
 
         assertEquals("홍길동", response.data?.applicantName)
-        assertEquals(APPLICATION_START_AT, response.data?.schedule?.applicationPeriod?.startAt)
-        assertEquals(APPLICATION_END_AT, response.data?.schedule?.applicationPeriod?.endAt)
-        assertEquals(RESULT_ANNOUNCED_AT, response.data?.schedule?.resultAnnouncedAt)
+        assertEquals(applicationStartAt, response.data?.schedule?.applicationPeriod?.startAt)
+        assertEquals(applicationEndAt, response.data?.schedule?.applicationPeriod?.endAt)
+        assertEquals(resultAnnouncedAt, response.data?.schedule?.resultAnnouncedAt)
     }
 
     private class FakeApplicationPort : ApplicationPort {
@@ -61,15 +61,15 @@ class ApplicationControllerTest {
     }
 
     private companion object {
-        val APPLICATION_START_AT: LocalDateTime = LocalDateTime.parse("2026-04-01T09:00:00")
-        val APPLICATION_END_AT: LocalDateTime = LocalDateTime.parse("2026-04-30T17:00:00")
-        val RESULT_ANNOUNCED_AT: LocalDateTime = LocalDateTime.parse("2026-05-15T10:00:00")
+        val applicationStartAt: LocalDateTime = LocalDateTime.parse("2026-10-19T09:00:00")
+        val applicationEndAt: LocalDateTime = LocalDateTime.parse("2026-10-23T17:00:00")
+        val resultAnnouncedAt: LocalDateTime = LocalDateTime.parse("2026-10-30T10:00:00")
 
         fun scheduleProperties(): LandingScheduleProperties =
             LandingScheduleProperties(
-                applicationStartAt = APPLICATION_START_AT,
-                applicationEndAt = APPLICATION_END_AT,
-                resultAnnouncedAt = RESULT_ANNOUNCED_AT,
+                applicationStartAt = applicationStartAt,
+                applicationEndAt = applicationEndAt,
+                resultAnnouncedAt = resultAnnouncedAt,
             )
     }
 }

--- a/systems/application/application-application/BUILD.bazel
+++ b/systems/application/application-application/BUILD.bazel
@@ -17,5 +17,5 @@ kt_jvm_test(
     javac_opts = "//:javac_options",
     kotlinc_opts = "//:kotlinc_options",
     test_class = "hs.kr.entrydsm.application.application.ApplicationApplicationModuleTest",
-    deps = MODULE_DEPS + TEST_DEPS,
+    deps = [":main"] + MODULE_DEPS + TEST_DEPS,
 )

--- a/systems/application/application-application/src/main/kotlin/hs/kr/entrydsm/application/application/service/ApplicationCommandService.kt
+++ b/systems/application/application-application/src/main/kotlin/hs/kr/entrydsm/application/application/service/ApplicationCommandService.kt
@@ -129,6 +129,10 @@ class ApplicationCommandService(
         applicant.region = region
         applicant.graduationType = graduationType
         applicant.graduationDate = graduationDate
+        if (graduationType == GraduationType.GED) {
+            applicant.middleSchoolInfo = null
+            applicant.academicRecord?.subjectGrades?.clear()
+        }
         saveTouched(applicant)
     }
 

--- a/systems/application/application-application/src/test/kotlin/hs/kr/entrydsm/TestMain.kt
+++ b/systems/application/application-application/src/test/kotlin/hs/kr/entrydsm/TestMain.kt
@@ -1,11 +1,13 @@
 package hs.kr.entrydsm.application.application
 
-import org.junit.Assert.assertTrue
-import org.junit.Test
+import hs.kr.entrydsm.application.application.service.ApplicationCommandServiceTest
+import hs.kr.entrydsm.application.application.service.EvaluationCommandServiceTest
+import org.junit.runner.RunWith
+import org.junit.runners.Suite
 
-class ApplicationApplicationModuleTest {
-    @Test
-    fun moduleLoads() {
-        assertTrue(true)
-    }
-}
+@RunWith(Suite::class)
+@Suite.SuiteClasses(
+    ApplicationCommandServiceTest::class,
+    EvaluationCommandServiceTest::class,
+)
+class ApplicationApplicationModuleTest

--- a/systems/application/application-application/src/test/kotlin/hs/kr/entrydsm/application/application/service/ApplicationCommandServiceTest.kt
+++ b/systems/application/application-application/src/test/kotlin/hs/kr/entrydsm/application/application/service/ApplicationCommandServiceTest.kt
@@ -1,0 +1,84 @@
+package hs.kr.entrydsm.application.application.service
+
+import hs.kr.entrydsm.application.application.port.out.ApplicantRepository
+import hs.kr.entrydsm.application.domain.enum.AdmissionType
+import hs.kr.entrydsm.application.domain.enum.GraduationType
+import hs.kr.entrydsm.application.domain.enum.Region
+import hs.kr.entrydsm.application.domain.enum.SchoolSemester
+import hs.kr.entrydsm.application.domain.enum.SubjectGrade
+import hs.kr.entrydsm.application.domain.model.AcademicRecord
+import hs.kr.entrydsm.application.domain.model.Applicant
+import hs.kr.entrydsm.application.domain.model.MiddleSchoolInfo
+import hs.kr.entrydsm.application.domain.model.SubjectGrades
+import org.junit.Assert.assertNull
+import org.junit.Assert.assertTrue
+import org.junit.Test
+
+class ApplicationCommandServiceTest {
+    @Test
+    fun updateTypeClearsMiddleSchoolInfoAndSubjectGradesWhenChangedToGed() {
+        val repository = FakeApplicantRepository(
+            Applicant(
+                id = 1L,
+                accountId = 10L,
+                graduationType = GraduationType.PROSPECTIVE,
+                middleSchoolInfo = MiddleSchoolInfo(
+                    schoolName = "대덕중학교",
+                    studentNumber = "30101",
+                    schoolPhone = "042-000-0000",
+                    teacherName = "담임",
+                ),
+                academicRecord = AcademicRecord(
+                    subjectGrades = linkedMapOf(
+                        SchoolSemester.THIRD_GRADE_FIRST_SEMESTER to all(SubjectGrade.A),
+                    ),
+                ),
+            ),
+        )
+        val service = ApplicationCommandService(repository)
+
+        service.updateType(
+            applicantId = 1L,
+            userId = 10L,
+            admissionType = AdmissionType.REGULAR,
+            region = Region.DAEJEON,
+            graduationType = GraduationType.GED,
+            graduationDate = null,
+        )
+
+        val savedApplicant = requireNotNull(repository.savedApplicant)
+        assertNull(savedApplicant.middleSchoolInfo)
+        assertTrue(savedApplicant.academicRecord?.subjectGrades?.isEmpty() == true)
+    }
+
+    private class FakeApplicantRepository(
+        private var applicant: Applicant,
+    ) : ApplicantRepository {
+        var savedApplicant: Applicant? = null
+
+        override fun save(applicant: Applicant): Applicant {
+            savedApplicant = applicant
+            this.applicant = applicant
+            return applicant
+        }
+
+        override fun findById(id: Long): Applicant? =
+            applicant.takeIf { it.id == id }
+
+        override fun findByAccountId(accountId: Long): Applicant? =
+            applicant.takeIf { it.accountId == accountId }
+    }
+
+    private companion object {
+        fun all(grade: SubjectGrade): SubjectGrades =
+            SubjectGrades(
+                koreanGrade = grade,
+                mathGrade = grade,
+                englishGrade = grade,
+                scienceGrade = grade,
+                societyGrade = grade,
+                technologyGrade = grade,
+                historyGrade = grade,
+            )
+    }
+}

--- a/systems/application/application-application/src/test/kotlin/hs/kr/entrydsm/application/application/service/EvaluationCommandServiceTest.kt
+++ b/systems/application/application-application/src/test/kotlin/hs/kr/entrydsm/application/application/service/EvaluationCommandServiceTest.kt
@@ -1,0 +1,75 @@
+package hs.kr.entrydsm.application.application.service
+
+import hs.kr.entrydsm.application.application.port.out.ApplicantRepository
+import hs.kr.entrydsm.application.domain.enum.AdmissionType
+import hs.kr.entrydsm.application.domain.enum.GraduationType
+import hs.kr.entrydsm.application.domain.enum.SchoolSemester
+import hs.kr.entrydsm.application.domain.enum.SubjectGrade
+import hs.kr.entrydsm.application.domain.model.AcademicRecord
+import hs.kr.entrydsm.application.domain.model.Applicant
+import hs.kr.entrydsm.application.domain.model.SubjectGrades
+import hs.kr.entrydsm.application.domain.service.ScoreCalculator
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertNotNull
+import org.junit.Test
+
+class EvaluationCommandServiceTest {
+    @Test
+    fun calculateResultSavesScoreForApplicantsAdmissionType() {
+        val repository = FakeApplicantRepository(
+            Applicant(
+                id = 1L,
+                accountId = 10L,
+                admissionType = AdmissionType.REGULAR,
+                graduationType = GraduationType.PROSPECTIVE,
+                academicRecord = AcademicRecord(
+                    volunteerTime = 15,
+                    isDsmAlgorithmAwarded = true,
+                    subjectGrades = linkedMapOf(
+                        SchoolSemester.THIRD_GRADE_FIRST_SEMESTER to all(SubjectGrade.A),
+                        SchoolSemester.SECOND_GRADE_SECOND_SEMESTER to all(SubjectGrade.A),
+                        SchoolSemester.SECOND_GRADE_FIRST_SEMESTER to all(SubjectGrade.A),
+                    ),
+                ),
+            ),
+        )
+        val service = EvaluationCommandService(repository, ScoreCalculator())
+
+        service.calculateResult(userId = 10L)
+
+        val savedApplicant = requireNotNull(repository.savedApplicant)
+        assertEquals(173.0, savedApplicant.totalScore ?: 0.0, 0.0)
+        assertNotNull(savedApplicant.totalScoreUpdatedAt)
+    }
+
+    private class FakeApplicantRepository(
+        private var applicant: Applicant,
+    ) : ApplicantRepository {
+        var savedApplicant: Applicant? = null
+
+        override fun save(applicant: Applicant): Applicant {
+            savedApplicant = applicant
+            this.applicant = applicant
+            return applicant
+        }
+
+        override fun findById(id: Long): Applicant? =
+            applicant.takeIf { it.id == id }
+
+        override fun findByAccountId(accountId: Long): Applicant? =
+            applicant.takeIf { it.accountId == accountId }
+    }
+
+    private companion object {
+        fun all(grade: SubjectGrade): SubjectGrades =
+            SubjectGrades(
+                koreanGrade = grade,
+                mathGrade = grade,
+                englishGrade = grade,
+                scienceGrade = grade,
+                societyGrade = grade,
+                technologyGrade = grade,
+                historyGrade = grade,
+            )
+    }
+}

--- a/systems/application/application-bootstrap/BUILD.bazel
+++ b/systems/application/application-bootstrap/BUILD.bazel
@@ -8,7 +8,7 @@ kt_jvm_binary(
     srcs = glob(["src/main/kotlin/**/*.kt"]),
     javac_opts = "//:javac_options",
     kotlinc_opts = "//:kotlinc_options",
-    main_class = "hs.kr.entrydsm.application.ApplicationBootstrapApplicationKt",
+    main_class = "hs.kr.entrydsm.application.ExampleApplicationKt",
     plugins = ["//:spring_allopen"],
     resources = glob(["src/main/resources/**"]),
     deps = MODULE_DEPS + [

--- a/systems/application/application-bootstrap/deps.bzl
+++ b/systems/application/application-bootstrap/deps.bzl
@@ -1,11 +1,13 @@
 SPRING_DEPS = [
     "@maven//:org_springframework_boot_spring_boot_starter_web",
     "@maven//:org_springframework_boot_spring_boot_starter_actuator",
+    "@maven//:org_springframework_boot_spring_boot_starter_data_jpa",
 ]
 
 KOTLIN_DEPS = [
     "@maven//:org_jetbrains_kotlin_kotlin_reflect",
     "@maven//:com_fasterxml_jackson_module_jackson_module_kotlin",
+    "@maven//:com_mysql_mysql_connector_j",
 ]
 
 TEST_DEPS = [

--- a/systems/application/application-bootstrap/src/main/kotlin/hs/kr/entrydsm/application/config/ApplicationUseCaseConfig.kt
+++ b/systems/application/application-bootstrap/src/main/kotlin/hs/kr/entrydsm/application/config/ApplicationUseCaseConfig.kt
@@ -1,0 +1,22 @@
+package hs.kr.entrydsm.application.config
+
+import hs.kr.entrydsm.application.application.port.`in`.ApplicationPort
+import hs.kr.entrydsm.application.application.port.`in`.EvaluationPort
+import hs.kr.entrydsm.application.application.port.out.ApplicantRepository
+import hs.kr.entrydsm.application.application.service.ApplicationCommandService
+import hs.kr.entrydsm.application.application.service.EvaluationCommandService
+import org.springframework.context.annotation.Bean
+import org.springframework.context.annotation.Configuration
+
+@Configuration(proxyBeanMethods = false)
+class ApplicationUseCaseConfig {
+    @Bean
+    fun applicationService(
+        applicantRepository: ApplicantRepository,
+    ): ApplicationPort = ApplicationCommandService(applicantRepository)
+
+    @Bean
+    fun evaluationService(
+        applicantRepository: ApplicantRepository,
+    ): EvaluationPort = EvaluationCommandService(applicantRepository)
+}

--- a/systems/application/application-bootstrap/src/main/kotlin/hs/kr/entrydsm/application/config/ApplicationUseCaseConfig.kt
+++ b/systems/application/application-bootstrap/src/main/kotlin/hs/kr/entrydsm/application/config/ApplicationUseCaseConfig.kt
@@ -5,11 +5,15 @@ import hs.kr.entrydsm.application.application.port.`in`.EvaluationPort
 import hs.kr.entrydsm.application.application.port.out.ApplicantRepository
 import hs.kr.entrydsm.application.application.service.ApplicationCommandService
 import hs.kr.entrydsm.application.application.service.EvaluationCommandService
+import hs.kr.entrydsm.application.domain.service.ScoreCalculator
 import org.springframework.context.annotation.Bean
 import org.springframework.context.annotation.Configuration
 
 @Configuration(proxyBeanMethods = false)
 class ApplicationUseCaseConfig {
+    @Bean
+    fun scoreCalculator(): ScoreCalculator = ScoreCalculator()
+
     @Bean
     fun applicationService(
         applicantRepository: ApplicantRepository,
@@ -18,5 +22,6 @@ class ApplicationUseCaseConfig {
     @Bean
     fun evaluationService(
         applicantRepository: ApplicantRepository,
-    ): EvaluationPort = EvaluationCommandService(applicantRepository)
+        scoreCalculator: ScoreCalculator,
+    ): EvaluationPort = EvaluationCommandService(applicantRepository, scoreCalculator)
 }

--- a/systems/application/application-bootstrap/src/main/resources/application-dev.yaml
+++ b/systems/application/application-bootstrap/src/main/resources/application-dev.yaml
@@ -15,3 +15,10 @@ spring:
     properties:
       hibernate:
         dialect: org.hibernate.dialect.MySQLDialect
+
+entrydsm:
+  application:
+    schedule:
+      application-start-at: ${APPLICATION_START_AT}
+      application-end-at: ${APPLICATION_END_AT}
+      result-announced-at: ${RESULT_ANNOUNCED_AT}

--- a/systems/application/application-bootstrap/src/main/resources/application-dev.yaml
+++ b/systems/application/application-bootstrap/src/main/resources/application-dev.yaml
@@ -1,0 +1,17 @@
+spring:
+  config:
+    activate:
+      on-profile: dev
+  datasource:
+    url: ${DB_URL}
+    username: ${DB_USERNAME}
+    password: ${DB_PASSWORD}
+    driver-class-name: com.mysql.cj.jdbc.Driver
+  jpa:
+    hibernate:
+      ddl-auto: update
+    open-in-view: false
+    show-sql: false
+    properties:
+      hibernate:
+        dialect: org.hibernate.dialect.MySQLDialect

--- a/systems/application/application-bootstrap/src/main/resources/application-prod.yaml
+++ b/systems/application/application-bootstrap/src/main/resources/application-prod.yaml
@@ -1,0 +1,17 @@
+spring:
+  config:
+    activate:
+      on-profile: prod
+  datasource:
+    url: ${DB_URL}
+    username: ${DB_USERNAME}
+    password: ${DB_PASSWORD}
+    driver-class-name: com.mysql.cj.jdbc.Driver
+  jpa:
+    hibernate:
+      ddl-auto: validate
+    open-in-view: false
+    show-sql: false
+    properties:
+      hibernate:
+        dialect: org.hibernate.dialect.MySQLDialect

--- a/systems/application/application-bootstrap/src/main/resources/application-prod.yaml
+++ b/systems/application/application-bootstrap/src/main/resources/application-prod.yaml
@@ -15,3 +15,10 @@ spring:
     properties:
       hibernate:
         dialect: org.hibernate.dialect.MySQLDialect
+
+entrydsm:
+  application:
+    schedule:
+      application-start-at: ${APPLICATION_START_AT}
+      application-end-at: ${APPLICATION_END_AT}
+      result-announced-at: ${RESULT_ANNOUNCED_AT}

--- a/systems/application/application-bootstrap/src/main/resources/application.yaml
+++ b/systems/application/application-bootstrap/src/main/resources/application.yaml
@@ -2,11 +2,16 @@ spring:
   application:
     name: application
   profiles:
-    default: local
+    default: dev
   main:
     lazy-initialization: true
+
 server:
   shutdown: graceful
+
+grpc:
+  port: ${GRPC_PORT:9090}
+
 management:
   endpoints:
     web:
@@ -16,6 +21,14 @@ management:
     health:
       probes:
         enabled: true
+
 logging:
   level:
     root: INFO
+
+entrydsm:
+  application:
+    schedule:
+      application-start-at: "${APPLICATION_START_AT:2026-04-01T09:00:00}"
+      application-end-at: "${APPLICATION_END_AT:2026-04-30T17:00:00}"
+      result-announced-at: "${RESULT_ANNOUNCED_AT:2026-05-15T10:00:00}"

--- a/systems/application/application-bootstrap/src/main/resources/application.yaml
+++ b/systems/application/application-bootstrap/src/main/resources/application.yaml
@@ -25,10 +25,3 @@ management:
 logging:
   level:
     root: INFO
-
-entrydsm:
-  application:
-    schedule:
-      application-start-at: "${APPLICATION_START_AT:2026-04-01T09:00:00}"
-      application-end-at: "${APPLICATION_END_AT:2026-04-30T17:00:00}"
-      result-announced-at: "${RESULT_ANNOUNCED_AT:2026-05-15T10:00:00}"

--- a/systems/application/application-domain/src/main/kotlin/hs/kr/entrydsm/application/domain/service/ScoreCalculator.kt
+++ b/systems/application/application-domain/src/main/kotlin/hs/kr/entrydsm/application/domain/service/ScoreCalculator.kt
@@ -117,15 +117,16 @@ class ScoreCalculator {
             return EMPTY_SCORE
         }
 
-        val convertedAbsences = record.absentCount + floor(
+        val convertedAbsences = record.absentCount.toLong() + floor(
             (
-                record.lateCount +
-                    record.earlyLeaveCount +
-                    record.classAbsenceCount
+                record.lateCount.toLong() +
+                    record.earlyLeaveCount.toLong() +
+                    record.classAbsenceCount.toLong()
                 ) / ATTENDANCE_CONVERSION_UNIT.toDouble(),
-        ).toInt()
+        ).toLong()
 
-        return (ATTENDANCE_MAX_SCORE - convertedAbsences).coerceAtLeast(EMPTY_SCORE)
+        return (ATTENDANCE_MAX_SCORE - convertedAbsences)
+            .coerceIn(EMPTY_SCORE, ATTENDANCE_MAX_SCORE)
     }
 
     private fun calculateVolunteerScore(

--- a/systems/application/application-domain/src/test/kotlin/hs/kr/entrydsm/application/domain/service/ScoreCalculatorTest.kt
+++ b/systems/application/application-domain/src/test/kotlin/hs/kr/entrydsm/application/domain/service/ScoreCalculatorTest.kt
@@ -105,6 +105,32 @@ class ScoreCalculatorTest {
     }
 
     @Test
+    fun clampsAttendanceScoreWhenAttendanceCountsAreTooLarge() {
+        val applicant = Applicant(
+            id = 1L,
+            accountId = 1L,
+            graduationType = GraduationType.PROSPECTIVE,
+            academicRecord = AcademicRecord(
+                absentCount = Int.MAX_VALUE,
+                lateCount = Int.MAX_VALUE,
+                earlyLeaveCount = Int.MAX_VALUE,
+                classAbsenceCount = Int.MAX_VALUE,
+                subjectGrades = linkedMapOf(
+                    SchoolSemester.THIRD_GRADE_FIRST_SEMESTER to all(SubjectGrade.A),
+                    SchoolSemester.SECOND_GRADE_SECOND_SEMESTER to all(SubjectGrade.A),
+                    SchoolSemester.SECOND_GRADE_FIRST_SEMESTER to all(SubjectGrade.A),
+                ),
+            ),
+        )
+
+        val result = calculator.calculate(applicant)
+
+        assertEquals(140.0, result.getValue(AdmissionType.REGULAR), 0.0)
+        assertEquals(80.0, result.getValue(AdmissionType.SOCIAL), 0.0)
+        assertEquals(80.0, result.getValue(AdmissionType.MEISTER), 0.0)
+    }
+
+    @Test
     fun returnsZeroWhenAcademicRecordDoesNotExist() {
         val result = calculator.calculate(Applicant(id = 1L, accountId = 1L))
 


### PR DESCRIPTION
## Summary
application 서비스의 bootstrap 실행 설정과 테스트를 정리했습니다.
dev/prod profile별 MySQL 설정을 추가했습니다.
application bootstrap main class와 Bazel 의존성을 정리했습니다.
ScoreCalculator, ApplicationController, EvaluationController 테스트를 추가했습니다.

## Related Issue
Closes #24

## Scope
In scope:
- application bootstrap BUILD/deps 정리
- application.yaml
- application-dev.yaml
- application-prod.yaml
- ScoreCalculatorTest
- ApplicationControllerTest
- EvaluationControllerTest
- Bazel test target 정리

Out of scope:
- 운영 migration 도구
- 실제 identity 인증 연동
- admin 합격 결과 처리
- 2차 전형 점수 계산

## Implementation
application 기본 profile은 dev로 구성했습니다.
dev/prod 모두 MySQL datasource와 JPA 설정을 사용하도록 정리했습니다.
랜딩 일정은 APPLICATION_START_AT, APPLICATION_END_AT, RESULT_ANNOUNCED_AT 환경변수로 주입할 수 있게 구성했습니다.
Bazel bootstrap main_class를 실제 Kotlin main class와 일치하도록 수정했습니다.
도메인 점수 계산과 REST controller 응답 흐름을 테스트로 검증했습니다.

## Testing
Unit tests:
- ScoreCalculatorTest
- ApplicationControllerTest
- EvaluationControllerTest

Manual verification:
```bash
bazel --output_user_root=C:/bazel-cache/entrydsm-tests test //systems/application/application-domain:test //systems/application/application-adapter-in:test --shell_executable="C:/Program Files/Git/bin/bash.exe" --jobs=2 --test_output=errors