### PR TITLE
feat(notification): notification 도메인 구성 #28

### DIFF
--- a/systems/notification/notification-adapter-in/BUILD.bazel
+++ b/systems/notification/notification-adapter-in/BUILD.bazel
@@ -17,5 +17,5 @@ kt_jvm_test(
     javac_opts = "//:javac_options",
     kotlinc_opts = "//:kotlinc_options",
     test_class = "hs.kr.entrydsm.notification.adapterin.NotificationAdapterInModuleTest",
-    deps = MODULE_DEPS + TEST_DEPS,
+    deps = [":main"] + MODULE_DEPS + TEST_DEPS,
 )

--- a/systems/notification/notification-adapter-in/deps.bzl
+++ b/systems/notification/notification-adapter-in/deps.bzl
@@ -1,3 +1,4 @@
+# Dependencies for the notification REST adapter module.
 KOTLIN_DEPS = [
     "@maven//:org_springframework_boot_spring_boot_starter_web",
     "//systems/notification/notification-application:main",

--- a/systems/notification/notification-adapter-in/deps.bzl
+++ b/systems/notification/notification-adapter-in/deps.bzl
@@ -1,4 +1,8 @@
-KOTLIN_DEPS = []
+KOTLIN_DEPS = [
+    "@maven//:org_springframework_boot_spring_boot_starter_web",
+    "//systems/notification/notification-application:main",
+    "//systems/notification/notification-domain:main",
+]
 
 TEST_DEPS = [
     "@maven//:junit_junit",

--- a/systems/notification/notification-adapter-in/src/main/kotlin/hs/kr/entrydsm/notification/adapterin/web/NotificationController.kt
+++ b/systems/notification/notification-adapter-in/src/main/kotlin/hs/kr/entrydsm/notification/adapterin/web/NotificationController.kt
@@ -25,8 +25,15 @@ class NotificationController(
     fun getNotices(
         @RequestParam(defaultValue = "0") page: Int,
         @RequestParam(defaultValue = "10") size: Int,
+        @RequestParam(required = false) category: String?,
     ): ApiResponse<PageResponse<NoticeSummaryResponse>> {
-        val result = notificationPort.getNotices(ReadNotificationPageCommand(page = page, size = size))
+        val result = notificationPort.getNotices(
+            ReadNotificationPageCommand.of(
+                page = page,
+                size = size,
+                category = category,
+            ),
+        )
         return ApiResponse(
             status = 200,
             message = "공지 목록 조회 성공",

--- a/systems/notification/notification-adapter-in/src/main/kotlin/hs/kr/entrydsm/notification/adapterin/web/NotificationController.kt
+++ b/systems/notification/notification-adapter-in/src/main/kotlin/hs/kr/entrydsm/notification/adapterin/web/NotificationController.kt
@@ -1,0 +1,84 @@
+package hs.kr.entrydsm.notification.adapterin.web
+
+import hs.kr.entrydsm.notification.adapterin.web.dto.common.ApiResponse
+import hs.kr.entrydsm.notification.adapterin.web.dto.common.toResponse
+import hs.kr.entrydsm.notification.adapterin.web.dto.response.FaqDetailResponse
+import hs.kr.entrydsm.notification.adapterin.web.dto.response.FaqSummaryResponse
+import hs.kr.entrydsm.notification.adapterin.web.dto.response.NoticeDetailResponse
+import hs.kr.entrydsm.notification.adapterin.web.dto.response.NoticeSummaryResponse
+import hs.kr.entrydsm.notification.adapterin.web.dto.response.PageResponse
+import hs.kr.entrydsm.notification.adapterin.web.dto.response.RecruitmentGuidelineResponse
+import hs.kr.entrydsm.notification.application.port.`in`.NotificationPort
+import hs.kr.entrydsm.notification.application.port.`in`.command.ReadNotificationPageCommand
+import org.springframework.web.bind.annotation.GetMapping
+import org.springframework.web.bind.annotation.PathVariable
+import org.springframework.web.bind.annotation.RequestMapping
+import org.springframework.web.bind.annotation.RequestParam
+import org.springframework.web.bind.annotation.RestController
+
+@RestController
+@RequestMapping("/api/notification/v11/notifications")
+class NotificationController(
+    private val notificationPort: NotificationPort,
+) {
+    @GetMapping("/notification")
+    fun getNotices(
+        @RequestParam(defaultValue = "0") page: Int,
+        @RequestParam(defaultValue = "10") size: Int,
+    ): ApiResponse<PageResponse<NoticeSummaryResponse>> {
+        val result = notificationPort.getNotices(ReadNotificationPageCommand(page = page, size = size))
+        return ApiResponse(
+            status = 200,
+            message = "공지 목록 조회 성공",
+            data = result.toResponse { it.toResponse() },
+        )
+    }
+
+    @GetMapping("/notification/{id}")
+    fun getNotice(
+        @PathVariable id: Long,
+    ): ApiResponse<NoticeDetailResponse> {
+        val result = notificationPort.getNotice(id)
+        return ApiResponse(
+            status = 200,
+            message = "공지 상세 조회 성공",
+            data = result.toResponse(),
+        )
+    }
+
+    @GetMapping("/qna")
+    fun getFaqs(
+        @RequestParam(defaultValue = "0") page: Int,
+        @RequestParam(defaultValue = "10") size: Int,
+    ): ApiResponse<PageResponse<FaqSummaryResponse>> {
+        val result = notificationPort.getFaqs(ReadNotificationPageCommand(page = page, size = size))
+        return ApiResponse(
+            status = 200,
+            message = "자주 묻는 질문 목록 조회 성공",
+            data = result.toResponse { it.toResponse() },
+        )
+    }
+
+    @GetMapping("/qna/{id}")
+    fun getFaq(
+        @PathVariable id: Long,
+    ): ApiResponse<FaqDetailResponse> {
+        val result = notificationPort.getFaq(id)
+        return ApiResponse(
+            status = 200,
+            message = "자주 묻는 질문 상세 조회 성공",
+            data = result.toResponse(),
+        )
+    }
+
+    @GetMapping("/guideline")
+    fun getRecruitmentGuideline(): ApiResponse<RecruitmentGuidelineResponse> {
+        val result = notificationPort.getRecruitmentGuideline()
+        return ApiResponse(
+            status = 200,
+            message = "전형 요강 상세 조회 성공",
+            data = result.toResponse(),
+        )
+    }
+}
+

--- a/systems/notification/notification-adapter-in/src/main/kotlin/hs/kr/entrydsm/notification/adapterin/web/NotificationController.kt
+++ b/systems/notification/notification-adapter-in/src/main/kotlin/hs/kr/entrydsm/notification/adapterin/web/NotificationController.kt
@@ -9,6 +9,7 @@ import hs.kr.entrydsm.notification.adapterin.web.dto.response.NoticeSummaryRespo
 import hs.kr.entrydsm.notification.adapterin.web.dto.response.PageResponse
 import hs.kr.entrydsm.notification.adapterin.web.dto.response.RecruitmentGuidelineResponse
 import hs.kr.entrydsm.notification.application.port.`in`.NotificationPort
+import hs.kr.entrydsm.notification.application.port.`in`.command.ReadFaqPageCommand
 import hs.kr.entrydsm.notification.application.port.`in`.command.ReadNotificationPageCommand
 import org.springframework.web.bind.annotation.GetMapping
 import org.springframework.web.bind.annotation.PathVariable
@@ -57,8 +58,15 @@ class NotificationController(
     fun getFaqs(
         @RequestParam(defaultValue = "0") page: Int,
         @RequestParam(defaultValue = "10") size: Int,
+        @RequestParam(required = false) category: String?,
     ): ApiResponse<PageResponse<FaqSummaryResponse>> {
-        val result = notificationPort.getFaqs(ReadNotificationPageCommand(page = page, size = size))
+        val result = notificationPort.getFaqs(
+            ReadFaqPageCommand.of(
+                page = page,
+                size = size,
+                category = category,
+            ),
+        )
         return ApiResponse(
             status = 200,
             message = "자주 묻는 질문 목록 조회 성공",

--- a/systems/notification/notification-adapter-in/src/main/kotlin/hs/kr/entrydsm/notification/adapterin/web/dto/common/ApiResponse.kt
+++ b/systems/notification/notification-adapter-in/src/main/kotlin/hs/kr/entrydsm/notification/adapterin/web/dto/common/ApiResponse.kt
@@ -1,0 +1,8 @@
+package hs.kr.entrydsm.notification.adapterin.web.dto.common
+
+data class ApiResponse<T>(
+    val status: Int,
+    val message: String,
+    val data: T?,
+)
+

--- a/systems/notification/notification-adapter-in/src/main/kotlin/hs/kr/entrydsm/notification/adapterin/web/dto/common/ErrorResponse.kt
+++ b/systems/notification/notification-adapter-in/src/main/kotlin/hs/kr/entrydsm/notification/adapterin/web/dto/common/ErrorResponse.kt
@@ -1,0 +1,7 @@
+package hs.kr.entrydsm.notification.adapterin.web.dto.common
+
+data class ErrorResponse(
+    val status: Int,
+    val message: String,
+    val code: String,
+)

--- a/systems/notification/notification-adapter-in/src/main/kotlin/hs/kr/entrydsm/notification/adapterin/web/dto/common/ResponseMapper.kt
+++ b/systems/notification/notification-adapter-in/src/main/kotlin/hs/kr/entrydsm/notification/adapterin/web/dto/common/ResponseMapper.kt
@@ -1,0 +1,77 @@
+package hs.kr.entrydsm.notification.adapterin.web.dto.common
+
+import hs.kr.entrydsm.notification.adapterin.web.dto.response.FaqDetailResponse
+import hs.kr.entrydsm.notification.adapterin.web.dto.response.FaqSummaryResponse
+import hs.kr.entrydsm.notification.adapterin.web.dto.response.NoticeDetailResponse
+import hs.kr.entrydsm.notification.adapterin.web.dto.response.NoticeSummaryResponse
+import hs.kr.entrydsm.notification.adapterin.web.dto.response.PageResponse
+import hs.kr.entrydsm.notification.adapterin.web.dto.response.RecruitmentGuidelineResponse
+import hs.kr.entrydsm.notification.adapterin.web.dto.response.RecruitmentScheduleResponse
+import hs.kr.entrydsm.notification.application.port.`in`.result.FaqDetailResult
+import hs.kr.entrydsm.notification.application.port.`in`.result.FaqSummaryResult
+import hs.kr.entrydsm.notification.application.port.`in`.result.NoticeDetailResult
+import hs.kr.entrydsm.notification.application.port.`in`.result.NoticeSummaryResult
+import hs.kr.entrydsm.notification.application.port.`in`.result.PageResult
+import hs.kr.entrydsm.notification.application.port.`in`.result.RecruitmentGuidelineResult
+
+fun NoticeSummaryResult.toResponse(): NoticeSummaryResponse =
+    NoticeSummaryResponse(
+        noticeId = noticeId,
+        title = title,
+        author = author,
+        createdAt = createdAt,
+    )
+
+fun NoticeDetailResult.toResponse(): NoticeDetailResponse =
+    NoticeDetailResponse(
+        noticeId = noticeId,
+        title = title,
+        content = content,
+        author = author,
+        viewCount = viewCount,
+        createdAt = createdAt,
+        updatedAt = updatedAt,
+    )
+
+fun FaqSummaryResult.toResponse(): FaqSummaryResponse =
+    FaqSummaryResponse(
+        faqId = faqId,
+        category = category,
+        question = question,
+        answer = answer,
+    )
+
+fun FaqDetailResult.toResponse(): FaqDetailResponse =
+    FaqDetailResponse(
+        faqId = faqId,
+        category = category,
+        question = question,
+        answer = answer,
+        viewCount = viewCount,
+        createdAt = createdAt,
+        updatedAt = updatedAt,
+    )
+
+fun RecruitmentGuidelineResult.toResponse(): RecruitmentGuidelineResponse =
+    RecruitmentGuidelineResponse(
+        recruitmentId = recruitmentId,
+        title = title,
+        description = description,
+        schedule = RecruitmentScheduleResponse(
+            applicationStart = schedule.applicationStart,
+            applicationEnd = schedule.applicationEnd,
+            resultAt = schedule.resultAt,
+        ),
+        createdAt = createdAt,
+        updatedAt = updatedAt,
+    )
+
+fun <T, R> PageResult<T>.toResponse(mapper: (T) -> R): PageResponse<R> =
+    PageResponse(
+        content = content.map(mapper),
+        page = page,
+        size = size,
+        totalElements = totalElements,
+        totalPages = totalPages,
+        last = last,
+    )

--- a/systems/notification/notification-adapter-in/src/main/kotlin/hs/kr/entrydsm/notification/adapterin/web/dto/response/FaqResponses.kt
+++ b/systems/notification/notification-adapter-in/src/main/kotlin/hs/kr/entrydsm/notification/adapterin/web/dto/response/FaqResponses.kt
@@ -1,0 +1,21 @@
+package hs.kr.entrydsm.notification.adapterin.web.dto.response
+
+import java.time.LocalDateTime
+
+data class FaqSummaryResponse(
+    val faqId: Long,
+    val category: String,
+    val question: String,
+    val answer: String,
+)
+
+data class FaqDetailResponse(
+    val faqId: Long,
+    val category: String,
+    val question: String,
+    val answer: String,
+    val viewCount: Int,
+    val createdAt: LocalDateTime,
+    val updatedAt: LocalDateTime,
+)
+

--- a/systems/notification/notification-adapter-in/src/main/kotlin/hs/kr/entrydsm/notification/adapterin/web/dto/response/NoticeResponses.kt
+++ b/systems/notification/notification-adapter-in/src/main/kotlin/hs/kr/entrydsm/notification/adapterin/web/dto/response/NoticeResponses.kt
@@ -1,0 +1,21 @@
+package hs.kr.entrydsm.notification.adapterin.web.dto.response
+
+import java.time.LocalDateTime
+
+data class NoticeSummaryResponse(
+    val noticeId: Long,
+    val title: String,
+    val author: String,
+    val createdAt: LocalDateTime,
+)
+
+data class NoticeDetailResponse(
+    val noticeId: Long,
+    val title: String,
+    val content: String,
+    val author: String,
+    val viewCount: Int,
+    val createdAt: LocalDateTime,
+    val updatedAt: LocalDateTime,
+)
+

--- a/systems/notification/notification-adapter-in/src/main/kotlin/hs/kr/entrydsm/notification/adapterin/web/dto/response/PageResponse.kt
+++ b/systems/notification/notification-adapter-in/src/main/kotlin/hs/kr/entrydsm/notification/adapterin/web/dto/response/PageResponse.kt
@@ -1,0 +1,11 @@
+package hs.kr.entrydsm.notification.adapterin.web.dto.response
+
+data class PageResponse<T>(
+    val content: List<T>,
+    val page: Int,
+    val size: Int,
+    val totalElements: Long,
+    val totalPages: Int,
+    val last: Boolean,
+)
+

--- a/systems/notification/notification-adapter-in/src/main/kotlin/hs/kr/entrydsm/notification/adapterin/web/dto/response/RecruitmentGuidelineResponse.kt
+++ b/systems/notification/notification-adapter-in/src/main/kotlin/hs/kr/entrydsm/notification/adapterin/web/dto/response/RecruitmentGuidelineResponse.kt
@@ -1,0 +1,19 @@
+package hs.kr.entrydsm.notification.adapterin.web.dto.response
+
+import java.time.LocalDate
+import java.time.LocalDateTime
+
+data class RecruitmentGuidelineResponse(
+    val recruitmentId: Long,
+    val title: String,
+    val description: String,
+    val schedule: RecruitmentScheduleResponse,
+    val createdAt: LocalDateTime,
+    val updatedAt: LocalDateTime,
+)
+
+data class RecruitmentScheduleResponse(
+    val applicationStart: LocalDate,
+    val applicationEnd: LocalDate,
+    val resultAt: LocalDate,
+)

--- a/systems/notification/notification-adapter-in/src/main/kotlin/hs/kr/entrydsm/notification/adapterin/web/exception/GlobalExceptionHandler.kt
+++ b/systems/notification/notification-adapter-in/src/main/kotlin/hs/kr/entrydsm/notification/adapterin/web/exception/GlobalExceptionHandler.kt
@@ -23,7 +23,7 @@ class GlobalExceptionHandler {
         response(
             status = HttpStatus.NOT_FOUND,
             code = "NOTIFICATION_NOT_FOUND",
-            message = exception.message ?: "notification not found",
+            message = "notification not found",
         )
 
     @ExceptionHandler(
@@ -38,7 +38,7 @@ class GlobalExceptionHandler {
         response(
             status = HttpStatus.BAD_REQUEST,
             code = "INVALID_REQUEST",
-            message = exception.message ?: "invalid request",
+            message = "invalid request",
         )
 
     @ExceptionHandler(Exception::class)

--- a/systems/notification/notification-adapter-in/src/main/kotlin/hs/kr/entrydsm/notification/adapterin/web/exception/GlobalExceptionHandler.kt
+++ b/systems/notification/notification-adapter-in/src/main/kotlin/hs/kr/entrydsm/notification/adapterin/web/exception/GlobalExceptionHandler.kt
@@ -1,0 +1,72 @@
+package hs.kr.entrydsm.notification.adapterin.web.exception
+
+import hs.kr.entrydsm.notification.adapterin.web.dto.common.ErrorResponse
+import hs.kr.entrydsm.notification.application.exception.NotificationNotFoundException
+import org.slf4j.LoggerFactory
+import org.slf4j.MDC
+import org.springframework.http.HttpStatus
+import org.springframework.http.ResponseEntity
+import org.springframework.http.converter.HttpMessageNotReadableException
+import org.springframework.web.bind.MissingPathVariableException
+import org.springframework.web.bind.MissingServletRequestParameterException
+import org.springframework.web.bind.MethodArgumentNotValidException
+import org.springframework.web.bind.annotation.ExceptionHandler
+import org.springframework.web.bind.annotation.RestControllerAdvice
+import org.springframework.web.method.annotation.MethodArgumentTypeMismatchException
+
+@RestControllerAdvice
+class GlobalExceptionHandler {
+    private val logger = LoggerFactory.getLogger(javaClass)
+
+    @ExceptionHandler(NotificationNotFoundException::class)
+    fun handleNotFound(exception: NotificationNotFoundException): ResponseEntity<ErrorResponse> =
+        response(
+            status = HttpStatus.NOT_FOUND,
+            code = "NOTIFICATION_NOT_FOUND",
+            message = exception.message ?: "notification not found",
+        )
+
+    @ExceptionHandler(
+        IllegalArgumentException::class,
+        HttpMessageNotReadableException::class,
+        MethodArgumentNotValidException::class,
+        MissingPathVariableException::class,
+        MissingServletRequestParameterException::class,
+        MethodArgumentTypeMismatchException::class,
+    )
+    fun handleInvalidRequest(exception: Exception): ResponseEntity<ErrorResponse> =
+        response(
+            status = HttpStatus.BAD_REQUEST,
+            code = "INVALID_REQUEST",
+            message = exception.message ?: "invalid request",
+        )
+
+    @ExceptionHandler(Exception::class)
+    fun handleUnhandledException(exception: Exception): ResponseEntity<ErrorResponse> =
+        response(
+            status = HttpStatus.INTERNAL_SERVER_ERROR,
+            code = "INTERNAL_SERVER_ERROR",
+            message = "internal server error",
+        ).also {
+            logger.error(
+                "Unhandled exception [correlationId={}]",
+                MDC.get("correlationId") ?: "unknown",
+                exception,
+            )
+        }
+
+    private fun response(
+        status: HttpStatus,
+        code: String,
+        message: String,
+    ): ResponseEntity<ErrorResponse> =
+        ResponseEntity
+            .status(status)
+            .body(
+                ErrorResponse(
+                    status = status.value(),
+                    message = message,
+                    code = code,
+                ),
+            )
+}

--- a/systems/notification/notification-adapter-in/src/test/kotlin/hs/kr/entrydsm/TestMain.kt
+++ b/systems/notification/notification-adapter-in/src/test/kotlin/hs/kr/entrydsm/TestMain.kt
@@ -34,4 +34,15 @@ class NotificationAdapterInModuleTest {
         assertEquals("INVALID_REQUEST", response.body?.code)
         assertEquals("invalid request", response.body?.message)
     }
+
+    @Test
+    fun unhandledExceptionReturnsStableErrorResponse() {
+        val response = GlobalExceptionHandler()
+            .handleUnhandledException(RuntimeException("database connection failed"))
+
+        assertEquals(HttpStatus.INTERNAL_SERVER_ERROR, response.statusCode)
+        assertEquals(500, response.body?.status)
+        assertEquals("INTERNAL_SERVER_ERROR", response.body?.code)
+        assertEquals("internal server error", response.body?.message)
+    }
 }

--- a/systems/notification/notification-adapter-in/src/test/kotlin/hs/kr/entrydsm/TestMain.kt
+++ b/systems/notification/notification-adapter-in/src/test/kotlin/hs/kr/entrydsm/TestMain.kt
@@ -1,11 +1,37 @@
 package hs.kr.entrydsm.notification.adapterin
 
+import hs.kr.entrydsm.notification.adapterin.web.exception.GlobalExceptionHandler
+import hs.kr.entrydsm.notification.application.exception.NotificationNotFoundException
+import org.junit.Assert.assertEquals
 import org.junit.Assert.assertTrue
 import org.junit.Test
+import org.springframework.http.HttpStatus
 
 class NotificationAdapterInModuleTest {
     @Test
     fun moduleLoads() {
         assertTrue(true)
+    }
+
+    @Test
+    fun notFoundExceptionReturnsStableErrorResponse() {
+        val response = GlobalExceptionHandler()
+            .handleNotFound(NotificationNotFoundException("notice not found: id=1"))
+
+        assertEquals(HttpStatus.NOT_FOUND, response.statusCode)
+        assertEquals(404, response.body?.status)
+        assertEquals("NOTIFICATION_NOT_FOUND", response.body?.code)
+        assertEquals("notification not found", response.body?.message)
+    }
+
+    @Test
+    fun invalidRequestReturnsStableErrorResponse() {
+        val response = GlobalExceptionHandler()
+            .handleInvalidRequest(IllegalArgumentException("page must be greater than or equal to 0"))
+
+        assertEquals(HttpStatus.BAD_REQUEST, response.statusCode)
+        assertEquals(400, response.body?.status)
+        assertEquals("INVALID_REQUEST", response.body?.code)
+        assertEquals("invalid request", response.body?.message)
     }
 }

--- a/systems/notification/notification-adapter-out/BUILD.bazel
+++ b/systems/notification/notification-adapter-out/BUILD.bazel
@@ -17,5 +17,5 @@ kt_jvm_test(
     javac_opts = "//:javac_options",
     kotlinc_opts = "//:kotlinc_options",
     test_class = "hs.kr.entrydsm.notification.adapterout.NotificationAdapterOutModuleTest",
-    deps = MODULE_DEPS + TEST_DEPS,
+    deps = [":main"] + MODULE_DEPS + TEST_DEPS,
 )

--- a/systems/notification/notification-adapter-out/deps.bzl
+++ b/systems/notification/notification-adapter-out/deps.bzl
@@ -1,4 +1,9 @@
-KOTLIN_DEPS = []
+KOTLIN_DEPS = [
+    "@maven//:org_springframework_boot_spring_boot_starter_data_jpa",
+    "@maven//:com_mysql_mysql_connector_j",
+    "//systems/notification/notification-application:main",
+    "//systems/notification/notification-domain:main",
+]
 
 TEST_DEPS = [
     "@maven//:junit_junit",

--- a/systems/notification/notification-adapter-out/src/main/kotlin/hs/kr/entrydsm/notification/adapterout/entity/FaqJpaEntity.kt
+++ b/systems/notification/notification-adapter-out/src/main/kotlin/hs/kr/entrydsm/notification/adapterout/entity/FaqJpaEntity.kt
@@ -1,0 +1,49 @@
+package hs.kr.entrydsm.notification.adapterout.entity
+
+import hs.kr.entrydsm.notification.domain.model.Faq
+import jakarta.persistence.Column
+import jakarta.persistence.Entity
+import jakarta.persistence.GeneratedValue
+import jakarta.persistence.GenerationType
+import jakarta.persistence.Id
+import jakarta.persistence.Table
+import java.time.LocalDateTime
+
+@Entity
+@Table(name = "faqs")
+open class FaqJpaEntity(
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    @Column(name = "id")
+    var id: Long? = null,
+
+    @Column(name = "category", nullable = false, length = 50)
+    var category: String = "",
+
+    @Column(name = "question", nullable = false, length = 255)
+    var question: String = "",
+
+    @Column(name = "answer", nullable = false, columnDefinition = "TEXT")
+    var answer: String = "",
+
+    @Column(name = "view_count", nullable = false)
+    var viewCount: Int = 0,
+
+    @Column(name = "created_at", nullable = false)
+    var createdAt: LocalDateTime = LocalDateTime.now(),
+
+    @Column(name = "updated_at", nullable = false)
+    var updatedAt: LocalDateTime = LocalDateTime.now(),
+) {
+    fun toDomain(): Faq =
+        Faq(
+            id = requireNotNull(id),
+            category = category,
+            question = question,
+            answer = answer,
+            viewCount = viewCount,
+            createdAt = createdAt,
+            updatedAt = updatedAt,
+        )
+}
+

--- a/systems/notification/notification-adapter-out/src/main/kotlin/hs/kr/entrydsm/notification/adapterout/entity/NoticeJpaEntity.kt
+++ b/systems/notification/notification-adapter-out/src/main/kotlin/hs/kr/entrydsm/notification/adapterout/entity/NoticeJpaEntity.kt
@@ -1,8 +1,11 @@
 package hs.kr.entrydsm.notification.adapterout.entity
 
 import hs.kr.entrydsm.notification.domain.model.Notice
+import hs.kr.entrydsm.notification.domain.model.NoticeCategory
 import jakarta.persistence.Column
 import jakarta.persistence.Entity
+import jakarta.persistence.EnumType
+import jakarta.persistence.Enumerated
 import jakarta.persistence.GeneratedValue
 import jakarta.persistence.GenerationType
 import jakarta.persistence.Id
@@ -23,6 +26,10 @@ open class NoticeJpaEntity(
     @Column(name = "content", nullable = false, columnDefinition = "TEXT")
     var content: String = "",
 
+    @Enumerated(EnumType.STRING)
+    @Column(name = "category", nullable = false, length = 32)
+    var category: NoticeCategory = NoticeCategory.ADMISSION_NOTICE,
+
     @Column(name = "author", nullable = false, length = 50)
     var author: String = "",
 
@@ -40,6 +47,7 @@ open class NoticeJpaEntity(
             id = requireNotNull(id),
             title = title,
             content = content,
+            category = category,
             author = author,
             viewCount = viewCount,
             createdAt = createdAt,

--- a/systems/notification/notification-adapter-out/src/main/kotlin/hs/kr/entrydsm/notification/adapterout/entity/NoticeJpaEntity.kt
+++ b/systems/notification/notification-adapter-out/src/main/kotlin/hs/kr/entrydsm/notification/adapterout/entity/NoticeJpaEntity.kt
@@ -1,0 +1,49 @@
+package hs.kr.entrydsm.notification.adapterout.entity
+
+import hs.kr.entrydsm.notification.domain.model.Notice
+import jakarta.persistence.Column
+import jakarta.persistence.Entity
+import jakarta.persistence.GeneratedValue
+import jakarta.persistence.GenerationType
+import jakarta.persistence.Id
+import jakarta.persistence.Table
+import java.time.LocalDateTime
+
+@Entity
+@Table(name = "notices")
+open class NoticeJpaEntity(
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    @Column(name = "id")
+    var id: Long? = null,
+
+    @Column(name = "title", nullable = false, length = 255)
+    var title: String = "",
+
+    @Column(name = "content", nullable = false, columnDefinition = "TEXT")
+    var content: String = "",
+
+    @Column(name = "author", nullable = false, length = 50)
+    var author: String = "",
+
+    @Column(name = "view_count", nullable = false)
+    var viewCount: Int = 0,
+
+    @Column(name = "created_at", nullable = false)
+    var createdAt: LocalDateTime = LocalDateTime.now(),
+
+    @Column(name = "updated_at", nullable = false)
+    var updatedAt: LocalDateTime = LocalDateTime.now(),
+) {
+    fun toDomain(): Notice =
+        Notice(
+            id = requireNotNull(id),
+            title = title,
+            content = content,
+            author = author,
+            viewCount = viewCount,
+            createdAt = createdAt,
+            updatedAt = updatedAt,
+        )
+}
+

--- a/systems/notification/notification-adapter-out/src/main/kotlin/hs/kr/entrydsm/notification/adapterout/entity/RecruitmentGuidelineJpaEntity.kt
+++ b/systems/notification/notification-adapter-out/src/main/kotlin/hs/kr/entrydsm/notification/adapterout/entity/RecruitmentGuidelineJpaEntity.kt
@@ -1,0 +1,68 @@
+package hs.kr.entrydsm.notification.adapterout.entity
+
+import hs.kr.entrydsm.notification.domain.model.RecruitmentGuideline
+import hs.kr.entrydsm.notification.domain.model.RecruitmentSchedule
+import jakarta.persistence.Column
+import jakarta.persistence.Embedded
+import jakarta.persistence.Embeddable
+import jakarta.persistence.Entity
+import jakarta.persistence.GeneratedValue
+import jakarta.persistence.GenerationType
+import jakarta.persistence.Id
+import jakarta.persistence.Table
+import java.time.LocalDate
+import java.time.LocalDateTime
+
+@Entity
+@Table(name = "recruitment_guidelines")
+open class RecruitmentGuidelineJpaEntity(
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    @Column(name = "id")
+    var id: Long? = null,
+
+    @Column(name = "title", nullable = false, length = 255)
+    var title: String = "",
+
+    @Column(name = "description", nullable = false, columnDefinition = "TEXT")
+    var description: String = "",
+
+    @Embedded
+    var schedule: RecruitmentScheduleEmbeddable = RecruitmentScheduleEmbeddable(),
+
+    @Column(name = "created_at", nullable = false)
+    var createdAt: LocalDateTime = LocalDateTime.now(),
+
+    @Column(name = "updated_at", nullable = false)
+    var updatedAt: LocalDateTime = LocalDateTime.now(),
+) {
+    fun toDomain(): RecruitmentGuideline =
+        RecruitmentGuideline(
+            id = requireNotNull(id),
+            title = title,
+            description = description,
+            schedule = schedule.toDomain(),
+            createdAt = createdAt,
+            updatedAt = updatedAt,
+        )
+}
+
+@Embeddable
+class RecruitmentScheduleEmbeddable(
+    @Column(name = "application_start", nullable = false)
+    var applicationStart: LocalDate = LocalDate.MIN,
+
+    @Column(name = "application_end", nullable = false)
+    var applicationEnd: LocalDate = LocalDate.MIN,
+
+    @Column(name = "result_at", nullable = false)
+    var resultAt: LocalDate = LocalDate.MIN,
+) {
+    fun toDomain(): RecruitmentSchedule =
+        RecruitmentSchedule(
+            applicationStart = applicationStart,
+            applicationEnd = applicationEnd,
+            resultAt = resultAt,
+        )
+}
+

--- a/systems/notification/notification-adapter-out/src/main/kotlin/hs/kr/entrydsm/notification/adapterout/repository/FaqJpaRepository.kt
+++ b/systems/notification/notification-adapter-out/src/main/kotlin/hs/kr/entrydsm/notification/adapterout/repository/FaqJpaRepository.kt
@@ -1,9 +1,11 @@
 package hs.kr.entrydsm.notification.adapterout.repository
 
 import hs.kr.entrydsm.notification.adapterout.entity.FaqJpaEntity
+import org.springframework.data.domain.Page
+import org.springframework.data.domain.Pageable
 import org.springframework.data.jpa.repository.JpaRepository
 
 interface FaqJpaRepository : JpaRepository<FaqJpaEntity, Long> {
-    fun findAllByOrderByIdAsc(): List<FaqJpaEntity>
+    fun findAllByOrderByIdAsc(pageable: Pageable): Page<FaqJpaEntity>
 }
 

--- a/systems/notification/notification-adapter-out/src/main/kotlin/hs/kr/entrydsm/notification/adapterout/repository/FaqJpaRepository.kt
+++ b/systems/notification/notification-adapter-out/src/main/kotlin/hs/kr/entrydsm/notification/adapterout/repository/FaqJpaRepository.kt
@@ -7,5 +7,6 @@ import org.springframework.data.jpa.repository.JpaRepository
 
 interface FaqJpaRepository : JpaRepository<FaqJpaEntity, Long> {
     fun findAllByOrderByIdAsc(pageable: Pageable): Page<FaqJpaEntity>
+    fun findAllByCategoryOrderByIdAsc(category: String, pageable: Pageable): Page<FaqJpaEntity>
 }
 

--- a/systems/notification/notification-adapter-out/src/main/kotlin/hs/kr/entrydsm/notification/adapterout/repository/FaqJpaRepository.kt
+++ b/systems/notification/notification-adapter-out/src/main/kotlin/hs/kr/entrydsm/notification/adapterout/repository/FaqJpaRepository.kt
@@ -1,0 +1,9 @@
+package hs.kr.entrydsm.notification.adapterout.repository
+
+import hs.kr.entrydsm.notification.adapterout.entity.FaqJpaEntity
+import org.springframework.data.jpa.repository.JpaRepository
+
+interface FaqJpaRepository : JpaRepository<FaqJpaEntity, Long> {
+    fun findAllByOrderByIdAsc(): List<FaqJpaEntity>
+}
+

--- a/systems/notification/notification-adapter-out/src/main/kotlin/hs/kr/entrydsm/notification/adapterout/repository/FaqPersistenceAdapter.kt
+++ b/systems/notification/notification-adapter-out/src/main/kotlin/hs/kr/entrydsm/notification/adapterout/repository/FaqPersistenceAdapter.kt
@@ -1,7 +1,10 @@
 package hs.kr.entrydsm.notification.adapterout.repository
 
+import hs.kr.entrydsm.notification.application.port.`in`.command.ReadNotificationPageCommand
 import hs.kr.entrydsm.notification.application.port.out.FaqRepository
+import hs.kr.entrydsm.notification.application.port.out.data.PageData
 import hs.kr.entrydsm.notification.domain.model.Faq
+import org.springframework.data.domain.PageRequest
 import org.springframework.stereotype.Repository
 import org.springframework.transaction.annotation.Transactional
 
@@ -10,10 +13,20 @@ import org.springframework.transaction.annotation.Transactional
 class FaqPersistenceAdapter(
     private val faqJpaRepository: FaqJpaRepository,
 ) : FaqRepository {
-    override fun findAll(): List<Faq> =
-        faqJpaRepository.findAllByOrderByIdAsc().map { it.toDomain() }
+    override fun findPage(command: ReadNotificationPageCommand): PageData<Faq> {
+        val page = faqJpaRepository.findAllByOrderByIdAsc(command.toPageRequest())
+        return PageData(
+            content = page.content.map { it.toDomain() },
+            page = command.page,
+            size = command.size,
+            totalElements = page.totalElements,
+        )
+    }
 
     override fun findById(id: Long): Faq? =
         faqJpaRepository.findById(id).orElse(null)?.toDomain()
+
+    private fun ReadNotificationPageCommand.toPageRequest(): PageRequest =
+        PageRequest.of(page, size)
 }
 

--- a/systems/notification/notification-adapter-out/src/main/kotlin/hs/kr/entrydsm/notification/adapterout/repository/FaqPersistenceAdapter.kt
+++ b/systems/notification/notification-adapter-out/src/main/kotlin/hs/kr/entrydsm/notification/adapterout/repository/FaqPersistenceAdapter.kt
@@ -1,0 +1,19 @@
+package hs.kr.entrydsm.notification.adapterout.repository
+
+import hs.kr.entrydsm.notification.application.port.out.FaqRepository
+import hs.kr.entrydsm.notification.domain.model.Faq
+import org.springframework.stereotype.Repository
+import org.springframework.transaction.annotation.Transactional
+
+@Repository
+@Transactional(readOnly = true)
+class FaqPersistenceAdapter(
+    private val faqJpaRepository: FaqJpaRepository,
+) : FaqRepository {
+    override fun findAll(): List<Faq> =
+        faqJpaRepository.findAllByOrderByIdAsc().map { it.toDomain() }
+
+    override fun findById(id: Long): Faq? =
+        faqJpaRepository.findById(id).orElse(null)?.toDomain()
+}
+

--- a/systems/notification/notification-adapter-out/src/main/kotlin/hs/kr/entrydsm/notification/adapterout/repository/FaqPersistenceAdapter.kt
+++ b/systems/notification/notification-adapter-out/src/main/kotlin/hs/kr/entrydsm/notification/adapterout/repository/FaqPersistenceAdapter.kt
@@ -1,6 +1,6 @@
 package hs.kr.entrydsm.notification.adapterout.repository
 
-import hs.kr.entrydsm.notification.application.port.`in`.command.ReadNotificationPageCommand
+import hs.kr.entrydsm.notification.application.port.`in`.command.ReadFaqPageCommand
 import hs.kr.entrydsm.notification.application.port.out.FaqRepository
 import hs.kr.entrydsm.notification.application.port.out.data.PageData
 import hs.kr.entrydsm.notification.domain.model.Faq
@@ -13,8 +13,10 @@ import org.springframework.transaction.annotation.Transactional
 class FaqPersistenceAdapter(
     private val faqJpaRepository: FaqJpaRepository,
 ) : FaqRepository {
-    override fun findPage(command: ReadNotificationPageCommand): PageData<Faq> {
-        val page = faqJpaRepository.findAllByOrderByIdAsc(command.toPageRequest())
+    override fun findPage(command: ReadFaqPageCommand): PageData<Faq> {
+        val page = command.category?.let { category ->
+            faqJpaRepository.findAllByCategoryOrderByIdAsc(category.label, command.toPageRequest())
+        } ?: faqJpaRepository.findAllByOrderByIdAsc(command.toPageRequest())
         return PageData(
             content = page.content.map { it.toDomain() },
             page = command.page,
@@ -26,7 +28,7 @@ class FaqPersistenceAdapter(
     override fun findById(id: Long): Faq? =
         faqJpaRepository.findById(id).orElse(null)?.toDomain()
 
-    private fun ReadNotificationPageCommand.toPageRequest(): PageRequest =
+    private fun ReadFaqPageCommand.toPageRequest(): PageRequest =
         PageRequest.of(page, size)
 }
 

--- a/systems/notification/notification-adapter-out/src/main/kotlin/hs/kr/entrydsm/notification/adapterout/repository/NoticeJpaRepository.kt
+++ b/systems/notification/notification-adapter-out/src/main/kotlin/hs/kr/entrydsm/notification/adapterout/repository/NoticeJpaRepository.kt
@@ -1,9 +1,11 @@
 package hs.kr.entrydsm.notification.adapterout.repository
 
 import hs.kr.entrydsm.notification.adapterout.entity.NoticeJpaEntity
+import org.springframework.data.domain.Page
+import org.springframework.data.domain.Pageable
 import org.springframework.data.jpa.repository.JpaRepository
 
 interface NoticeJpaRepository : JpaRepository<NoticeJpaEntity, Long> {
-    fun findAllByOrderByCreatedAtDesc(): List<NoticeJpaEntity>
+    fun findAllByOrderByCreatedAtDescIdDesc(pageable: Pageable): Page<NoticeJpaEntity>
 }
 

--- a/systems/notification/notification-adapter-out/src/main/kotlin/hs/kr/entrydsm/notification/adapterout/repository/NoticeJpaRepository.kt
+++ b/systems/notification/notification-adapter-out/src/main/kotlin/hs/kr/entrydsm/notification/adapterout/repository/NoticeJpaRepository.kt
@@ -1,0 +1,9 @@
+package hs.kr.entrydsm.notification.adapterout.repository
+
+import hs.kr.entrydsm.notification.adapterout.entity.NoticeJpaEntity
+import org.springframework.data.jpa.repository.JpaRepository
+
+interface NoticeJpaRepository : JpaRepository<NoticeJpaEntity, Long> {
+    fun findAllByOrderByCreatedAtDesc(): List<NoticeJpaEntity>
+}
+

--- a/systems/notification/notification-adapter-out/src/main/kotlin/hs/kr/entrydsm/notification/adapterout/repository/NoticeJpaRepository.kt
+++ b/systems/notification/notification-adapter-out/src/main/kotlin/hs/kr/entrydsm/notification/adapterout/repository/NoticeJpaRepository.kt
@@ -1,11 +1,16 @@
 package hs.kr.entrydsm.notification.adapterout.repository
 
 import hs.kr.entrydsm.notification.adapterout.entity.NoticeJpaEntity
+import hs.kr.entrydsm.notification.domain.model.NoticeCategory
 import org.springframework.data.domain.Page
 import org.springframework.data.domain.Pageable
 import org.springframework.data.jpa.repository.JpaRepository
 
 interface NoticeJpaRepository : JpaRepository<NoticeJpaEntity, Long> {
     fun findAllByOrderByCreatedAtDescIdDesc(pageable: Pageable): Page<NoticeJpaEntity>
+    fun findAllByCategoryOrderByCreatedAtDescIdDesc(
+        category: NoticeCategory,
+        pageable: Pageable,
+    ): Page<NoticeJpaEntity>
 }
 

--- a/systems/notification/notification-adapter-out/src/main/kotlin/hs/kr/entrydsm/notification/adapterout/repository/NoticePersistenceAdapter.kt
+++ b/systems/notification/notification-adapter-out/src/main/kotlin/hs/kr/entrydsm/notification/adapterout/repository/NoticePersistenceAdapter.kt
@@ -1,7 +1,10 @@
 package hs.kr.entrydsm.notification.adapterout.repository
 
+import hs.kr.entrydsm.notification.application.port.`in`.command.ReadNotificationPageCommand
 import hs.kr.entrydsm.notification.application.port.out.NoticeRepository
+import hs.kr.entrydsm.notification.application.port.out.data.PageData
 import hs.kr.entrydsm.notification.domain.model.Notice
+import org.springframework.data.domain.PageRequest
 import org.springframework.stereotype.Repository
 import org.springframework.transaction.annotation.Transactional
 
@@ -10,10 +13,20 @@ import org.springframework.transaction.annotation.Transactional
 class NoticePersistenceAdapter(
     private val noticeJpaRepository: NoticeJpaRepository,
 ) : NoticeRepository {
-    override fun findAll(): List<Notice> =
-        noticeJpaRepository.findAllByOrderByCreatedAtDesc().map { it.toDomain() }
+    override fun findPage(command: ReadNotificationPageCommand): PageData<Notice> {
+        val page = noticeJpaRepository.findAllByOrderByCreatedAtDescIdDesc(command.toPageRequest())
+        return PageData(
+            content = page.content.map { it.toDomain() },
+            page = command.page,
+            size = command.size,
+            totalElements = page.totalElements,
+        )
+    }
 
     override fun findById(id: Long): Notice? =
         noticeJpaRepository.findById(id).orElse(null)?.toDomain()
+
+    private fun ReadNotificationPageCommand.toPageRequest(): PageRequest =
+        PageRequest.of(page, size)
 }
 

--- a/systems/notification/notification-adapter-out/src/main/kotlin/hs/kr/entrydsm/notification/adapterout/repository/NoticePersistenceAdapter.kt
+++ b/systems/notification/notification-adapter-out/src/main/kotlin/hs/kr/entrydsm/notification/adapterout/repository/NoticePersistenceAdapter.kt
@@ -14,7 +14,12 @@ class NoticePersistenceAdapter(
     private val noticeJpaRepository: NoticeJpaRepository,
 ) : NoticeRepository {
     override fun findPage(command: ReadNotificationPageCommand): PageData<Notice> {
-        val page = noticeJpaRepository.findAllByOrderByCreatedAtDescIdDesc(command.toPageRequest())
+        val page = command.category?.let { category ->
+            noticeJpaRepository.findAllByCategoryOrderByCreatedAtDescIdDesc(
+                category,
+                command.toPageRequest(),
+            )
+        } ?: noticeJpaRepository.findAllByOrderByCreatedAtDescIdDesc(command.toPageRequest())
         return PageData(
             content = page.content.map { it.toDomain() },
             page = command.page,

--- a/systems/notification/notification-adapter-out/src/main/kotlin/hs/kr/entrydsm/notification/adapterout/repository/NoticePersistenceAdapter.kt
+++ b/systems/notification/notification-adapter-out/src/main/kotlin/hs/kr/entrydsm/notification/adapterout/repository/NoticePersistenceAdapter.kt
@@ -1,0 +1,19 @@
+package hs.kr.entrydsm.notification.adapterout.repository
+
+import hs.kr.entrydsm.notification.application.port.out.NoticeRepository
+import hs.kr.entrydsm.notification.domain.model.Notice
+import org.springframework.stereotype.Repository
+import org.springframework.transaction.annotation.Transactional
+
+@Repository
+@Transactional(readOnly = true)
+class NoticePersistenceAdapter(
+    private val noticeJpaRepository: NoticeJpaRepository,
+) : NoticeRepository {
+    override fun findAll(): List<Notice> =
+        noticeJpaRepository.findAllByOrderByCreatedAtDesc().map { it.toDomain() }
+
+    override fun findById(id: Long): Notice? =
+        noticeJpaRepository.findById(id).orElse(null)?.toDomain()
+}
+

--- a/systems/notification/notification-adapter-out/src/main/kotlin/hs/kr/entrydsm/notification/adapterout/repository/RecruitmentGuidelineJpaRepository.kt
+++ b/systems/notification/notification-adapter-out/src/main/kotlin/hs/kr/entrydsm/notification/adapterout/repository/RecruitmentGuidelineJpaRepository.kt
@@ -1,0 +1,9 @@
+package hs.kr.entrydsm.notification.adapterout.repository
+
+import hs.kr.entrydsm.notification.adapterout.entity.RecruitmentGuidelineJpaEntity
+import org.springframework.data.jpa.repository.JpaRepository
+
+interface RecruitmentGuidelineJpaRepository : JpaRepository<RecruitmentGuidelineJpaEntity, Long> {
+    fun findTopByOrderByCreatedAtDesc(): RecruitmentGuidelineJpaEntity?
+}
+

--- a/systems/notification/notification-adapter-out/src/main/kotlin/hs/kr/entrydsm/notification/adapterout/repository/RecruitmentGuidelinePersistenceAdapter.kt
+++ b/systems/notification/notification-adapter-out/src/main/kotlin/hs/kr/entrydsm/notification/adapterout/repository/RecruitmentGuidelinePersistenceAdapter.kt
@@ -1,0 +1,16 @@
+package hs.kr.entrydsm.notification.adapterout.repository
+
+import hs.kr.entrydsm.notification.application.port.out.RecruitmentGuidelineRepository
+import hs.kr.entrydsm.notification.domain.model.RecruitmentGuideline
+import org.springframework.stereotype.Repository
+import org.springframework.transaction.annotation.Transactional
+
+@Repository
+@Transactional(readOnly = true)
+class RecruitmentGuidelinePersistenceAdapter(
+    private val recruitmentGuidelineJpaRepository: RecruitmentGuidelineJpaRepository,
+) : RecruitmentGuidelineRepository {
+    override fun findCurrent(): RecruitmentGuideline? =
+        recruitmentGuidelineJpaRepository.findTopByOrderByCreatedAtDesc()?.toDomain()
+}
+

--- a/systems/notification/notification-application/BUILD.bazel
+++ b/systems/notification/notification-application/BUILD.bazel
@@ -17,5 +17,5 @@ kt_jvm_test(
     javac_opts = "//:javac_options",
     kotlinc_opts = "//:kotlinc_options",
     test_class = "hs.kr.entrydsm.notification.application.NotificationApplicationModuleTest",
-    deps = MODULE_DEPS + TEST_DEPS,
+    deps = [":main"] + MODULE_DEPS + TEST_DEPS,
 )

--- a/systems/notification/notification-application/deps.bzl
+++ b/systems/notification/notification-application/deps.bzl
@@ -1,4 +1,7 @@
-KOTLIN_DEPS = []
+KOTLIN_DEPS = [
+    "@maven//:org_springframework_boot_spring_boot_starter",
+    "//systems/notification/notification-domain:main",
+]
 
 TEST_DEPS = [
     "@maven//:junit_junit",

--- a/systems/notification/notification-application/deps.bzl
+++ b/systems/notification/notification-application/deps.bzl
@@ -1,5 +1,4 @@
 KOTLIN_DEPS = [
-    "@maven//:org_springframework_boot_spring_boot_starter",
     "//systems/notification/notification-domain:main",
 ]
 

--- a/systems/notification/notification-application/src/main/kotlin/hs/kr/entrydsm/notification/application/exception/NotificationNotFoundException.kt
+++ b/systems/notification/notification-application/src/main/kotlin/hs/kr/entrydsm/notification/application/exception/NotificationNotFoundException.kt
@@ -1,0 +1,6 @@
+package hs.kr.entrydsm.notification.application.exception
+
+class NotificationNotFoundException(
+    message: String,
+) : RuntimeException(message)
+

--- a/systems/notification/notification-application/src/main/kotlin/hs/kr/entrydsm/notification/application/port/in/NotificationPort.kt
+++ b/systems/notification/notification-application/src/main/kotlin/hs/kr/entrydsm/notification/application/port/in/NotificationPort.kt
@@ -1,0 +1,18 @@
+package hs.kr.entrydsm.notification.application.port.`in`
+
+import hs.kr.entrydsm.notification.application.port.`in`.command.ReadNotificationPageCommand
+import hs.kr.entrydsm.notification.application.port.`in`.result.FaqDetailResult
+import hs.kr.entrydsm.notification.application.port.`in`.result.FaqSummaryResult
+import hs.kr.entrydsm.notification.application.port.`in`.result.NoticeDetailResult
+import hs.kr.entrydsm.notification.application.port.`in`.result.NoticeSummaryResult
+import hs.kr.entrydsm.notification.application.port.`in`.result.PageResult
+import hs.kr.entrydsm.notification.application.port.`in`.result.RecruitmentGuidelineResult
+
+interface NotificationPort {
+    fun getNotices(command: ReadNotificationPageCommand): PageResult<NoticeSummaryResult>
+    fun getNotice(id: Long): NoticeDetailResult
+    fun getFaqs(command: ReadNotificationPageCommand): PageResult<FaqSummaryResult>
+    fun getFaq(id: Long): FaqDetailResult
+    fun getRecruitmentGuideline(): RecruitmentGuidelineResult
+}
+

--- a/systems/notification/notification-application/src/main/kotlin/hs/kr/entrydsm/notification/application/port/in/NotificationPort.kt
+++ b/systems/notification/notification-application/src/main/kotlin/hs/kr/entrydsm/notification/application/port/in/NotificationPort.kt
@@ -1,5 +1,6 @@
 package hs.kr.entrydsm.notification.application.port.`in`
 
+import hs.kr.entrydsm.notification.application.port.`in`.command.ReadFaqPageCommand
 import hs.kr.entrydsm.notification.application.port.`in`.command.ReadNotificationPageCommand
 import hs.kr.entrydsm.notification.application.port.`in`.result.FaqDetailResult
 import hs.kr.entrydsm.notification.application.port.`in`.result.FaqSummaryResult
@@ -11,7 +12,7 @@ import hs.kr.entrydsm.notification.application.port.`in`.result.RecruitmentGuide
 interface NotificationPort {
     fun getNotices(command: ReadNotificationPageCommand): PageResult<NoticeSummaryResult>
     fun getNotice(id: Long): NoticeDetailResult
-    fun getFaqs(command: ReadNotificationPageCommand): PageResult<FaqSummaryResult>
+    fun getFaqs(command: ReadFaqPageCommand): PageResult<FaqSummaryResult>
     fun getFaq(id: Long): FaqDetailResult
     fun getRecruitmentGuideline(): RecruitmentGuidelineResult
 }

--- a/systems/notification/notification-application/src/main/kotlin/hs/kr/entrydsm/notification/application/port/in/command/ReadFaqPageCommand.kt
+++ b/systems/notification/notification-application/src/main/kotlin/hs/kr/entrydsm/notification/application/port/in/command/ReadFaqPageCommand.kt
@@ -1,0 +1,29 @@
+package hs.kr.entrydsm.notification.application.port.`in`.command
+
+import hs.kr.entrydsm.notification.domain.model.FaqCategory
+
+data class ReadFaqPageCommand(
+    val page: Int = 0,
+    val size: Int = 10,
+    val category: FaqCategory? = null,
+) {
+    init {
+        require(page >= 0) { "page must be greater than or equal to 0" }
+        require(size > 0) { "size must be greater than 0" }
+    }
+
+    fun offset(): Long = page.toLong() * size.toLong()
+
+    companion object {
+        fun of(
+            page: Int,
+            size: Int,
+            category: String? = null,
+        ): ReadFaqPageCommand =
+            ReadFaqPageCommand(
+                page = page,
+                size = size,
+                category = category?.let(FaqCategory::from),
+            )
+    }
+}

--- a/systems/notification/notification-application/src/main/kotlin/hs/kr/entrydsm/notification/application/port/in/command/ReadNotificationPageCommand.kt
+++ b/systems/notification/notification-application/src/main/kotlin/hs/kr/entrydsm/notification/application/port/in/command/ReadNotificationPageCommand.kt
@@ -1,0 +1,7 @@
+package hs.kr.entrydsm.notification.application.port.`in`.command
+
+data class ReadNotificationPageCommand(
+    val page: Int = 0,
+    val size: Int = 10,
+)
+

--- a/systems/notification/notification-application/src/main/kotlin/hs/kr/entrydsm/notification/application/port/in/command/ReadNotificationPageCommand.kt
+++ b/systems/notification/notification-application/src/main/kotlin/hs/kr/entrydsm/notification/application/port/in/command/ReadNotificationPageCommand.kt
@@ -1,8 +1,11 @@
 package hs.kr.entrydsm.notification.application.port.`in`.command
 
+import hs.kr.entrydsm.notification.domain.model.NoticeCategory
+
 data class ReadNotificationPageCommand(
     val page: Int = 0,
     val size: Int = 10,
+    val category: NoticeCategory? = null,
 ) {
     init {
         require(page >= 0) { "page must be greater than or equal to 0" }
@@ -10,4 +13,17 @@ data class ReadNotificationPageCommand(
     }
 
     fun offset(): Long = page.toLong() * size.toLong()
+
+    companion object {
+        fun of(
+            page: Int,
+            size: Int,
+            category: String? = null,
+        ): ReadNotificationPageCommand =
+            ReadNotificationPageCommand(
+                page = page,
+                size = size,
+                category = category?.let(NoticeCategory::from),
+            )
+    }
 }

--- a/systems/notification/notification-application/src/main/kotlin/hs/kr/entrydsm/notification/application/port/in/command/ReadNotificationPageCommand.kt
+++ b/systems/notification/notification-application/src/main/kotlin/hs/kr/entrydsm/notification/application/port/in/command/ReadNotificationPageCommand.kt
@@ -3,5 +3,11 @@ package hs.kr.entrydsm.notification.application.port.`in`.command
 data class ReadNotificationPageCommand(
     val page: Int = 0,
     val size: Int = 10,
-)
+) {
+    init {
+        require(page >= 0) { "page must be greater than or equal to 0" }
+        require(size > 0) { "size must be greater than 0" }
+    }
 
+    fun offset(): Long = page.toLong() * size.toLong()
+}

--- a/systems/notification/notification-application/src/main/kotlin/hs/kr/entrydsm/notification/application/port/in/result/FaqResults.kt
+++ b/systems/notification/notification-application/src/main/kotlin/hs/kr/entrydsm/notification/application/port/in/result/FaqResults.kt
@@ -1,0 +1,21 @@
+package hs.kr.entrydsm.notification.application.port.`in`.result
+
+import java.time.LocalDateTime
+
+data class FaqSummaryResult(
+    val faqId: Long,
+    val category: String,
+    val question: String,
+    val answer: String,
+)
+
+data class FaqDetailResult(
+    val faqId: Long,
+    val category: String,
+    val question: String,
+    val answer: String,
+    val viewCount: Int,
+    val createdAt: LocalDateTime,
+    val updatedAt: LocalDateTime,
+)
+

--- a/systems/notification/notification-application/src/main/kotlin/hs/kr/entrydsm/notification/application/port/in/result/NoticeResults.kt
+++ b/systems/notification/notification-application/src/main/kotlin/hs/kr/entrydsm/notification/application/port/in/result/NoticeResults.kt
@@ -1,0 +1,21 @@
+package hs.kr.entrydsm.notification.application.port.`in`.result
+
+import java.time.LocalDateTime
+
+data class NoticeSummaryResult(
+    val noticeId: Long,
+    val title: String,
+    val author: String,
+    val createdAt: LocalDateTime,
+)
+
+data class NoticeDetailResult(
+    val noticeId: Long,
+    val title: String,
+    val content: String,
+    val author: String,
+    val viewCount: Int,
+    val createdAt: LocalDateTime,
+    val updatedAt: LocalDateTime,
+)
+

--- a/systems/notification/notification-application/src/main/kotlin/hs/kr/entrydsm/notification/application/port/in/result/PageResult.kt
+++ b/systems/notification/notification-application/src/main/kotlin/hs/kr/entrydsm/notification/application/port/in/result/PageResult.kt
@@ -1,0 +1,11 @@
+package hs.kr.entrydsm.notification.application.port.`in`.result
+
+data class PageResult<T>(
+    val content: List<T>,
+    val page: Int,
+    val size: Int,
+    val totalElements: Long,
+    val totalPages: Int,
+    val last: Boolean,
+)
+

--- a/systems/notification/notification-application/src/main/kotlin/hs/kr/entrydsm/notification/application/port/in/result/RecruitmentGuidelineResult.kt
+++ b/systems/notification/notification-application/src/main/kotlin/hs/kr/entrydsm/notification/application/port/in/result/RecruitmentGuidelineResult.kt
@@ -1,0 +1,19 @@
+package hs.kr.entrydsm.notification.application.port.`in`.result
+
+import java.time.LocalDate
+import java.time.LocalDateTime
+
+data class RecruitmentGuidelineResult(
+    val recruitmentId: Long,
+    val title: String,
+    val description: String,
+    val schedule: RecruitmentScheduleResult,
+    val createdAt: LocalDateTime,
+    val updatedAt: LocalDateTime,
+)
+
+data class RecruitmentScheduleResult(
+    val applicationStart: LocalDate,
+    val applicationEnd: LocalDate,
+    val resultAt: LocalDate,
+)

--- a/systems/notification/notification-application/src/main/kotlin/hs/kr/entrydsm/notification/application/port/out/FaqRepository.kt
+++ b/systems/notification/notification-application/src/main/kotlin/hs/kr/entrydsm/notification/application/port/out/FaqRepository.kt
@@ -1,11 +1,11 @@
 package hs.kr.entrydsm.notification.application.port.out
 
-import hs.kr.entrydsm.notification.application.port.`in`.command.ReadNotificationPageCommand
+import hs.kr.entrydsm.notification.application.port.`in`.command.ReadFaqPageCommand
 import hs.kr.entrydsm.notification.application.port.out.data.PageData
 import hs.kr.entrydsm.notification.domain.model.Faq
 
 interface FaqRepository {
-    fun findPage(command: ReadNotificationPageCommand): PageData<Faq>
+    fun findPage(command: ReadFaqPageCommand): PageData<Faq>
     fun findById(id: Long): Faq?
 }
 

--- a/systems/notification/notification-application/src/main/kotlin/hs/kr/entrydsm/notification/application/port/out/FaqRepository.kt
+++ b/systems/notification/notification-application/src/main/kotlin/hs/kr/entrydsm/notification/application/port/out/FaqRepository.kt
@@ -1,0 +1,9 @@
+package hs.kr.entrydsm.notification.application.port.out
+
+import hs.kr.entrydsm.notification.domain.model.Faq
+
+interface FaqRepository {
+    fun findAll(): List<Faq>
+    fun findById(id: Long): Faq?
+}
+

--- a/systems/notification/notification-application/src/main/kotlin/hs/kr/entrydsm/notification/application/port/out/FaqRepository.kt
+++ b/systems/notification/notification-application/src/main/kotlin/hs/kr/entrydsm/notification/application/port/out/FaqRepository.kt
@@ -1,9 +1,11 @@
 package hs.kr.entrydsm.notification.application.port.out
 
+import hs.kr.entrydsm.notification.application.port.`in`.command.ReadNotificationPageCommand
+import hs.kr.entrydsm.notification.application.port.out.data.PageData
 import hs.kr.entrydsm.notification.domain.model.Faq
 
 interface FaqRepository {
-    fun findAll(): List<Faq>
+    fun findPage(command: ReadNotificationPageCommand): PageData<Faq>
     fun findById(id: Long): Faq?
 }
 

--- a/systems/notification/notification-application/src/main/kotlin/hs/kr/entrydsm/notification/application/port/out/NoticeRepository.kt
+++ b/systems/notification/notification-application/src/main/kotlin/hs/kr/entrydsm/notification/application/port/out/NoticeRepository.kt
@@ -1,0 +1,9 @@
+package hs.kr.entrydsm.notification.application.port.out
+
+import hs.kr.entrydsm.notification.domain.model.Notice
+
+interface NoticeRepository {
+    fun findAll(): List<Notice>
+    fun findById(id: Long): Notice?
+}
+

--- a/systems/notification/notification-application/src/main/kotlin/hs/kr/entrydsm/notification/application/port/out/NoticeRepository.kt
+++ b/systems/notification/notification-application/src/main/kotlin/hs/kr/entrydsm/notification/application/port/out/NoticeRepository.kt
@@ -1,9 +1,11 @@
 package hs.kr.entrydsm.notification.application.port.out
 
+import hs.kr.entrydsm.notification.application.port.`in`.command.ReadNotificationPageCommand
+import hs.kr.entrydsm.notification.application.port.out.data.PageData
 import hs.kr.entrydsm.notification.domain.model.Notice
 
 interface NoticeRepository {
-    fun findAll(): List<Notice>
+    fun findPage(command: ReadNotificationPageCommand): PageData<Notice>
     fun findById(id: Long): Notice?
 }
 

--- a/systems/notification/notification-application/src/main/kotlin/hs/kr/entrydsm/notification/application/port/out/RecruitmentGuidelineRepository.kt
+++ b/systems/notification/notification-application/src/main/kotlin/hs/kr/entrydsm/notification/application/port/out/RecruitmentGuidelineRepository.kt
@@ -1,0 +1,8 @@
+package hs.kr.entrydsm.notification.application.port.out
+
+import hs.kr.entrydsm.notification.domain.model.RecruitmentGuideline
+
+interface RecruitmentGuidelineRepository {
+    fun findCurrent(): RecruitmentGuideline?
+}
+

--- a/systems/notification/notification-application/src/main/kotlin/hs/kr/entrydsm/notification/application/port/out/data/PageData.kt
+++ b/systems/notification/notification-application/src/main/kotlin/hs/kr/entrydsm/notification/application/port/out/data/PageData.kt
@@ -1,0 +1,17 @@
+package hs.kr.entrydsm.notification.application.port.out.data
+
+data class PageData<T>(
+    val content: List<T>,
+    val page: Int,
+    val size: Int,
+    val totalElements: Long,
+) {
+    val totalPages: Int =
+        if (totalElements == 0L) {
+            0
+        } else {
+            ((totalElements - 1) / size).toInt() + 1
+        }
+
+    val last: Boolean = page >= totalPages - 1
+}

--- a/systems/notification/notification-application/src/main/kotlin/hs/kr/entrydsm/notification/application/service/NotificationService.kt
+++ b/systems/notification/notification-application/src/main/kotlin/hs/kr/entrydsm/notification/application/service/NotificationService.kt
@@ -15,9 +15,7 @@ import hs.kr.entrydsm.notification.application.port.out.NoticeRepository
 import hs.kr.entrydsm.notification.application.port.out.RecruitmentGuidelineRepository
 import hs.kr.entrydsm.notification.domain.model.Faq
 import hs.kr.entrydsm.notification.domain.model.Notice
-import org.springframework.stereotype.Service
 
-@Service
 class NotificationService(
     private val noticeRepository: NoticeRepository,
     private val faqRepository: FaqRepository,
@@ -100,11 +98,12 @@ class NotificationService(
         command: ReadNotificationPageCommand,
         mapper: (T) -> R,
     ): PageResult<R> {
-        require(command.page >= 0) { "page must be greater than or equal to 0" }
-        require(command.size > 0) { "size must be greater than 0" }
-
-        val fromIndex = (command.page * command.size).coerceAtMost(size)
-        val toIndex = (fromIndex + command.size).coerceAtMost(size)
+        val fromIndex = command.offset()
+            .coerceAtMost(size.toLong())
+            .toInt()
+        val toIndex = (fromIndex.toLong() + command.size.toLong())
+            .coerceAtMost(size.toLong())
+            .toInt()
         val totalPages = if (isEmpty()) 0 else ((size - 1) / command.size) + 1
         return PageResult(
             content = subList(fromIndex, toIndex).map(mapper),

--- a/systems/notification/notification-application/src/main/kotlin/hs/kr/entrydsm/notification/application/service/NotificationService.kt
+++ b/systems/notification/notification-application/src/main/kotlin/hs/kr/entrydsm/notification/application/service/NotificationService.kt
@@ -13,6 +13,7 @@ import hs.kr.entrydsm.notification.application.port.`in`.result.RecruitmentSched
 import hs.kr.entrydsm.notification.application.port.out.FaqRepository
 import hs.kr.entrydsm.notification.application.port.out.NoticeRepository
 import hs.kr.entrydsm.notification.application.port.out.RecruitmentGuidelineRepository
+import hs.kr.entrydsm.notification.application.port.out.data.PageData
 import hs.kr.entrydsm.notification.domain.model.Faq
 import hs.kr.entrydsm.notification.domain.model.Notice
 
@@ -22,18 +23,14 @@ class NotificationService(
     private val recruitmentGuidelineRepository: RecruitmentGuidelineRepository,
 ) : NotificationPort {
     override fun getNotices(command: ReadNotificationPageCommand): PageResult<NoticeSummaryResult> =
-        noticeRepository.findAll()
-            .sortedByDescending { it.createdAt }
-            .toPage(command) { it.toSummaryResult() }
+        noticeRepository.findPage(command).toResult { it.toSummaryResult() }
 
     override fun getNotice(id: Long): NoticeDetailResult =
         noticeRepository.findById(id)?.toDetailResult()
             ?: throw NotificationNotFoundException("notice not found: id=$id")
 
     override fun getFaqs(command: ReadNotificationPageCommand): PageResult<FaqSummaryResult> =
-        faqRepository.findAll()
-            .sortedBy { it.id }
-            .toPage(command) { it.toSummaryResult() }
+        faqRepository.findPage(command).toResult { it.toSummaryResult() }
 
     override fun getFaq(id: Long): FaqDetailResult =
         faqRepository.findById(id)?.toDetailResult()
@@ -94,24 +91,16 @@ class NotificationService(
             updatedAt = updatedAt,
         )
 
-    private fun <T, R> List<T>.toPage(
-        command: ReadNotificationPageCommand,
+    private fun <T, R> PageData<T>.toResult(
         mapper: (T) -> R,
     ): PageResult<R> {
-        val fromIndex = command.offset()
-            .coerceAtMost(size.toLong())
-            .toInt()
-        val toIndex = (fromIndex.toLong() + command.size.toLong())
-            .coerceAtMost(size.toLong())
-            .toInt()
-        val totalPages = if (isEmpty()) 0 else ((size - 1) / command.size) + 1
         return PageResult(
-            content = subList(fromIndex, toIndex).map(mapper),
-            page = command.page,
-            size = command.size,
-            totalElements = size.toLong(),
+            content = content.map(mapper),
+            page = page,
+            size = size,
+            totalElements = totalElements,
             totalPages = totalPages,
-            last = command.page >= totalPages - 1,
+            last = last,
         )
     }
 }

--- a/systems/notification/notification-application/src/main/kotlin/hs/kr/entrydsm/notification/application/service/NotificationService.kt
+++ b/systems/notification/notification-application/src/main/kotlin/hs/kr/entrydsm/notification/application/service/NotificationService.kt
@@ -1,0 +1,118 @@
+package hs.kr.entrydsm.notification.application.service
+
+import hs.kr.entrydsm.notification.application.exception.NotificationNotFoundException
+import hs.kr.entrydsm.notification.application.port.`in`.NotificationPort
+import hs.kr.entrydsm.notification.application.port.`in`.command.ReadNotificationPageCommand
+import hs.kr.entrydsm.notification.application.port.`in`.result.FaqDetailResult
+import hs.kr.entrydsm.notification.application.port.`in`.result.FaqSummaryResult
+import hs.kr.entrydsm.notification.application.port.`in`.result.NoticeDetailResult
+import hs.kr.entrydsm.notification.application.port.`in`.result.NoticeSummaryResult
+import hs.kr.entrydsm.notification.application.port.`in`.result.PageResult
+import hs.kr.entrydsm.notification.application.port.`in`.result.RecruitmentGuidelineResult
+import hs.kr.entrydsm.notification.application.port.`in`.result.RecruitmentScheduleResult
+import hs.kr.entrydsm.notification.application.port.out.FaqRepository
+import hs.kr.entrydsm.notification.application.port.out.NoticeRepository
+import hs.kr.entrydsm.notification.application.port.out.RecruitmentGuidelineRepository
+import hs.kr.entrydsm.notification.domain.model.Faq
+import hs.kr.entrydsm.notification.domain.model.Notice
+import org.springframework.stereotype.Service
+
+@Service
+class NotificationService(
+    private val noticeRepository: NoticeRepository,
+    private val faqRepository: FaqRepository,
+    private val recruitmentGuidelineRepository: RecruitmentGuidelineRepository,
+) : NotificationPort {
+    override fun getNotices(command: ReadNotificationPageCommand): PageResult<NoticeSummaryResult> =
+        noticeRepository.findAll()
+            .sortedByDescending { it.createdAt }
+            .toPage(command) { it.toSummaryResult() }
+
+    override fun getNotice(id: Long): NoticeDetailResult =
+        noticeRepository.findById(id)?.toDetailResult()
+            ?: throw NotificationNotFoundException("notice not found: id=$id")
+
+    override fun getFaqs(command: ReadNotificationPageCommand): PageResult<FaqSummaryResult> =
+        faqRepository.findAll()
+            .sortedBy { it.id }
+            .toPage(command) { it.toSummaryResult() }
+
+    override fun getFaq(id: Long): FaqDetailResult =
+        faqRepository.findById(id)?.toDetailResult()
+            ?: throw NotificationNotFoundException("faq not found: id=$id")
+
+    override fun getRecruitmentGuideline(): RecruitmentGuidelineResult {
+        val guideline = recruitmentGuidelineRepository.findCurrent()
+            ?: throw NotificationNotFoundException("recruitment guideline not found")
+        return RecruitmentGuidelineResult(
+            recruitmentId = guideline.id,
+            title = guideline.title,
+            description = guideline.description,
+            schedule = RecruitmentScheduleResult(
+                applicationStart = guideline.schedule.applicationStart,
+                applicationEnd = guideline.schedule.applicationEnd,
+                resultAt = guideline.schedule.resultAt,
+            ),
+            createdAt = guideline.createdAt,
+            updatedAt = guideline.updatedAt,
+        )
+    }
+
+    private fun Notice.toSummaryResult(): NoticeSummaryResult =
+        NoticeSummaryResult(
+            noticeId = id,
+            title = title,
+            author = author,
+            createdAt = createdAt,
+        )
+
+    private fun Notice.toDetailResult(): NoticeDetailResult =
+        NoticeDetailResult(
+            noticeId = id,
+            title = title,
+            content = content,
+            author = author,
+            viewCount = viewCount,
+            createdAt = createdAt,
+            updatedAt = updatedAt,
+        )
+
+    private fun Faq.toSummaryResult(): FaqSummaryResult =
+        FaqSummaryResult(
+            faqId = id,
+            category = category,
+            question = question,
+            answer = answer,
+        )
+
+    private fun Faq.toDetailResult(): FaqDetailResult =
+        FaqDetailResult(
+            faqId = id,
+            category = category,
+            question = question,
+            answer = answer,
+            viewCount = viewCount,
+            createdAt = createdAt,
+            updatedAt = updatedAt,
+        )
+
+    private fun <T, R> List<T>.toPage(
+        command: ReadNotificationPageCommand,
+        mapper: (T) -> R,
+    ): PageResult<R> {
+        require(command.page >= 0) { "page must be greater than or equal to 0" }
+        require(command.size > 0) { "size must be greater than 0" }
+
+        val fromIndex = (command.page * command.size).coerceAtMost(size)
+        val toIndex = (fromIndex + command.size).coerceAtMost(size)
+        val totalPages = if (isEmpty()) 0 else ((size - 1) / command.size) + 1
+        return PageResult(
+            content = subList(fromIndex, toIndex).map(mapper),
+            page = command.page,
+            size = command.size,
+            totalElements = size.toLong(),
+            totalPages = totalPages,
+            last = command.page >= totalPages - 1,
+        )
+    }
+}

--- a/systems/notification/notification-application/src/main/kotlin/hs/kr/entrydsm/notification/application/service/NotificationService.kt
+++ b/systems/notification/notification-application/src/main/kotlin/hs/kr/entrydsm/notification/application/service/NotificationService.kt
@@ -2,6 +2,7 @@ package hs.kr.entrydsm.notification.application.service
 
 import hs.kr.entrydsm.notification.application.exception.NotificationNotFoundException
 import hs.kr.entrydsm.notification.application.port.`in`.NotificationPort
+import hs.kr.entrydsm.notification.application.port.`in`.command.ReadFaqPageCommand
 import hs.kr.entrydsm.notification.application.port.`in`.command.ReadNotificationPageCommand
 import hs.kr.entrydsm.notification.application.port.`in`.result.FaqDetailResult
 import hs.kr.entrydsm.notification.application.port.`in`.result.FaqSummaryResult
@@ -29,7 +30,7 @@ class NotificationService(
         noticeRepository.findById(id)?.toDetailResult()
             ?: throw NotificationNotFoundException("notice not found: id=$id")
 
-    override fun getFaqs(command: ReadNotificationPageCommand): PageResult<FaqSummaryResult> =
+    override fun getFaqs(command: ReadFaqPageCommand): PageResult<FaqSummaryResult> =
         faqRepository.findPage(command).toResult { it.toSummaryResult() }
 
     override fun getFaq(id: Long): FaqDetailResult =

--- a/systems/notification/notification-application/src/test/kotlin/hs/kr/entrydsm/TestMain.kt
+++ b/systems/notification/notification-application/src/test/kotlin/hs/kr/entrydsm/TestMain.kt
@@ -1,11 +1,11 @@
 package hs.kr.entrydsm.notification.application
 
-import org.junit.Assert.assertTrue
-import org.junit.Test
+import hs.kr.entrydsm.notification.application.service.NotificationServiceTest
+import org.junit.runner.RunWith
+import org.junit.runners.Suite
 
-class NotificationApplicationModuleTest {
-    @Test
-    fun moduleLoads() {
-        assertTrue(true)
-    }
-}
+@RunWith(Suite::class)
+@Suite.SuiteClasses(
+    NotificationServiceTest::class,
+)
+class NotificationApplicationModuleTest

--- a/systems/notification/notification-application/src/test/kotlin/hs/kr/entrydsm/notification/application/service/NotificationServiceTest.kt
+++ b/systems/notification/notification-application/src/test/kotlin/hs/kr/entrydsm/notification/application/service/NotificationServiceTest.kt
@@ -1,0 +1,213 @@
+package hs.kr.entrydsm.notification.application.service
+
+import hs.kr.entrydsm.notification.application.exception.NotificationNotFoundException
+import hs.kr.entrydsm.notification.application.port.`in`.command.ReadNotificationPageCommand
+import hs.kr.entrydsm.notification.application.port.out.FaqRepository
+import hs.kr.entrydsm.notification.application.port.out.NoticeRepository
+import hs.kr.entrydsm.notification.application.port.out.RecruitmentGuidelineRepository
+import hs.kr.entrydsm.notification.domain.model.Faq
+import hs.kr.entrydsm.notification.domain.model.Notice
+import hs.kr.entrydsm.notification.domain.model.RecruitmentGuideline
+import hs.kr.entrydsm.notification.domain.model.RecruitmentSchedule
+import java.time.LocalDate
+import java.time.LocalDateTime
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertFalse
+import org.junit.Assert.assertTrue
+import org.junit.Test
+
+class NotificationServiceTest {
+    @Test
+    fun getNoticesReturnsPagedNoticesOrderedByCreatedAtDesc() {
+        val service = service(
+            notices = listOf(
+                notice(id = 1L, title = "older", createdAt = now.minusDays(1)),
+                notice(id = 2L, title = "newer", createdAt = now),
+            ),
+        )
+
+        val result = service.getNotices(ReadNotificationPageCommand(page = 0, size = 1))
+
+        assertEquals(1, result.content.size)
+        assertEquals(2L, result.content.first().noticeId)
+        assertEquals(2L, result.totalElements)
+        assertEquals(2, result.totalPages)
+        assertFalse(result.last)
+    }
+
+    @Test
+    fun getNoticeReturnsDetailFields() {
+        val service = service(
+            notices = listOf(
+                notice(
+                    id = 1L,
+                    title = "notice title",
+                    content = "notice content",
+                    author = "admin",
+                    viewCount = 12,
+                    createdAt = now.minusDays(2),
+                    updatedAt = now.minusDays(1),
+                ),
+            ),
+        )
+
+        val result = service.getNotice(1L)
+
+        assertEquals(1L, result.noticeId)
+        assertEquals("notice title", result.title)
+        assertEquals("notice content", result.content)
+        assertEquals("admin", result.author)
+        assertEquals(12, result.viewCount)
+        assertEquals(now.minusDays(2), result.createdAt)
+        assertEquals(now.minusDays(1), result.updatedAt)
+    }
+
+    @Test(expected = NotificationNotFoundException::class)
+    fun getNoticeThrowsWhenNoticeDoesNotExist() {
+        service().getNotice(1L)
+    }
+
+    @Test
+    fun getFaqsReturnsPagedFaqsOrderedById() {
+        val service = service(
+            faqs = listOf(
+                faq(id = 2L, question = "second"),
+                faq(id = 1L, question = "first"),
+            ),
+        )
+
+        val result = service.getFaqs(ReadNotificationPageCommand(page = 0, size = 1))
+
+        assertEquals(1, result.content.size)
+        assertEquals(1L, result.content.first().faqId)
+        assertEquals("first", result.content.first().question)
+        assertEquals(2L, result.totalElements)
+        assertFalse(result.last)
+    }
+
+    @Test(expected = NotificationNotFoundException::class)
+    fun getFaqThrowsWhenFaqDoesNotExist() {
+        service().getFaq(1L)
+    }
+
+    @Test
+    fun getRecruitmentGuidelineReturnsCurrentGuideline() {
+        val guideline = RecruitmentGuideline(
+            id = 1L,
+            title = "2027 admission",
+            description = "guideline",
+            schedule = RecruitmentSchedule(
+                applicationStart = LocalDate.parse("2026-10-19"),
+                applicationEnd = LocalDate.parse("2026-10-23"),
+                resultAt = LocalDate.parse("2026-10-30"),
+            ),
+            createdAt = now.minusDays(3),
+            updatedAt = now.minusDays(2),
+        )
+
+        val result = service(guideline = guideline).getRecruitmentGuideline()
+
+        assertEquals(1L, result.recruitmentId)
+        assertEquals("2027 admission", result.title)
+        assertEquals("guideline", result.description)
+        assertEquals(LocalDate.parse("2026-10-19"), result.schedule.applicationStart)
+        assertEquals(LocalDate.parse("2026-10-23"), result.schedule.applicationEnd)
+        assertEquals(LocalDate.parse("2026-10-30"), result.schedule.resultAt)
+        assertEquals(now.minusDays(3), result.createdAt)
+        assertEquals(now.minusDays(2), result.updatedAt)
+    }
+
+    @Test
+    fun getNoticesHandlesLargePageWithoutIntOverflow() {
+        val result = service(notices = listOf(notice(id = 1L)))
+            .getNotices(ReadNotificationPageCommand(page = Int.MAX_VALUE, size = Int.MAX_VALUE))
+
+        assertTrue(result.content.isEmpty())
+        assertEquals(1L, result.totalElements)
+        assertEquals(1, result.totalPages)
+        assertTrue(result.last)
+    }
+
+    @Test(expected = IllegalArgumentException::class)
+    fun commandRejectsNegativePage() {
+        ReadNotificationPageCommand(page = -1, size = 10)
+    }
+
+    @Test(expected = IllegalArgumentException::class)
+    fun commandRejectsZeroSize() {
+        ReadNotificationPageCommand(page = 0, size = 0)
+    }
+
+    private fun service(
+        notices: List<Notice> = emptyList(),
+        faqs: List<Faq> = emptyList(),
+        guideline: RecruitmentGuideline? = null,
+    ): NotificationService =
+        NotificationService(
+            noticeRepository = FakeNoticeRepository(notices),
+            faqRepository = FakeFaqRepository(faqs),
+            recruitmentGuidelineRepository = FakeRecruitmentGuidelineRepository(guideline),
+        )
+
+    private class FakeNoticeRepository(
+        private val notices: List<Notice> = emptyList(),
+    ) : NoticeRepository {
+        override fun findAll(): List<Notice> = notices
+        override fun findById(id: Long): Notice? = notices.firstOrNull { it.id == id }
+    }
+
+    private class FakeFaqRepository(
+        private val faqs: List<Faq> = emptyList(),
+    ) : FaqRepository {
+        override fun findAll(): List<Faq> = faqs
+        override fun findById(id: Long): Faq? = faqs.firstOrNull { it.id == id }
+    }
+
+    private class FakeRecruitmentGuidelineRepository(
+        private val guideline: RecruitmentGuideline? = null,
+    ) : RecruitmentGuidelineRepository {
+        override fun findCurrent(): RecruitmentGuideline? = guideline
+    }
+
+    private fun notice(
+        id: Long,
+        title: String = "title",
+        content: String = "content",
+        author: String = "admin",
+        viewCount: Int = 0,
+        createdAt: LocalDateTime = now,
+        updatedAt: LocalDateTime = now,
+    ): Notice =
+        Notice(
+            id = id,
+            title = title,
+            content = content,
+            author = author,
+            viewCount = viewCount,
+            createdAt = createdAt,
+            updatedAt = updatedAt,
+        )
+
+    private fun faq(
+        id: Long,
+        category: String = "입학 문의",
+        question: String = "question",
+        answer: String = "answer",
+        viewCount: Int = 0,
+        createdAt: LocalDateTime = now,
+        updatedAt: LocalDateTime = now,
+    ): Faq =
+        Faq(
+            id = id,
+            category = category,
+            question = question,
+            answer = answer,
+            viewCount = viewCount,
+            createdAt = createdAt,
+            updatedAt = updatedAt,
+        )
+
+    private companion object {
+        val now: LocalDateTime = LocalDateTime.parse("2026-08-17T09:00:00")
+    }
+}

--- a/systems/notification/notification-application/src/test/kotlin/hs/kr/entrydsm/notification/application/service/NotificationServiceTest.kt
+++ b/systems/notification/notification-application/src/test/kotlin/hs/kr/entrydsm/notification/application/service/NotificationServiceTest.kt
@@ -5,6 +5,7 @@ import hs.kr.entrydsm.notification.application.port.`in`.command.ReadNotificatio
 import hs.kr.entrydsm.notification.application.port.out.FaqRepository
 import hs.kr.entrydsm.notification.application.port.out.NoticeRepository
 import hs.kr.entrydsm.notification.application.port.out.RecruitmentGuidelineRepository
+import hs.kr.entrydsm.notification.application.port.out.data.PageData
 import hs.kr.entrydsm.notification.domain.model.Faq
 import hs.kr.entrydsm.notification.domain.model.Notice
 import hs.kr.entrydsm.notification.domain.model.RecruitmentGuideline
@@ -149,17 +150,23 @@ class NotificationServiceTest {
             recruitmentGuidelineRepository = FakeRecruitmentGuidelineRepository(guideline),
         )
 
-    private class FakeNoticeRepository(
+    private inner class FakeNoticeRepository(
         private val notices: List<Notice> = emptyList(),
     ) : NoticeRepository {
-        override fun findAll(): List<Notice> = notices
+        override fun findPage(command: ReadNotificationPageCommand): PageData<Notice> {
+            val sorted = notices.sortedWith(compareByDescending<Notice> { it.createdAt }.thenByDescending { it.id })
+            return sorted.toPageData(command)
+        }
+
         override fun findById(id: Long): Notice? = notices.firstOrNull { it.id == id }
     }
 
-    private class FakeFaqRepository(
+    private inner class FakeFaqRepository(
         private val faqs: List<Faq> = emptyList(),
     ) : FaqRepository {
-        override fun findAll(): List<Faq> = faqs
+        override fun findPage(command: ReadNotificationPageCommand): PageData<Faq> =
+            faqs.sortedBy { it.id }.toPageData(command)
+
         override fun findById(id: Long): Faq? = faqs.firstOrNull { it.id == id }
     }
 
@@ -206,6 +213,21 @@ class NotificationServiceTest {
             createdAt = createdAt,
             updatedAt = updatedAt,
         )
+
+    private fun <T> List<T>.toPageData(command: ReadNotificationPageCommand): PageData<T> {
+        val fromIndex = command.offset()
+            .coerceAtMost(size.toLong())
+            .toInt()
+        val toIndex = (fromIndex.toLong() + command.size.toLong())
+            .coerceAtMost(size.toLong())
+            .toInt()
+        return PageData(
+            content = subList(fromIndex, toIndex),
+            page = command.page,
+            size = command.size,
+            totalElements = size.toLong(),
+        )
+    }
 
     private companion object {
         val now: LocalDateTime = LocalDateTime.parse("2026-08-17T09:00:00")

--- a/systems/notification/notification-application/src/test/kotlin/hs/kr/entrydsm/notification/application/service/NotificationServiceTest.kt
+++ b/systems/notification/notification-application/src/test/kotlin/hs/kr/entrydsm/notification/application/service/NotificationServiceTest.kt
@@ -8,6 +8,7 @@ import hs.kr.entrydsm.notification.application.port.out.RecruitmentGuidelineRepo
 import hs.kr.entrydsm.notification.application.port.out.data.PageData
 import hs.kr.entrydsm.notification.domain.model.Faq
 import hs.kr.entrydsm.notification.domain.model.Notice
+import hs.kr.entrydsm.notification.domain.model.NoticeCategory
 import hs.kr.entrydsm.notification.domain.model.RecruitmentGuideline
 import hs.kr.entrydsm.notification.domain.model.RecruitmentSchedule
 import java.time.LocalDate
@@ -34,6 +35,40 @@ class NotificationServiceTest {
         assertEquals(2L, result.totalElements)
         assertEquals(2, result.totalPages)
         assertFalse(result.last)
+    }
+
+    @Test
+    fun getNoticesReturnsPagedNoticesFilteredByCategory() {
+        val service = service(
+            notices = listOf(
+                notice(
+                    id = 1L,
+                    title = "admission",
+                    category = NoticeCategory.ADMISSION_NOTICE,
+                    createdAt = now.minusDays(1),
+                ),
+                notice(
+                    id = 2L,
+                    title = "prospective",
+                    category = NoticeCategory.PROSPECTIVE_STUDENT,
+                    createdAt = now,
+                ),
+            ),
+        )
+
+        val result = service.getNotices(
+            ReadNotificationPageCommand(
+                page = 0,
+                size = 10,
+                category = NoticeCategory.ADMISSION_NOTICE,
+            ),
+        )
+
+        assertEquals(1, result.content.size)
+        assertEquals(1L, result.content.first().noticeId)
+        assertEquals("admission", result.content.first().title)
+        assertEquals(1L, result.totalElements)
+        assertTrue(result.last)
     }
 
     @Test
@@ -154,7 +189,9 @@ class NotificationServiceTest {
         private val notices: List<Notice> = emptyList(),
     ) : NoticeRepository {
         override fun findPage(command: ReadNotificationPageCommand): PageData<Notice> {
-            val sorted = notices.sortedWith(compareByDescending<Notice> { it.createdAt }.thenByDescending { it.id })
+            val sorted = notices
+                .filter { command.category == null || it.category == command.category }
+                .sortedWith(compareByDescending<Notice> { it.createdAt }.thenByDescending { it.id })
             return sorted.toPageData(command)
         }
 
@@ -180,6 +217,7 @@ class NotificationServiceTest {
         id: Long,
         title: String = "title",
         content: String = "content",
+        category: NoticeCategory = NoticeCategory.ADMISSION_NOTICE,
         author: String = "admin",
         viewCount: Int = 0,
         createdAt: LocalDateTime = now,
@@ -189,6 +227,7 @@ class NotificationServiceTest {
             id = id,
             title = title,
             content = content,
+            category = category,
             author = author,
             viewCount = viewCount,
             createdAt = createdAt,

--- a/systems/notification/notification-application/src/test/kotlin/hs/kr/entrydsm/notification/application/service/NotificationServiceTest.kt
+++ b/systems/notification/notification-application/src/test/kotlin/hs/kr/entrydsm/notification/application/service/NotificationServiceTest.kt
@@ -1,12 +1,14 @@
 package hs.kr.entrydsm.notification.application.service
 
 import hs.kr.entrydsm.notification.application.exception.NotificationNotFoundException
+import hs.kr.entrydsm.notification.application.port.`in`.command.ReadFaqPageCommand
 import hs.kr.entrydsm.notification.application.port.`in`.command.ReadNotificationPageCommand
 import hs.kr.entrydsm.notification.application.port.out.FaqRepository
 import hs.kr.entrydsm.notification.application.port.out.NoticeRepository
 import hs.kr.entrydsm.notification.application.port.out.RecruitmentGuidelineRepository
 import hs.kr.entrydsm.notification.application.port.out.data.PageData
 import hs.kr.entrydsm.notification.domain.model.Faq
+import hs.kr.entrydsm.notification.domain.model.FaqCategory
 import hs.kr.entrydsm.notification.domain.model.Notice
 import hs.kr.entrydsm.notification.domain.model.NoticeCategory
 import hs.kr.entrydsm.notification.domain.model.RecruitmentGuideline
@@ -112,13 +114,38 @@ class NotificationServiceTest {
             ),
         )
 
-        val result = service.getFaqs(ReadNotificationPageCommand(page = 0, size = 1))
+        val result = service.getFaqs(ReadFaqPageCommand(page = 0, size = 1))
 
         assertEquals(1, result.content.size)
         assertEquals(1L, result.content.first().faqId)
         assertEquals("first", result.content.first().question)
         assertEquals(2L, result.totalElements)
         assertFalse(result.last)
+    }
+
+    @Test
+    fun getFaqsReturnsPagedFaqsFilteredByCategory() {
+        val service = service(
+            faqs = listOf(
+                faq(id = 1L, category = FaqCategory.ADMISSION.label, question = "admission"),
+                faq(id = 2L, category = FaqCategory.CAREER.label, question = "career"),
+            ),
+        )
+
+        val result = service.getFaqs(
+            ReadFaqPageCommand(
+                page = 0,
+                size = 10,
+                category = FaqCategory.ADMISSION,
+            ),
+        )
+
+        assertEquals(1, result.content.size)
+        assertEquals(1L, result.content.first().faqId)
+        assertEquals("admission", result.content.first().question)
+        assertEquals(FaqCategory.ADMISSION.label, result.content.first().category)
+        assertEquals(1L, result.totalElements)
+        assertTrue(result.last)
     }
 
     @Test(expected = NotificationNotFoundException::class)
@@ -201,8 +228,13 @@ class NotificationServiceTest {
     private inner class FakeFaqRepository(
         private val faqs: List<Faq> = emptyList(),
     ) : FaqRepository {
-        override fun findPage(command: ReadNotificationPageCommand): PageData<Faq> =
-            faqs.sortedBy { it.id }.toPageData(command)
+        override fun findPage(command: ReadFaqPageCommand): PageData<Faq> {
+            val category = command.category
+            return faqs
+                .filter { category == null || it.category == category.label }
+                .sortedBy { it.id }
+                .toPageData(command)
+        }
 
         override fun findById(id: Long): Faq? = faqs.firstOrNull { it.id == id }
     }
@@ -254,6 +286,21 @@ class NotificationServiceTest {
         )
 
     private fun <T> List<T>.toPageData(command: ReadNotificationPageCommand): PageData<T> {
+        val fromIndex = command.offset()
+            .coerceAtMost(size.toLong())
+            .toInt()
+        val toIndex = (fromIndex.toLong() + command.size.toLong())
+            .coerceAtMost(size.toLong())
+            .toInt()
+        return PageData(
+            content = subList(fromIndex, toIndex),
+            page = command.page,
+            size = command.size,
+            totalElements = size.toLong(),
+        )
+    }
+
+    private fun <T> List<T>.toPageData(command: ReadFaqPageCommand): PageData<T> {
         val fromIndex = command.offset()
             .coerceAtMost(size.toLong())
             .toInt()

--- a/systems/notification/notification-bootstrap/BUILD.bazel
+++ b/systems/notification/notification-bootstrap/BUILD.bazel
@@ -8,7 +8,7 @@ kt_jvm_binary(
     srcs = glob(["src/main/kotlin/**/*.kt"]),
     javac_opts = "//:javac_options",
     kotlinc_opts = "//:kotlinc_options",
-    main_class = "hs.kr.entrydsm.notification.NotificationBootstrapApplicationKt",
+    main_class = "hs.kr.entrydsm.notification.ExampleApplicationKt",
     plugins = ["//:spring_allopen"],
     resources = glob(["src/main/resources/**"]),
     deps = MODULE_DEPS + [

--- a/systems/notification/notification-bootstrap/deps.bzl
+++ b/systems/notification/notification-bootstrap/deps.bzl
@@ -1,11 +1,13 @@
 SPRING_DEPS = [
     "@maven//:org_springframework_boot_spring_boot_starter_web",
     "@maven//:org_springframework_boot_spring_boot_starter_actuator",
+    "@maven//:org_springframework_boot_spring_boot_starter_data_jpa",
 ]
 
 KOTLIN_DEPS = [
     "@maven//:org_jetbrains_kotlin_kotlin_reflect",
     "@maven//:com_fasterxml_jackson_module_jackson_module_kotlin",
+    "@maven//:com_mysql_mysql_connector_j",
 ]
 
 TEST_DEPS = [

--- a/systems/notification/notification-bootstrap/src/main/resources/application-dev.yaml
+++ b/systems/notification/notification-bootstrap/src/main/resources/application-dev.yaml
@@ -1,0 +1,17 @@
+spring:
+  config:
+    activate:
+      on-profile: dev
+  datasource:
+    url: ${DB_URL}
+    username: ${DB_USERNAME}
+    password: ${DB_PASSWORD}
+    driver-class-name: com.mysql.cj.jdbc.Driver
+  jpa:
+    hibernate:
+      ddl-auto: update
+    open-in-view: false
+    show-sql: false
+    properties:
+      hibernate:
+        dialect: org.hibernate.dialect.MySQLDialect

--- a/systems/notification/notification-bootstrap/src/main/resources/application-local.yaml
+++ b/systems/notification/notification-bootstrap/src/main/resources/application-local.yaml
@@ -1,0 +1,17 @@
+spring:
+  config:
+    activate:
+      on-profile: local
+  datasource:
+    url: ${DB_URL}
+    username: ${DB_USERNAME}
+    password: ${DB_PASSWORD}
+    driver-class-name: com.mysql.cj.jdbc.Driver
+  jpa:
+    hibernate:
+      ddl-auto: update
+    open-in-view: false
+    show-sql: false
+    properties:
+      hibernate:
+        dialect: org.hibernate.dialect.MySQLDialect

--- a/systems/notification/notification-bootstrap/src/main/resources/application-prod.yaml
+++ b/systems/notification/notification-bootstrap/src/main/resources/application-prod.yaml
@@ -1,0 +1,17 @@
+spring:
+  config:
+    activate:
+      on-profile: prod
+  datasource:
+    url: ${DB_URL}
+    username: ${DB_USERNAME}
+    password: ${DB_PASSWORD}
+    driver-class-name: com.mysql.cj.jdbc.Driver
+  jpa:
+    hibernate:
+      ddl-auto: validate
+    open-in-view: false
+    show-sql: false
+    properties:
+      hibernate:
+        dialect: org.hibernate.dialect.MySQLDialect

--- a/systems/notification/notification-bootstrap/src/main/resources/application.yaml
+++ b/systems/notification/notification-bootstrap/src/main/resources/application.yaml
@@ -2,7 +2,7 @@ spring:
   application:
     name: notification
   profiles:
-    default: dev
+    default: local
   main:
     lazy-initialization: true
 
@@ -10,7 +10,7 @@ server:
   shutdown: graceful
 
 grpc:
-  port: ${GRPC_PORT:9090}
+  port: ${GRPC_PORT}
 
 management:
   endpoints:

--- a/systems/notification/notification-bootstrap/src/main/resources/application.yaml
+++ b/systems/notification/notification-bootstrap/src/main/resources/application.yaml
@@ -2,11 +2,16 @@ spring:
   application:
     name: notification
   profiles:
-    default: local
+    default: dev
   main:
     lazy-initialization: true
+
 server:
   shutdown: graceful
+
+grpc:
+  port: ${GRPC_PORT:9090}
+
 management:
   endpoints:
     web:
@@ -16,6 +21,7 @@ management:
     health:
       probes:
         enabled: true
+
 logging:
   level:
     root: INFO

--- a/systems/notification/notification-bootstrap/src/main/resources/db/migration/V028__create_notification_tables.sql
+++ b/systems/notification/notification-bootstrap/src/main/resources/db/migration/V028__create_notification_tables.sql
@@ -1,0 +1,33 @@
+CREATE TABLE IF NOT EXISTS notices (
+    id BIGINT NOT NULL AUTO_INCREMENT,
+    title VARCHAR(255) NOT NULL,
+    content TEXT NOT NULL,
+    author VARCHAR(50) NOT NULL,
+    view_count INT NOT NULL,
+    created_at DATETIME(6) NOT NULL,
+    updated_at DATETIME(6) NOT NULL,
+    PRIMARY KEY (id)
+);
+
+CREATE TABLE IF NOT EXISTS faqs (
+    id BIGINT NOT NULL AUTO_INCREMENT,
+    category VARCHAR(50) NOT NULL,
+    question VARCHAR(255) NOT NULL,
+    answer TEXT NOT NULL,
+    view_count INT NOT NULL,
+    created_at DATETIME(6) NOT NULL,
+    updated_at DATETIME(6) NOT NULL,
+    PRIMARY KEY (id)
+);
+
+CREATE TABLE IF NOT EXISTS recruitment_guidelines (
+    id BIGINT NOT NULL AUTO_INCREMENT,
+    title VARCHAR(255) NOT NULL,
+    description TEXT NOT NULL,
+    application_start DATE NOT NULL,
+    application_end DATE NOT NULL,
+    result_at DATE NOT NULL,
+    created_at DATETIME(6) NOT NULL,
+    updated_at DATETIME(6) NOT NULL,
+    PRIMARY KEY (id)
+);

--- a/systems/notification/notification-bootstrap/src/main/resources/db/migration/V028__create_notification_tables.sql
+++ b/systems/notification/notification-bootstrap/src/main/resources/db/migration/V028__create_notification_tables.sql
@@ -2,6 +2,7 @@ CREATE TABLE IF NOT EXISTS notices (
     id BIGINT NOT NULL AUTO_INCREMENT,
     title VARCHAR(255) NOT NULL,
     content TEXT NOT NULL,
+    category VARCHAR(32) NOT NULL,
     author VARCHAR(50) NOT NULL,
     view_count INT NOT NULL,
     created_at DATETIME(6) NOT NULL,

--- a/systems/notification/notification-domain/src/main/kotlin/hs/kr/entrydsm/notification/domain/model/Faq.kt
+++ b/systems/notification/notification-domain/src/main/kotlin/hs/kr/entrydsm/notification/domain/model/Faq.kt
@@ -1,0 +1,14 @@
+package hs.kr.entrydsm.notification.domain.model
+
+import java.time.LocalDateTime
+
+data class Faq(
+    val id: Long,
+    val category: String,
+    val question: String,
+    val answer: String,
+    val viewCount: Int,
+    val createdAt: LocalDateTime,
+    val updatedAt: LocalDateTime,
+)
+

--- a/systems/notification/notification-domain/src/main/kotlin/hs/kr/entrydsm/notification/domain/model/FaqCategory.kt
+++ b/systems/notification/notification-domain/src/main/kotlin/hs/kr/entrydsm/notification/domain/model/FaqCategory.kt
@@ -1,0 +1,21 @@
+package hs.kr.entrydsm.notification.domain.model
+
+import java.util.Locale
+
+enum class FaqCategory(
+    val label: String,
+) {
+    ADMISSION("입학 문의"),
+    CAREER("진로"),
+    SCHOOL_LIFE("학교 생활"),
+    DORMITORY("기숙사"),
+    ETC("기타"),
+    ;
+
+    companion object {
+        fun from(value: String): FaqCategory =
+            entries.firstOrNull { category ->
+                category.name == value.uppercase(Locale.ROOT) || category.label == value
+            } ?: throw IllegalArgumentException("invalid faq category: $value")
+    }
+}

--- a/systems/notification/notification-domain/src/main/kotlin/hs/kr/entrydsm/notification/domain/model/Notice.kt
+++ b/systems/notification/notification-domain/src/main/kotlin/hs/kr/entrydsm/notification/domain/model/Notice.kt
@@ -6,6 +6,7 @@ data class Notice(
     val id: Long,
     val title: String,
     val content: String,
+    val category: NoticeCategory,
     val author: String,
     val viewCount: Int,
     val createdAt: LocalDateTime,

--- a/systems/notification/notification-domain/src/main/kotlin/hs/kr/entrydsm/notification/domain/model/Notice.kt
+++ b/systems/notification/notification-domain/src/main/kotlin/hs/kr/entrydsm/notification/domain/model/Notice.kt
@@ -1,0 +1,14 @@
+package hs.kr.entrydsm.notification.domain.model
+
+import java.time.LocalDateTime
+
+data class Notice(
+    val id: Long,
+    val title: String,
+    val content: String,
+    val author: String,
+    val viewCount: Int,
+    val createdAt: LocalDateTime,
+    val updatedAt: LocalDateTime,
+)
+

--- a/systems/notification/notification-domain/src/main/kotlin/hs/kr/entrydsm/notification/domain/model/NoticeCategory.kt
+++ b/systems/notification/notification-domain/src/main/kotlin/hs/kr/entrydsm/notification/domain/model/NoticeCategory.kt
@@ -1,0 +1,18 @@
+package hs.kr.entrydsm.notification.domain.model
+
+import java.util.Locale
+
+enum class NoticeCategory(
+    val label: String,
+) {
+    ADMISSION_NOTICE("입학 공지사항"),
+    PROSPECTIVE_STUDENT("예비 신입생 안내"),
+    ;
+
+    companion object {
+        fun from(value: String): NoticeCategory =
+            entries.firstOrNull { category ->
+                category.name == value.uppercase(Locale.ROOT) || category.label == value
+            } ?: throw IllegalArgumentException("invalid notice category: $value")
+    }
+}

--- a/systems/notification/notification-domain/src/main/kotlin/hs/kr/entrydsm/notification/domain/model/RecruitmentGuideline.kt
+++ b/systems/notification/notification-domain/src/main/kotlin/hs/kr/entrydsm/notification/domain/model/RecruitmentGuideline.kt
@@ -1,0 +1,19 @@
+package hs.kr.entrydsm.notification.domain.model
+
+import java.time.LocalDate
+import java.time.LocalDateTime
+
+data class RecruitmentGuideline(
+    val id: Long,
+    val title: String,
+    val description: String,
+    val schedule: RecruitmentSchedule,
+    val createdAt: LocalDateTime,
+    val updatedAt: LocalDateTime,
+)
+
+data class RecruitmentSchedule(
+    val applicationStart: LocalDate,
+    val applicationEnd: LocalDate,
+    val resultAt: LocalDate,
+)


### PR DESCRIPTION
## Summary
notification 조회 기능의 domain/application 기반을 구성했습니다.
공지, QnA, 전형요강 domain model을 추가했습니다.
조회 use case를 위한 input/output port, command/result, service, exception을 정의했습니다.

## Related Issue
Related to #28

## Scope
In scope:
- Notice domain model
- Faq domain model
- RecruitmentGuideline domain model
- NotificationPort
- NotificationRepository port
- NotificationService
- NotificationNotFoundException
- notification-application Bazel 의존성

Out of scope:
- REST controller
- JPA 저장소 구현
- admin 등록/수정/삭제 API
- 파일 서비스 연동
- bootstrap 실행 설정
- 게시 예약/상태 변경
- 도메인 이벤트

## Implementation
공지 목록/상세, QnA 목록/상세, 전형요강 조회 흐름을 application service로 구성했습니다.
NotificationService는 repository port에만 의존하도록 구성했습니다.
공지 등록, 수정, 삭제는 admin API 범위이므로 포함하지 않았습니다.

이 PR은 현재 전달받은 notification 조회 API 명세와 ERD 기준으로 공지/QnA/전형요강 조회에 필요한 도메인 골격을 우선 구성했습니다.
이슈 원문에 포함된 게시 예약, 상태 변경, 도메인 이벤트는 admin 등록/수정/삭제 API 범위와 함께 후속 작업으로 분리합니다.

## Testing
- Unit test code: 후속 PR에서 추가
- Integration tests: 후속 PR에서 추가
- Manual verification: 후속 PR에서 build/test 수행 예정

## Deployment Notes
Feature flag: 없음  
Migration required: 없음  
Rollout considerations:
- 실제 데이터 조회는 후속 persistence adapter PR에 의존합니다.
- 파일 첨부 및 전형요강 파일 다운로드는 configuration/document 서비스 연동 범위입니다.

## Checklist
- [x] Matches product/tech requirements
- [x] Backward compatibility considered
- [ ] API success flow verified in a running environment
- [ ] Real persistence adapter connected