### PR TITLE
feat(notification): notification 테스트 및 실행 설정 정리 #28

### DIFF
--- a/systems/notification/notification-adapter-in/BUILD.bazel
+++ b/systems/notification/notification-adapter-in/BUILD.bazel
@@ -17,5 +17,5 @@ kt_jvm_test(
     javac_opts = "//:javac_options",
     kotlinc_opts = "//:kotlinc_options",
     test_class = "hs.kr.entrydsm.notification.adapterin.NotificationAdapterInModuleTest",
-    deps = MODULE_DEPS + TEST_DEPS,
+    deps = [":main"] + MODULE_DEPS + TEST_DEPS,
 )

--- a/systems/notification/notification-adapter-in/deps.bzl
+++ b/systems/notification/notification-adapter-in/deps.bzl
@@ -1,3 +1,4 @@
+# Dependencies for the notification REST adapter module.
 KOTLIN_DEPS = [
     "@maven//:org_springframework_boot_spring_boot_starter_web",
     "//systems/notification/notification-application:main",

--- a/systems/notification/notification-adapter-in/src/main/kotlin/hs/kr/entrydsm/notification/adapterin/web/exception/GlobalExceptionHandler.kt
+++ b/systems/notification/notification-adapter-in/src/main/kotlin/hs/kr/entrydsm/notification/adapterin/web/exception/GlobalExceptionHandler.kt
@@ -23,7 +23,7 @@ class GlobalExceptionHandler {
         response(
             status = HttpStatus.NOT_FOUND,
             code = "NOTIFICATION_NOT_FOUND",
-            message = exception.message ?: "notification not found",
+            message = "notification not found",
         )
 
     @ExceptionHandler(
@@ -38,7 +38,7 @@ class GlobalExceptionHandler {
         response(
             status = HttpStatus.BAD_REQUEST,
             code = "INVALID_REQUEST",
-            message = exception.message ?: "invalid request",
+            message = "invalid request",
         )
 
     @ExceptionHandler(Exception::class)

--- a/systems/notification/notification-adapter-in/src/test/kotlin/hs/kr/entrydsm/TestMain.kt
+++ b/systems/notification/notification-adapter-in/src/test/kotlin/hs/kr/entrydsm/TestMain.kt
@@ -34,4 +34,15 @@ class NotificationAdapterInModuleTest {
         assertEquals("INVALID_REQUEST", response.body?.code)
         assertEquals("invalid request", response.body?.message)
     }
+
+    @Test
+    fun unhandledExceptionReturnsStableErrorResponse() {
+        val response = GlobalExceptionHandler()
+            .handleUnhandledException(RuntimeException("database connection failed"))
+
+        assertEquals(HttpStatus.INTERNAL_SERVER_ERROR, response.statusCode)
+        assertEquals(500, response.body?.status)
+        assertEquals("INTERNAL_SERVER_ERROR", response.body?.code)
+        assertEquals("internal server error", response.body?.message)
+    }
 }

--- a/systems/notification/notification-adapter-in/src/test/kotlin/hs/kr/entrydsm/TestMain.kt
+++ b/systems/notification/notification-adapter-in/src/test/kotlin/hs/kr/entrydsm/TestMain.kt
@@ -1,11 +1,37 @@
 package hs.kr.entrydsm.notification.adapterin
 
+import hs.kr.entrydsm.notification.adapterin.web.exception.GlobalExceptionHandler
+import hs.kr.entrydsm.notification.application.exception.NotificationNotFoundException
+import org.junit.Assert.assertEquals
 import org.junit.Assert.assertTrue
 import org.junit.Test
+import org.springframework.http.HttpStatus
 
 class NotificationAdapterInModuleTest {
     @Test
     fun moduleLoads() {
         assertTrue(true)
+    }
+
+    @Test
+    fun notFoundExceptionReturnsStableErrorResponse() {
+        val response = GlobalExceptionHandler()
+            .handleNotFound(NotificationNotFoundException("notice not found: id=1"))
+
+        assertEquals(HttpStatus.NOT_FOUND, response.statusCode)
+        assertEquals(404, response.body?.status)
+        assertEquals("NOTIFICATION_NOT_FOUND", response.body?.code)
+        assertEquals("notification not found", response.body?.message)
+    }
+
+    @Test
+    fun invalidRequestReturnsStableErrorResponse() {
+        val response = GlobalExceptionHandler()
+            .handleInvalidRequest(IllegalArgumentException("page must be greater than or equal to 0"))
+
+        assertEquals(HttpStatus.BAD_REQUEST, response.statusCode)
+        assertEquals(400, response.body?.status)
+        assertEquals("INVALID_REQUEST", response.body?.code)
+        assertEquals("invalid request", response.body?.message)
     }
 }

--- a/systems/notification/notification-bootstrap/BUILD.bazel
+++ b/systems/notification/notification-bootstrap/BUILD.bazel
@@ -8,7 +8,7 @@ kt_jvm_binary(
     srcs = glob(["src/main/kotlin/**/*.kt"]),
     javac_opts = "//:javac_options",
     kotlinc_opts = "//:kotlinc_options",
-    main_class = "hs.kr.entrydsm.notification.NotificationBootstrapApplicationKt",
+    main_class = "hs.kr.entrydsm.notification.ExampleApplicationKt",
     plugins = ["//:spring_allopen"],
     resources = glob(["src/main/resources/**"]),
     deps = MODULE_DEPS + [

--- a/systems/notification/notification-bootstrap/deps.bzl
+++ b/systems/notification/notification-bootstrap/deps.bzl
@@ -1,11 +1,13 @@
 SPRING_DEPS = [
     "@maven//:org_springframework_boot_spring_boot_starter_web",
     "@maven//:org_springframework_boot_spring_boot_starter_actuator",
+    "@maven//:org_springframework_boot_spring_boot_starter_data_jpa",
 ]
 
 KOTLIN_DEPS = [
     "@maven//:org_jetbrains_kotlin_kotlin_reflect",
     "@maven//:com_fasterxml_jackson_module_jackson_module_kotlin",
+    "@maven//:com_mysql_mysql_connector_j",
 ]
 
 TEST_DEPS = [

--- a/systems/notification/notification-bootstrap/src/main/resources/application-dev.yaml
+++ b/systems/notification/notification-bootstrap/src/main/resources/application-dev.yaml
@@ -1,0 +1,17 @@
+spring:
+  config:
+    activate:
+      on-profile: dev
+  datasource:
+    url: ${DB_URL}
+    username: ${DB_USERNAME}
+    password: ${DB_PASSWORD}
+    driver-class-name: com.mysql.cj.jdbc.Driver
+  jpa:
+    hibernate:
+      ddl-auto: update
+    open-in-view: false
+    show-sql: false
+    properties:
+      hibernate:
+        dialect: org.hibernate.dialect.MySQLDialect

--- a/systems/notification/notification-bootstrap/src/main/resources/application-local.yaml
+++ b/systems/notification/notification-bootstrap/src/main/resources/application-local.yaml
@@ -1,0 +1,17 @@
+spring:
+  config:
+    activate:
+      on-profile: local
+  datasource:
+    url: ${DB_URL}
+    username: ${DB_USERNAME}
+    password: ${DB_PASSWORD}
+    driver-class-name: com.mysql.cj.jdbc.Driver
+  jpa:
+    hibernate:
+      ddl-auto: update
+    open-in-view: false
+    show-sql: false
+    properties:
+      hibernate:
+        dialect: org.hibernate.dialect.MySQLDialect

--- a/systems/notification/notification-bootstrap/src/main/resources/application-prod.yaml
+++ b/systems/notification/notification-bootstrap/src/main/resources/application-prod.yaml
@@ -1,0 +1,17 @@
+spring:
+  config:
+    activate:
+      on-profile: prod
+  datasource:
+    url: ${DB_URL}
+    username: ${DB_USERNAME}
+    password: ${DB_PASSWORD}
+    driver-class-name: com.mysql.cj.jdbc.Driver
+  jpa:
+    hibernate:
+      ddl-auto: validate
+    open-in-view: false
+    show-sql: false
+    properties:
+      hibernate:
+        dialect: org.hibernate.dialect.MySQLDialect

--- a/systems/notification/notification-bootstrap/src/main/resources/application.yaml
+++ b/systems/notification/notification-bootstrap/src/main/resources/application.yaml
@@ -2,7 +2,7 @@ spring:
   application:
     name: notification
   profiles:
-    default: dev
+    default: local
   main:
     lazy-initialization: true
 
@@ -10,7 +10,7 @@ server:
   shutdown: graceful
 
 grpc:
-  port: ${GRPC_PORT:9090}
+  port: ${GRPC_PORT}
 
 management:
   endpoints:

--- a/systems/notification/notification-bootstrap/src/main/resources/application.yaml
+++ b/systems/notification/notification-bootstrap/src/main/resources/application.yaml
@@ -2,11 +2,16 @@ spring:
   application:
     name: notification
   profiles:
-    default: local
+    default: dev
   main:
     lazy-initialization: true
+
 server:
   shutdown: graceful
+
+grpc:
+  port: ${GRPC_PORT:9090}
+
 management:
   endpoints:
     web:
@@ -16,6 +21,7 @@ management:
     health:
       probes:
         enabled: true
+
 logging:
   level:
     root: INFO

--- a/systems/notification/notification-bootstrap/src/main/resources/db/migration/V028__create_notification_tables.sql
+++ b/systems/notification/notification-bootstrap/src/main/resources/db/migration/V028__create_notification_tables.sql
@@ -1,0 +1,33 @@
+CREATE TABLE IF NOT EXISTS notices (
+    id BIGINT NOT NULL AUTO_INCREMENT,
+    title VARCHAR(255) NOT NULL,
+    content TEXT NOT NULL,
+    author VARCHAR(50) NOT NULL,
+    view_count INT NOT NULL,
+    created_at DATETIME(6) NOT NULL,
+    updated_at DATETIME(6) NOT NULL,
+    PRIMARY KEY (id)
+);
+
+CREATE TABLE IF NOT EXISTS faqs (
+    id BIGINT NOT NULL AUTO_INCREMENT,
+    category VARCHAR(50) NOT NULL,
+    question VARCHAR(255) NOT NULL,
+    answer TEXT NOT NULL,
+    view_count INT NOT NULL,
+    created_at DATETIME(6) NOT NULL,
+    updated_at DATETIME(6) NOT NULL,
+    PRIMARY KEY (id)
+);
+
+CREATE TABLE IF NOT EXISTS recruitment_guidelines (
+    id BIGINT NOT NULL AUTO_INCREMENT,
+    title VARCHAR(255) NOT NULL,
+    description TEXT NOT NULL,
+    application_start DATE NOT NULL,
+    application_end DATE NOT NULL,
+    result_at DATE NOT NULL,
+    created_at DATETIME(6) NOT NULL,
+    updated_at DATETIME(6) NOT NULL,
+    PRIMARY KEY (id)
+);

--- a/systems/notification/notification-bootstrap/src/main/resources/db/migration/V028__create_notification_tables.sql
+++ b/systems/notification/notification-bootstrap/src/main/resources/db/migration/V028__create_notification_tables.sql
@@ -2,6 +2,7 @@ CREATE TABLE IF NOT EXISTS notices (
     id BIGINT NOT NULL AUTO_INCREMENT,
     title VARCHAR(255) NOT NULL,
     content TEXT NOT NULL,
+    category VARCHAR(32) NOT NULL,
     author VARCHAR(50) NOT NULL,
     view_count INT NOT NULL,
     created_at DATETIME(6) NOT NULL,


### PR DESCRIPTION
## Summary
notification 서비스의 bootstrap 실행 설정과 테스트를 정리했습니다.
dev/prod profile별 MySQL 설정을 추가했습니다.
notification bootstrap main class와 Bazel 의존성을 정리했습니다.
NotificationService 테스트를 추가했습니다.

## Related Issue
Related to  #28

## Scope
In scope:
- notification bootstrap BUILD/deps 정리
- application.yaml
- application-dev.yaml
- application-prod.yaml
- NotificationServiceTest
- Bazel test target 정리

Out of scope:
- admin 등록/수정/삭제 API
- 파일 서비스 연동
- 운영 migration 도구
- controller 통합 테스트

## Implementation
notification 기본 profile은 dev로 구성했습니다.
dev/prod 모두 MySQL datasource와 JPA 설정을 사용하도록 정리했습니다.
Bazel bootstrap main_class를 실제 Kotlin main class와 일치하도록 수정했습니다.
NotificationService의 목록/상세 조회와 not found 예외 흐름을 테스트했습니다.

## Testing
Unit tests:
- NotificationServiceTest

Manual verification:
```bash
bazel --output_user_root=C:/bazel-cache/entrydsm-tests test //systems/notification/notification-application:test --shell_executable="C:/Program Files/Git/bin/bash.exe" --jobs=2 --test_output=errors