### PR TITLE
feat(observability): observability 도메인 개발 #29

### DIFF
--- a/kotlin.MODULE.bazel
+++ b/kotlin.MODULE.bazel
@@ -24,4 +24,16 @@ maven.artifact(artifact = "protobuf-java", group = "com.google.protobuf", versio
 maven.artifact(artifact = "protobuf-kotlin", group = "com.google.protobuf", version = "4.30.2")
 maven.artifact(artifact = "javax.annotation-api", group = "javax.annotation", version = "1.3.2")
 
+# Redis
+maven.artifact(artifact = "spring-boot-starter-data-redis", group = "org.springframework.boot", version = "4.0.1")
+
+# JWT
+maven.artifact(artifact = "jjwt-api", group = "io.jsonwebtoken", version = "0.13.0")
+maven.artifact(artifact = "jjwt-impl", group = "io.jsonwebtoken", version = "0.13.0")
+maven.artifact(artifact = "jjwt-jackson", group = "io.jsonwebtoken", version = "0.13.0")
+
+# 리포트 생성 (xlsx)
+maven.artifact(artifact = "poi", group = "org.apache.poi", version = "5.4.0")
+maven.artifact(artifact = "poi-ooxml", group = "org.apache.poi", version = "5.4.0")
+
 use_repo(maven, "maven")

--- a/systems/observability/observability-adapter-in/BUILD.bazel
+++ b/systems/observability/observability-adapter-in/BUILD.bazel
@@ -17,5 +17,5 @@ kt_jvm_test(
     javac_opts = "//:javac_options",
     kotlinc_opts = "//:kotlinc_options",
     test_class = "hs.kr.entrydsm.observability.adapterin.ObservabilityAdapterInModuleTest",
-    deps = MODULE_DEPS + TEST_DEPS,
+    deps = [":main"] + MODULE_DEPS + TEST_DEPS,
 )

--- a/systems/observability/observability-adapter-in/deps.bzl
+++ b/systems/observability/observability-adapter-in/deps.bzl
@@ -4,8 +4,6 @@ KOTLIN_DEPS = [
     "@maven//:io_jsonwebtoken_jjwt_api",
     "@maven//:io_jsonwebtoken_jjwt_impl",
     "@maven//:io_jsonwebtoken_jjwt_jackson",
-    "@maven//:org_apache_poi_poi",
-    "@maven//:org_apache_poi_poi_ooxml",
     "//systems/observability/observability-application:main",
     "//systems/observability/observability-domain:main",
 ]

--- a/systems/observability/observability-adapter-in/deps.bzl
+++ b/systems/observability/observability-adapter-in/deps.bzl
@@ -10,6 +10,7 @@ KOTLIN_DEPS = [
 
 TEST_DEPS = [
     "@maven//:junit_junit",
+    "@maven//:org_springframework_boot_spring_boot_starter_test",
 ]
 
 MODULE_DEPS = KOTLIN_DEPS

--- a/systems/observability/observability-adapter-in/deps.bzl
+++ b/systems/observability/observability-adapter-in/deps.bzl
@@ -1,4 +1,14 @@
-KOTLIN_DEPS = []
+KOTLIN_DEPS = [
+    "@maven//:org_springframework_boot_spring_boot_starter_web",
+    "@maven//:org_springframework_boot_spring_boot_starter_validation",
+    "@maven//:io_jsonwebtoken_jjwt_api",
+    "@maven//:io_jsonwebtoken_jjwt_impl",
+    "@maven//:io_jsonwebtoken_jjwt_jackson",
+    "@maven//:org_apache_poi_poi",
+    "@maven//:org_apache_poi_poi_ooxml",
+    "//systems/observability/observability-application:main",
+    "//systems/observability/observability-domain:main",
+]
 
 TEST_DEPS = [
     "@maven//:junit_junit",

--- a/systems/observability/observability-adapter-in/src/main/kotlin/hs/kr/entrydsm/observability/adapterin/web/controller/ClientLogCollectController.kt
+++ b/systems/observability/observability-adapter-in/src/main/kotlin/hs/kr/entrydsm/observability/adapterin/web/controller/ClientLogCollectController.kt
@@ -1,0 +1,59 @@
+package hs.kr.entrydsm.observability.adapterin.web.controller
+
+import hs.kr.entrydsm.observability.adapterin.web.dto.common.ApiResponse
+import hs.kr.entrydsm.observability.adapterin.web.dto.common.toResponse
+import hs.kr.entrydsm.observability.adapterin.web.dto.request.ClientLogCollectRequest
+import hs.kr.entrydsm.observability.adapterin.web.dto.response.ClientLogAcceptResponse
+import hs.kr.entrydsm.observability.application.port.`in`.ClientLogItem
+import hs.kr.entrydsm.observability.application.port.`in`.RecordClientLogUseCase
+import hs.kr.entrydsm.observability.domain.enum.ErrorCode
+import hs.kr.entrydsm.observability.domain.exception.MonitorDomainException
+import jakarta.servlet.http.HttpServletRequest
+import jakarta.validation.Valid
+import org.springframework.http.HttpStatus
+import org.springframework.http.ResponseEntity
+import org.springframework.web.bind.annotation.PostMapping
+import org.springframework.web.bind.annotation.RequestBody
+import org.springframework.web.bind.annotation.RequestHeader
+import org.springframework.web.bind.annotation.RestController
+
+private const val MAX_PAYLOAD_BYTES = 64 * 1024
+
+@RestController
+class ClientLogCollectController(
+    private val recordClientLogUseCase: RecordClientLogUseCase,
+) {
+    @PostMapping("/api/monitor/v11/collect/client-log")
+    fun collect(
+        @Valid @RequestBody request: ClientLogCollectRequest,
+        @RequestHeader(value = "User-Agent", required = false) userAgent: String?,
+        httpRequest: HttpServletRequest,
+    ): ResponseEntity<ApiResponse<ClientLogAcceptResponse>> {
+        if (httpRequest.contentLengthLong > MAX_PAYLOAD_BYTES) {
+            throw MonitorDomainException(ErrorCode.PAYLOAD_TOO_LARGE)
+        }
+        val result = recordClientLogUseCase.record(
+            sessionId = request.sessionId,
+            logs = request.logs.map {
+                ClientLogItem(
+                    level = it.level,
+                    source = it.source,
+                    message = it.message,
+                    stack = it.stack,
+                    pageUrl = it.pageUrl,
+                    occurredAt = it.occurredAt,
+                )
+            },
+            userAgent = userAgent,
+            clientIp = clientIp(httpRequest),
+        )
+        return ResponseEntity.status(HttpStatus.ACCEPTED).body(ApiResponse(data = result.toResponse()))
+    }
+
+    private fun clientIp(request: HttpServletRequest): String =
+        request.getHeader("X-Forwarded-For")
+            ?.substringBefore(",")
+            ?.trim()
+            ?.takeIf { it.isNotBlank() }
+            ?: request.remoteAddr
+}

--- a/systems/observability/observability-adapter-in/src/main/kotlin/hs/kr/entrydsm/observability/adapterin/web/controller/ClientLogController.kt
+++ b/systems/observability/observability-adapter-in/src/main/kotlin/hs/kr/entrydsm/observability/adapterin/web/controller/ClientLogController.kt
@@ -1,0 +1,35 @@
+package hs.kr.entrydsm.observability.adapterin.web.controller
+
+import hs.kr.entrydsm.observability.adapterin.web.dto.common.ApiResponse
+import hs.kr.entrydsm.observability.adapterin.web.dto.common.toResponse
+import hs.kr.entrydsm.observability.adapterin.web.dto.response.ClientLogPageResponse
+import hs.kr.entrydsm.observability.application.port.`in`.GetClientLogsUseCase
+import hs.kr.entrydsm.observability.domain.enum.ErrorCode
+import hs.kr.entrydsm.observability.domain.enum.LogLevel
+import hs.kr.entrydsm.observability.domain.exception.MonitorDomainException
+import hs.kr.entrydsm.observability.domain.model.Cursor
+import java.time.Instant
+import org.springframework.web.bind.annotation.GetMapping
+import org.springframework.web.bind.annotation.RequestParam
+import org.springframework.web.bind.annotation.RestController
+
+@RestController
+class ClientLogController(
+    private val getClientLogsUseCase: GetClientLogsUseCase,
+) {
+    @GetMapping("/api/monitor/v11/logs/client")
+    fun logs(
+        @RequestParam(required = false) level: String?,
+        @RequestParam(required = false) from: Instant?,
+        @RequestParam(required = false) to: Instant?,
+        @RequestParam(defaultValue = "20") size: Int,
+        @RequestParam(required = false) cursor: String?,
+    ): ApiResponse<ClientLogPageResponse> {
+        val levels = level?.split(",")?.map {
+            runCatching { LogLevel.valueOf(it.trim()) }.getOrElse { throw MonitorDomainException(ErrorCode.INVALID_PAYLOAD) }
+        }?.toSet()
+        val decodedCursor = cursor?.let { Cursor.decode(it) }
+        val page = getClientLogsUseCase.getLogs(levels, from, to, size, decodedCursor)
+        return ApiResponse(data = page.toResponse())
+    }
+}

--- a/systems/observability/observability-adapter-in/src/main/kotlin/hs/kr/entrydsm/observability/adapterin/web/controller/DashboardController.kt
+++ b/systems/observability/observability-adapter-in/src/main/kotlin/hs/kr/entrydsm/observability/adapterin/web/controller/DashboardController.kt
@@ -1,0 +1,20 @@
+package hs.kr.entrydsm.observability.adapterin.web.controller
+
+import hs.kr.entrydsm.observability.adapterin.web.dto.common.ApiResponse
+import hs.kr.entrydsm.observability.adapterin.web.dto.common.toResponse
+import hs.kr.entrydsm.observability.adapterin.web.dto.response.DashboardSnapshotResponse
+import hs.kr.entrydsm.observability.application.port.`in`.GetDashboardSnapshotUseCase
+import org.springframework.web.bind.annotation.GetMapping
+import org.springframework.web.bind.annotation.RequestParam
+import org.springframework.web.bind.annotation.RestController
+
+@RestController
+class DashboardController(
+    private val getDashboardSnapshotUseCase: GetDashboardSnapshotUseCase,
+) {
+    @GetMapping("/api/monitor/v11/dashboard")
+    fun dashboard(
+        @RequestParam(required = false) round: String?,
+    ): ApiResponse<DashboardSnapshotResponse> =
+        ApiResponse(data = getDashboardSnapshotUseCase.getSnapshot(round).toResponse())
+}

--- a/systems/observability/observability-adapter-in/src/main/kotlin/hs/kr/entrydsm/observability/adapterin/web/controller/HealthController.kt
+++ b/systems/observability/observability-adapter-in/src/main/kotlin/hs/kr/entrydsm/observability/adapterin/web/controller/HealthController.kt
@@ -1,0 +1,17 @@
+package hs.kr.entrydsm.observability.adapterin.web.controller
+
+import hs.kr.entrydsm.observability.adapterin.web.dto.common.ApiResponse
+import hs.kr.entrydsm.observability.adapterin.web.dto.common.toResponse
+import hs.kr.entrydsm.observability.adapterin.web.dto.response.ServiceHealthResponse
+import hs.kr.entrydsm.observability.application.port.`in`.GetServiceHealthUseCase
+import org.springframework.web.bind.annotation.GetMapping
+import org.springframework.web.bind.annotation.RestController
+
+@RestController
+class HealthController(
+    private val getServiceHealthUseCase: GetServiceHealthUseCase,
+) {
+    @GetMapping("/api/monitor/v11/health")
+    fun health(): ApiResponse<ServiceHealthResponse> =
+        ApiResponse(data = getServiceHealthUseCase.getHealth().toResponse())
+}

--- a/systems/observability/observability-adapter-in/src/main/kotlin/hs/kr/entrydsm/observability/adapterin/web/controller/MetricsSeriesController.kt
+++ b/systems/observability/observability-adapter-in/src/main/kotlin/hs/kr/entrydsm/observability/adapterin/web/controller/MetricsSeriesController.kt
@@ -1,0 +1,33 @@
+package hs.kr.entrydsm.observability.adapterin.web.controller
+
+import hs.kr.entrydsm.observability.adapterin.web.dto.common.ApiResponse
+import hs.kr.entrydsm.observability.adapterin.web.dto.common.toResponse
+import hs.kr.entrydsm.observability.adapterin.web.dto.response.MetricsSeriesResponse
+import hs.kr.entrydsm.observability.application.port.`in`.GetMetricsSeriesUseCase
+import hs.kr.entrydsm.observability.domain.enum.ErrorCode
+import hs.kr.entrydsm.observability.domain.enum.MetricType
+import hs.kr.entrydsm.observability.domain.exception.MonitorDomainException
+import java.time.Instant
+import org.springframework.web.bind.annotation.GetMapping
+import org.springframework.web.bind.annotation.RequestParam
+import org.springframework.web.bind.annotation.RestController
+
+@RestController
+class MetricsSeriesController(
+    private val getMetricsSeriesUseCase: GetMetricsSeriesUseCase,
+) {
+    @GetMapping("/api/monitor/v11/metrics/series")
+    fun series(
+        @RequestParam metrics: String,
+        @RequestParam(required = false) from: Instant?,
+        @RequestParam(required = false) to: Instant?,
+        @RequestParam(required = false) interval: String?,
+    ): ApiResponse<MetricsSeriesResponse> {
+        val parsedMetrics = metrics.split(",").map { raw ->
+            runCatching { MetricType.valueOf(raw.trim()) }
+                .getOrElse { throw MonitorDomainException(ErrorCode.INVALID_METRIC) }
+        }
+        val result = getMetricsSeriesUseCase.getSeries(parsedMetrics, from, to, interval)
+        return ApiResponse(data = result.toResponse())
+    }
+}

--- a/systems/observability/observability-adapter-in/src/main/kotlin/hs/kr/entrydsm/observability/adapterin/web/controller/MonitorStreamController.kt
+++ b/systems/observability/observability-adapter-in/src/main/kotlin/hs/kr/entrydsm/observability/adapterin/web/controller/MonitorStreamController.kt
@@ -1,0 +1,43 @@
+package hs.kr.entrydsm.observability.adapterin.web.controller
+
+import hs.kr.entrydsm.observability.adapterin.web.sse.SseBroadcaster
+import hs.kr.entrydsm.observability.adapterin.web.sse.SseConnectionLimiter
+import hs.kr.entrydsm.observability.domain.enum.ErrorCode
+import hs.kr.entrydsm.observability.domain.exception.MonitorDomainException
+import jakarta.servlet.http.HttpServletRequest
+import java.util.concurrent.TimeUnit
+import org.springframework.http.MediaType
+import org.springframework.web.bind.annotation.GetMapping
+import org.springframework.web.bind.annotation.RestController
+import org.springframework.web.servlet.mvc.method.annotation.SseEmitter
+
+@RestController
+class MonitorStreamController(
+    private val sseBroadcaster: SseBroadcaster,
+    private val connectionLimiter: SseConnectionLimiter,
+) {
+    @GetMapping("/api/monitor/v11/stream", produces = [MediaType.TEXT_EVENT_STREAM_VALUE])
+    fun stream(httpRequest: HttpServletRequest): SseEmitter {
+        val clientKey = clientIp(httpRequest)
+        if (!connectionLimiter.tryAcquire(clientKey)) {
+            throw MonitorDomainException(ErrorCode.TOO_MANY_CONNECTIONS)
+        }
+        val emitter = SseEmitter(TimeUnit.MINUTES.toMillis(EMITTER_TIMEOUT_MINUTES))
+        emitter.onCompletion { connectionLimiter.release(clientKey) }
+        emitter.onTimeout { connectionLimiter.release(clientKey) }
+        emitter.onError { connectionLimiter.release(clientKey) }
+        sseBroadcaster.register(emitter)
+        return emitter
+    }
+
+    private fun clientIp(request: HttpServletRequest): String =
+        request.getHeader("X-Forwarded-For")
+            ?.substringBefore(",")
+            ?.trim()
+            ?.takeIf { it.isNotBlank() }
+            ?: request.remoteAddr
+
+    companion object {
+        private const val EMITTER_TIMEOUT_MINUTES = 30L
+    }
+}

--- a/systems/observability/observability-adapter-in/src/main/kotlin/hs/kr/entrydsm/observability/adapterin/web/controller/ReportController.kt
+++ b/systems/observability/observability-adapter-in/src/main/kotlin/hs/kr/entrydsm/observability/adapterin/web/controller/ReportController.kt
@@ -1,0 +1,27 @@
+package hs.kr.entrydsm.observability.adapterin.web.controller
+
+import hs.kr.entrydsm.observability.adapterin.web.dto.common.ApiResponse
+import hs.kr.entrydsm.observability.adapterin.web.dto.common.toResponse
+import hs.kr.entrydsm.observability.adapterin.web.dto.response.ReportGeneratedResponse
+import hs.kr.entrydsm.observability.application.port.`in`.GenerateReportUseCase
+import hs.kr.entrydsm.observability.domain.enum.ErrorCode
+import hs.kr.entrydsm.observability.domain.enum.ReportFormat
+import hs.kr.entrydsm.observability.domain.exception.MonitorDomainException
+import org.springframework.web.bind.annotation.GetMapping
+import org.springframework.web.bind.annotation.RequestParam
+import org.springframework.web.bind.annotation.RestController
+
+@RestController
+class ReportController(
+    private val generateReportUseCase: GenerateReportUseCase,
+) {
+    @GetMapping("/api/monitor/v11/reports")
+    fun generate(
+        @RequestParam(defaultValue = "xlsx") format: String,
+    ): ApiResponse<ReportGeneratedResponse> {
+        val parsedFormat = runCatching { ReportFormat.valueOf(format.trim().uppercase()) }
+            .getOrElse { throw MonitorDomainException(ErrorCode.INVALID_FORMAT) }
+        val result = generateReportUseCase.generate(parsedFormat)
+        return ApiResponse(data = result.toResponse())
+    }
+}

--- a/systems/observability/observability-adapter-in/src/main/kotlin/hs/kr/entrydsm/observability/adapterin/web/controller/ReportDownloadController.kt
+++ b/systems/observability/observability-adapter-in/src/main/kotlin/hs/kr/entrydsm/observability/adapterin/web/controller/ReportDownloadController.kt
@@ -1,0 +1,24 @@
+package hs.kr.entrydsm.observability.adapterin.web.controller
+
+import hs.kr.entrydsm.observability.application.port.out.ReportObjectStoragePort
+import org.springframework.http.HttpHeaders
+import org.springframework.http.MediaType
+import org.springframework.http.ResponseEntity
+import org.springframework.web.bind.annotation.GetMapping
+import org.springframework.web.bind.annotation.RequestParam
+import org.springframework.web.bind.annotation.RestController
+
+/** 리포트 다운로드 URL이 가리키는 실제 파일 서빙. S3 presigned URL의 로컬 대체 구현. */
+@RestController
+class ReportDownloadController(
+    private val reportObjectStoragePort: ReportObjectStoragePort,
+) {
+    @GetMapping("/api/monitor/v11/reports/download")
+    fun download(@RequestParam token: String): ResponseEntity<ByteArray> {
+        val downloaded = reportObjectStoragePort.resolve(token) ?: return ResponseEntity.notFound().build()
+        return ResponseEntity.ok()
+            .header(HttpHeaders.CONTENT_DISPOSITION, "attachment; filename=\"${downloaded.fileName}\"")
+            .contentType(MediaType.APPLICATION_OCTET_STREAM)
+            .body(downloaded.bytes)
+    }
+}

--- a/systems/observability/observability-adapter-in/src/main/kotlin/hs/kr/entrydsm/observability/adapterin/web/controller/ResourceController.kt
+++ b/systems/observability/observability-adapter-in/src/main/kotlin/hs/kr/entrydsm/observability/adapterin/web/controller/ResourceController.kt
@@ -1,0 +1,16 @@
+package hs.kr.entrydsm.observability.adapterin.web.controller
+
+import hs.kr.entrydsm.observability.adapterin.web.dto.common.ApiResponse
+import hs.kr.entrydsm.observability.adapterin.web.dto.common.toResponse
+import hs.kr.entrydsm.observability.adapterin.web.dto.response.StorageUsageResponse
+import hs.kr.entrydsm.observability.application.port.`in`.GetStorageUsageUseCase
+import org.springframework.web.bind.annotation.GetMapping
+import org.springframework.web.bind.annotation.RestController
+
+@RestController
+class ResourceController(
+    private val getStorageUsageUseCase: GetStorageUsageUseCase,
+) {
+    @GetMapping("/api/monitor/v11/resources")
+    fun resources(): ApiResponse<StorageUsageResponse> = ApiResponse(data = getStorageUsageUseCase.getUsage().toResponse())
+}

--- a/systems/observability/observability-adapter-in/src/main/kotlin/hs/kr/entrydsm/observability/adapterin/web/controller/ServerLogController.kt
+++ b/systems/observability/observability-adapter-in/src/main/kotlin/hs/kr/entrydsm/observability/adapterin/web/controller/ServerLogController.kt
@@ -1,0 +1,36 @@
+package hs.kr.entrydsm.observability.adapterin.web.controller
+
+import hs.kr.entrydsm.observability.adapterin.web.dto.common.ApiResponse
+import hs.kr.entrydsm.observability.adapterin.web.dto.common.toResponse
+import hs.kr.entrydsm.observability.adapterin.web.dto.response.ServerLogPageResponse
+import hs.kr.entrydsm.observability.application.port.`in`.GetServerLogsUseCase
+import hs.kr.entrydsm.observability.domain.enum.ErrorCode
+import hs.kr.entrydsm.observability.domain.enum.ServiceName
+import hs.kr.entrydsm.observability.domain.exception.MonitorDomainException
+import hs.kr.entrydsm.observability.domain.model.Cursor
+import java.time.Instant
+import org.springframework.web.bind.annotation.GetMapping
+import org.springframework.web.bind.annotation.RequestParam
+import org.springframework.web.bind.annotation.RestController
+
+@RestController
+class ServerLogController(
+    private val getServerLogsUseCase: GetServerLogsUseCase,
+) {
+    @GetMapping("/api/monitor/v11/logs/server")
+    fun logs(
+        @RequestParam(required = false) service: String?,
+        @RequestParam(required = false) status: String?,
+        @RequestParam(required = false) from: Instant?,
+        @RequestParam(required = false) to: Instant?,
+        @RequestParam(defaultValue = "20") size: Int,
+        @RequestParam(required = false) cursor: String?,
+    ): ApiResponse<ServerLogPageResponse> {
+        val resolvedService = service?.let {
+            runCatching { ServiceName.valueOf(it.trim()) }.getOrElse { throw MonitorDomainException(ErrorCode.INVALID_SERVICE) }
+        }
+        val decodedCursor = cursor?.let { Cursor.decode(it) }
+        val page = getServerLogsUseCase.getLogs(resolvedService, status, from, to, size, decodedCursor)
+        return ApiResponse(data = page.toResponse())
+    }
+}

--- a/systems/observability/observability-adapter-in/src/main/kotlin/hs/kr/entrydsm/observability/adapterin/web/controller/SessionCollectController.kt
+++ b/systems/observability/observability-adapter-in/src/main/kotlin/hs/kr/entrydsm/observability/adapterin/web/controller/SessionCollectController.kt
@@ -1,0 +1,43 @@
+package hs.kr.entrydsm.observability.adapterin.web.controller
+
+import hs.kr.entrydsm.observability.adapterin.web.dto.common.ApiResponse
+import hs.kr.entrydsm.observability.adapterin.web.dto.common.toResponse
+import hs.kr.entrydsm.observability.adapterin.web.dto.request.SessionEventRequest
+import hs.kr.entrydsm.observability.adapterin.web.dto.response.SessionEventResponse
+import hs.kr.entrydsm.observability.application.port.`in`.RecordSessionEventUseCase
+import jakarta.servlet.http.HttpServletRequest
+import jakarta.validation.Valid
+import org.springframework.http.HttpStatus
+import org.springframework.http.ResponseEntity
+import org.springframework.web.bind.annotation.PostMapping
+import org.springframework.web.bind.annotation.RequestBody
+import org.springframework.web.bind.annotation.RequestHeader
+import org.springframework.web.bind.annotation.RestController
+
+@RestController
+class SessionCollectController(
+    private val recordSessionEventUseCase: RecordSessionEventUseCase,
+) {
+    @PostMapping("/api/monitor/v11/collect/session")
+    fun collect(
+        @Valid @RequestBody request: SessionEventRequest,
+        @RequestHeader(value = "User-Agent", required = false) userAgent: String?,
+        httpRequest: HttpServletRequest,
+    ): ResponseEntity<ApiResponse<SessionEventResponse>> {
+        val result = recordSessionEventUseCase.record(
+            event = request.event,
+            sessionId = request.sessionId,
+            service = request.service,
+            userAgent = userAgent,
+            clientIp = clientIp(httpRequest),
+        )
+        return ResponseEntity.status(HttpStatus.ACCEPTED).body(ApiResponse(data = result.toResponse()))
+    }
+
+    private fun clientIp(request: HttpServletRequest): String =
+        request.getHeader("X-Forwarded-For")
+            ?.substringBefore(",")
+            ?.trim()
+            ?.takeIf { it.isNotBlank() }
+            ?: request.remoteAddr
+}

--- a/systems/observability/observability-adapter-in/src/main/kotlin/hs/kr/entrydsm/observability/adapterin/web/dto/common/ApiResponse.kt
+++ b/systems/observability/observability-adapter-in/src/main/kotlin/hs/kr/entrydsm/observability/adapterin/web/dto/common/ApiResponse.kt
@@ -1,0 +1,7 @@
+package hs.kr.entrydsm.observability.adapterin.web.dto.common
+
+data class ApiResponse<T>(
+    val success: Boolean = true,
+    val data: T?,
+    val error: ErrorDetail? = null,
+)

--- a/systems/observability/observability-adapter-in/src/main/kotlin/hs/kr/entrydsm/observability/adapterin/web/dto/common/ErrorDetail.kt
+++ b/systems/observability/observability-adapter-in/src/main/kotlin/hs/kr/entrydsm/observability/adapterin/web/dto/common/ErrorDetail.kt
@@ -1,0 +1,17 @@
+package hs.kr.entrydsm.observability.adapterin.web.dto.common
+
+import hs.kr.entrydsm.observability.domain.enum.ErrorCode
+
+data class ErrorDetail(
+    val code: String,
+    val message: String,
+    val status: Int,
+) {
+    companion object {
+        fun from(errorCode: ErrorCode) = ErrorDetail(
+            errorCode.name,
+            errorCode.message,
+            errorCode.status,
+        )
+    }
+}

--- a/systems/observability/observability-adapter-in/src/main/kotlin/hs/kr/entrydsm/observability/adapterin/web/dto/common/ErrorResponse.kt
+++ b/systems/observability/observability-adapter-in/src/main/kotlin/hs/kr/entrydsm/observability/adapterin/web/dto/common/ErrorResponse.kt
@@ -1,0 +1,9 @@
+package hs.kr.entrydsm.observability.adapterin.web.dto.common
+
+import java.time.Instant
+
+data class ErrorResponse(
+    val success: Boolean = false,
+    val error: ErrorDetail,
+    val timestamp: Instant = Instant.now(),
+)

--- a/systems/observability/observability-adapter-in/src/main/kotlin/hs/kr/entrydsm/observability/adapterin/web/dto/common/ResponseMapper.kt
+++ b/systems/observability/observability-adapter-in/src/main/kotlin/hs/kr/entrydsm/observability/adapterin/web/dto/common/ResponseMapper.kt
@@ -20,6 +20,7 @@ import hs.kr.entrydsm.observability.adapterin.web.dto.response.ServerLogItemResp
 import hs.kr.entrydsm.observability.adapterin.web.dto.response.ServerLogPageResponse
 import hs.kr.entrydsm.observability.adapterin.web.dto.response.ServiceActivityItemResponse
 import hs.kr.entrydsm.observability.adapterin.web.dto.response.ServiceActivityResponse
+import hs.kr.entrydsm.observability.adapterin.web.dto.response.ReportGeneratedResponse
 import hs.kr.entrydsm.observability.adapterin.web.dto.response.ServiceHealthItemResponse
 import hs.kr.entrydsm.observability.adapterin.web.dto.response.ServiceHealthResponse
 import hs.kr.entrydsm.observability.adapterin.web.dto.response.SessionEventResponse
@@ -48,6 +49,7 @@ import hs.kr.entrydsm.observability.application.port.`in`.result.ResourceUsageBr
 import hs.kr.entrydsm.observability.application.port.`in`.result.ServiceActivityItemResult
 import hs.kr.entrydsm.observability.application.port.`in`.result.ServiceActivityResult
 import hs.kr.entrydsm.observability.application.port.`in`.result.ServiceHealthItemResult
+import hs.kr.entrydsm.observability.application.port.`in`.result.ReportResult
 import hs.kr.entrydsm.observability.application.port.`in`.result.ServiceHealthResult
 import hs.kr.entrydsm.observability.application.port.`in`.result.SessionEventResult
 import hs.kr.entrydsm.observability.application.port.`in`.result.TrafficResult
@@ -194,3 +196,12 @@ fun DatabaseUsageResult.toResponse(): DatabaseUsageResponse =
 
 fun BucketUsageResult.toResponse(): BucketUsageResponse =
     BucketUsageResponse(usedBytes = usedBytes, objectCount = objectCount, measuredAt = measuredAt)
+
+fun ReportResult.toResponse(): ReportGeneratedResponse =
+    ReportGeneratedResponse(
+        status = "READY",
+        downloadUrl = downloadUrl,
+        fileName = fileName,
+        sizeBytes = sizeBytes,
+        expiresAt = expiresAt,
+    )

--- a/systems/observability/observability-adapter-in/src/main/kotlin/hs/kr/entrydsm/observability/adapterin/web/dto/common/ResponseMapper.kt
+++ b/systems/observability/observability-adapter-in/src/main/kotlin/hs/kr/entrydsm/observability/adapterin/web/dto/common/ResponseMapper.kt
@@ -23,6 +23,9 @@ import hs.kr.entrydsm.observability.adapterin.web.dto.response.ServiceActivityRe
 import hs.kr.entrydsm.observability.adapterin.web.dto.response.ServiceHealthItemResponse
 import hs.kr.entrydsm.observability.adapterin.web.dto.response.ServiceHealthResponse
 import hs.kr.entrydsm.observability.adapterin.web.dto.response.SessionEventResponse
+import hs.kr.entrydsm.observability.adapterin.web.dto.response.BucketUsageResponse
+import hs.kr.entrydsm.observability.adapterin.web.dto.response.DatabaseUsageResponse
+import hs.kr.entrydsm.observability.adapterin.web.dto.response.StorageUsageResponse
 import hs.kr.entrydsm.observability.adapterin.web.dto.response.TrafficResponse
 import hs.kr.entrydsm.observability.application.port.`in`.result.ApiStatsResult
 import hs.kr.entrydsm.observability.application.port.`in`.result.BusinessStatsResult
@@ -48,6 +51,9 @@ import hs.kr.entrydsm.observability.application.port.`in`.result.ServiceHealthIt
 import hs.kr.entrydsm.observability.application.port.`in`.result.ServiceHealthResult
 import hs.kr.entrydsm.observability.application.port.`in`.result.SessionEventResult
 import hs.kr.entrydsm.observability.application.port.`in`.result.TrafficResult
+import hs.kr.entrydsm.observability.application.port.`in`.result.BucketUsageResult
+import hs.kr.entrydsm.observability.application.port.`in`.result.DatabaseUsageResult
+import hs.kr.entrydsm.observability.application.port.`in`.result.StorageUsageResult
 
 fun SessionEventResult.toResponse(): SessionEventResponse =
     SessionEventResponse(sessionId = sessionId, heartbeatIntervalSeconds = heartbeatIntervalSeconds)
@@ -179,3 +185,12 @@ fun ServerLogEntry.toResponse(): ServerLogItemResponse =
         firstOccurredAt = firstOccurredAt,
         lastOccurredAt = lastOccurredAt,
     )
+
+fun StorageUsageResult.toResponse(): StorageUsageResponse =
+    StorageUsageResponse(database = database.toResponse(), bucket = bucket.toResponse(), cacheTtlSeconds = cacheTtlSeconds)
+
+fun DatabaseUsageResult.toResponse(): DatabaseUsageResponse =
+    DatabaseUsageResponse(usedBytes = usedBytes, totalBytes = totalBytes, usageRatio = usageRatio, measuredAt = measuredAt)
+
+fun BucketUsageResult.toResponse(): BucketUsageResponse =
+    BucketUsageResponse(usedBytes = usedBytes, objectCount = objectCount, measuredAt = measuredAt)

--- a/systems/observability/observability-adapter-in/src/main/kotlin/hs/kr/entrydsm/observability/adapterin/web/dto/common/ResponseMapper.kt
+++ b/systems/observability/observability-adapter-in/src/main/kotlin/hs/kr/entrydsm/observability/adapterin/web/dto/common/ResponseMapper.kt
@@ -1,7 +1,33 @@
 package hs.kr.entrydsm.observability.adapterin.web.dto.common
 
+import hs.kr.entrydsm.observability.adapterin.web.dto.response.DependencyStatusResponse
+import hs.kr.entrydsm.observability.adapterin.web.dto.response.ServiceHealthItemResponse
+import hs.kr.entrydsm.observability.adapterin.web.dto.response.ServiceHealthResponse
 import hs.kr.entrydsm.observability.adapterin.web.dto.response.SessionEventResponse
+import hs.kr.entrydsm.observability.application.port.`in`.result.DependencyStatusResult
+import hs.kr.entrydsm.observability.application.port.`in`.result.ServiceHealthItemResult
+import hs.kr.entrydsm.observability.application.port.`in`.result.ServiceHealthResult
 import hs.kr.entrydsm.observability.application.port.`in`.result.SessionEventResult
 
 fun SessionEventResult.toResponse(): SessionEventResponse =
     SessionEventResponse(sessionId = sessionId, heartbeatIntervalSeconds = heartbeatIntervalSeconds)
+
+fun ServiceHealthResult.toResponse(): ServiceHealthResponse =
+    ServiceHealthResponse(
+        overall = overall,
+        checkedAt = checkedAt,
+        services = services.map { it.toResponse() },
+    )
+
+fun ServiceHealthItemResult.toResponse(): ServiceHealthItemResponse =
+    ServiceHealthItemResponse(
+        service = service,
+        label = label,
+        status = status,
+        responseTimeMs = responseTimeMs,
+        version = version,
+        dependencies = dependencies.map { it.toResponse() },
+    )
+
+fun DependencyStatusResult.toResponse(): DependencyStatusResponse =
+    DependencyStatusResponse(name = name, status = status)

--- a/systems/observability/observability-adapter-in/src/main/kotlin/hs/kr/entrydsm/observability/adapterin/web/dto/common/ResponseMapper.kt
+++ b/systems/observability/observability-adapter-in/src/main/kotlin/hs/kr/entrydsm/observability/adapterin/web/dto/common/ResponseMapper.kt
@@ -16,6 +16,8 @@ import hs.kr.entrydsm.observability.adapterin.web.dto.response.MetricsSeriesResp
 import hs.kr.entrydsm.observability.adapterin.web.dto.response.OutcomeCountResponse
 import hs.kr.entrydsm.observability.adapterin.web.dto.response.PeriodResponse
 import hs.kr.entrydsm.observability.adapterin.web.dto.response.ResourceUsageBriefResponse
+import hs.kr.entrydsm.observability.adapterin.web.dto.response.ServerLogItemResponse
+import hs.kr.entrydsm.observability.adapterin.web.dto.response.ServerLogPageResponse
 import hs.kr.entrydsm.observability.adapterin.web.dto.response.ServiceActivityItemResponse
 import hs.kr.entrydsm.observability.adapterin.web.dto.response.ServiceActivityResponse
 import hs.kr.entrydsm.observability.adapterin.web.dto.response.ServiceHealthItemResponse
@@ -28,6 +30,8 @@ import hs.kr.entrydsm.observability.application.port.`in`.result.ClientLogAccept
 import hs.kr.entrydsm.observability.application.port.`in`.result.ClientLogCountResult
 import hs.kr.entrydsm.observability.application.port.out.ClientLogEntry
 import hs.kr.entrydsm.observability.application.port.out.ClientLogPage
+import hs.kr.entrydsm.observability.application.port.out.ServerLogEntry
+import hs.kr.entrydsm.observability.application.port.out.ServerLogPage
 import hs.kr.entrydsm.observability.application.port.`in`.result.ConcurrentResult
 import hs.kr.entrydsm.observability.application.port.`in`.result.DashboardSnapshotResult
 import hs.kr.entrydsm.observability.application.port.`in`.result.DependencyStatusResult
@@ -148,6 +152,29 @@ fun ClientLogEntry.toResponse(): ClientLogItemResponse =
         pageUrl = pageUrl,
         browser = browser,
         os = os,
+        count = count,
+        firstOccurredAt = firstOccurredAt,
+        lastOccurredAt = lastOccurredAt,
+    )
+
+fun ServerLogPage.toResponse(): ServerLogPageResponse =
+    ServerLogPageResponse(
+        totalCount = totalCount,
+        items = items.map { it.toResponse() },
+        nextCursor = nextCursor?.encode(),
+        hasNext = hasNext,
+    )
+
+fun ServerLogEntry.toResponse(): ServerLogItemResponse =
+    ServerLogItemResponse(
+        fingerprint = fingerprint,
+        service = service,
+        method = method,
+        path = path,
+        status = status,
+        code = code,
+        grpcStatus = grpcStatus,
+        message = message,
         count = count,
         firstOccurredAt = firstOccurredAt,
         lastOccurredAt = lastOccurredAt,

--- a/systems/observability/observability-adapter-in/src/main/kotlin/hs/kr/entrydsm/observability/adapterin/web/dto/common/ResponseMapper.kt
+++ b/systems/observability/observability-adapter-in/src/main/kotlin/hs/kr/entrydsm/observability/adapterin/web/dto/common/ResponseMapper.kt
@@ -2,6 +2,7 @@ package hs.kr.entrydsm.observability.adapterin.web.dto.common
 
 import hs.kr.entrydsm.observability.adapterin.web.dto.response.ApiStatsResponse
 import hs.kr.entrydsm.observability.adapterin.web.dto.response.BusinessStatsResponse
+import hs.kr.entrydsm.observability.adapterin.web.dto.response.ClientLogAcceptResponse
 import hs.kr.entrydsm.observability.adapterin.web.dto.response.ClientLogCountResponse
 import hs.kr.entrydsm.observability.adapterin.web.dto.response.ConcurrentResponse
 import hs.kr.entrydsm.observability.adapterin.web.dto.response.DashboardSnapshotResponse
@@ -21,6 +22,7 @@ import hs.kr.entrydsm.observability.adapterin.web.dto.response.SessionEventRespo
 import hs.kr.entrydsm.observability.adapterin.web.dto.response.TrafficResponse
 import hs.kr.entrydsm.observability.application.port.`in`.result.ApiStatsResult
 import hs.kr.entrydsm.observability.application.port.`in`.result.BusinessStatsResult
+import hs.kr.entrydsm.observability.application.port.`in`.result.ClientLogAcceptResult
 import hs.kr.entrydsm.observability.application.port.`in`.result.ClientLogCountResult
 import hs.kr.entrydsm.observability.application.port.`in`.result.ConcurrentResult
 import hs.kr.entrydsm.observability.application.port.`in`.result.DashboardSnapshotResult
@@ -120,3 +122,5 @@ fun MetricSeriesResult.toResponse(): MetricSeriesResponse =
     MetricSeriesResponse(metric = metric, points = points.map { it.toResponse() })
 
 fun MetricPointResult.toResponse(): MetricPointResponse = MetricPointResponse(t = t, v = v)
+
+fun ClientLogAcceptResult.toResponse(): ClientLogAcceptResponse = ClientLogAcceptResponse(accepted = accepted, rejected = rejected)

--- a/systems/observability/observability-adapter-in/src/main/kotlin/hs/kr/entrydsm/observability/adapterin/web/dto/common/ResponseMapper.kt
+++ b/systems/observability/observability-adapter-in/src/main/kotlin/hs/kr/entrydsm/observability/adapterin/web/dto/common/ResponseMapper.kt
@@ -7,6 +7,9 @@ import hs.kr.entrydsm.observability.adapterin.web.dto.response.ConcurrentRespons
 import hs.kr.entrydsm.observability.adapterin.web.dto.response.DashboardSnapshotResponse
 import hs.kr.entrydsm.observability.adapterin.web.dto.response.DependencyStatusResponse
 import hs.kr.entrydsm.observability.adapterin.web.dto.response.DeviceStatResponse
+import hs.kr.entrydsm.observability.adapterin.web.dto.response.MetricPointResponse
+import hs.kr.entrydsm.observability.adapterin.web.dto.response.MetricSeriesResponse
+import hs.kr.entrydsm.observability.adapterin.web.dto.response.MetricsSeriesResponse
 import hs.kr.entrydsm.observability.adapterin.web.dto.response.OutcomeCountResponse
 import hs.kr.entrydsm.observability.adapterin.web.dto.response.PeriodResponse
 import hs.kr.entrydsm.observability.adapterin.web.dto.response.ResourceUsageBriefResponse
@@ -23,6 +26,9 @@ import hs.kr.entrydsm.observability.application.port.`in`.result.ConcurrentResul
 import hs.kr.entrydsm.observability.application.port.`in`.result.DashboardSnapshotResult
 import hs.kr.entrydsm.observability.application.port.`in`.result.DependencyStatusResult
 import hs.kr.entrydsm.observability.application.port.`in`.result.DeviceStatResult
+import hs.kr.entrydsm.observability.application.port.`in`.result.MetricPointResult
+import hs.kr.entrydsm.observability.application.port.`in`.result.MetricSeriesResult
+import hs.kr.entrydsm.observability.application.port.`in`.result.MetricsSeriesResult
 import hs.kr.entrydsm.observability.application.port.`in`.result.OutcomeCountResult
 import hs.kr.entrydsm.observability.application.port.`in`.result.PeriodResult
 import hs.kr.entrydsm.observability.application.port.`in`.result.ResourceUsageBriefResult
@@ -106,3 +112,11 @@ fun ClientLogCountResult.toResponse(): ClientLogCountResponse =
 
 fun ResourceUsageBriefResult.toResponse(): ResourceUsageBriefResponse =
     ResourceUsageBriefResponse(dbUsedBytes = dbUsedBytes, bucketUsedBytes = bucketUsedBytes, measuredAt = measuredAt)
+
+fun MetricsSeriesResult.toResponse(): MetricsSeriesResponse =
+    MetricsSeriesResponse(from = from, to = to, interval = interval, series = series.map { it.toResponse() })
+
+fun MetricSeriesResult.toResponse(): MetricSeriesResponse =
+    MetricSeriesResponse(metric = metric, points = points.map { it.toResponse() })
+
+fun MetricPointResult.toResponse(): MetricPointResponse = MetricPointResponse(t = t, v = v)

--- a/systems/observability/observability-adapter-in/src/main/kotlin/hs/kr/entrydsm/observability/adapterin/web/dto/common/ResponseMapper.kt
+++ b/systems/observability/observability-adapter-in/src/main/kotlin/hs/kr/entrydsm/observability/adapterin/web/dto/common/ResponseMapper.kt
@@ -1,13 +1,37 @@
 package hs.kr.entrydsm.observability.adapterin.web.dto.common
 
+import hs.kr.entrydsm.observability.adapterin.web.dto.response.ApiStatsResponse
+import hs.kr.entrydsm.observability.adapterin.web.dto.response.BusinessStatsResponse
+import hs.kr.entrydsm.observability.adapterin.web.dto.response.ClientLogCountResponse
+import hs.kr.entrydsm.observability.adapterin.web.dto.response.ConcurrentResponse
+import hs.kr.entrydsm.observability.adapterin.web.dto.response.DashboardSnapshotResponse
 import hs.kr.entrydsm.observability.adapterin.web.dto.response.DependencyStatusResponse
+import hs.kr.entrydsm.observability.adapterin.web.dto.response.DeviceStatResponse
+import hs.kr.entrydsm.observability.adapterin.web.dto.response.OutcomeCountResponse
+import hs.kr.entrydsm.observability.adapterin.web.dto.response.PeriodResponse
+import hs.kr.entrydsm.observability.adapterin.web.dto.response.ResourceUsageBriefResponse
+import hs.kr.entrydsm.observability.adapterin.web.dto.response.ServiceActivityItemResponse
+import hs.kr.entrydsm.observability.adapterin.web.dto.response.ServiceActivityResponse
 import hs.kr.entrydsm.observability.adapterin.web.dto.response.ServiceHealthItemResponse
 import hs.kr.entrydsm.observability.adapterin.web.dto.response.ServiceHealthResponse
 import hs.kr.entrydsm.observability.adapterin.web.dto.response.SessionEventResponse
+import hs.kr.entrydsm.observability.adapterin.web.dto.response.TrafficResponse
+import hs.kr.entrydsm.observability.application.port.`in`.result.ApiStatsResult
+import hs.kr.entrydsm.observability.application.port.`in`.result.BusinessStatsResult
+import hs.kr.entrydsm.observability.application.port.`in`.result.ClientLogCountResult
+import hs.kr.entrydsm.observability.application.port.`in`.result.ConcurrentResult
+import hs.kr.entrydsm.observability.application.port.`in`.result.DashboardSnapshotResult
 import hs.kr.entrydsm.observability.application.port.`in`.result.DependencyStatusResult
+import hs.kr.entrydsm.observability.application.port.`in`.result.DeviceStatResult
+import hs.kr.entrydsm.observability.application.port.`in`.result.OutcomeCountResult
+import hs.kr.entrydsm.observability.application.port.`in`.result.PeriodResult
+import hs.kr.entrydsm.observability.application.port.`in`.result.ResourceUsageBriefResult
+import hs.kr.entrydsm.observability.application.port.`in`.result.ServiceActivityItemResult
+import hs.kr.entrydsm.observability.application.port.`in`.result.ServiceActivityResult
 import hs.kr.entrydsm.observability.application.port.`in`.result.ServiceHealthItemResult
 import hs.kr.entrydsm.observability.application.port.`in`.result.ServiceHealthResult
 import hs.kr.entrydsm.observability.application.port.`in`.result.SessionEventResult
+import hs.kr.entrydsm.observability.application.port.`in`.result.TrafficResult
 
 fun SessionEventResult.toResponse(): SessionEventResponse =
     SessionEventResponse(sessionId = sessionId, heartbeatIntervalSeconds = heartbeatIntervalSeconds)
@@ -31,3 +55,54 @@ fun ServiceHealthItemResult.toResponse(): ServiceHealthItemResponse =
 
 fun DependencyStatusResult.toResponse(): DependencyStatusResponse =
     DependencyStatusResponse(name = name, status = status)
+
+fun DashboardSnapshotResult.toResponse(): DashboardSnapshotResponse =
+    DashboardSnapshotResponse(
+        generatedAt = generatedAt,
+        period = period.toResponse(),
+        traffic = traffic.toResponse(),
+        api = api.toResponse(),
+        business = business.toResponse(),
+        services = services.toResponse(),
+        clientLog = clientLog.toResponse(),
+        resource = resource.toResponse(),
+    )
+
+fun PeriodResult.toResponse(): PeriodResponse = PeriodResponse(type = type, round = round, from = from, to = to)
+
+fun TrafficResult.toResponse(): TrafficResponse =
+    TrafficResponse(
+        totalVisitors = totalVisitors,
+        concurrent = concurrent.toResponse(),
+        avgSessionDurationSeconds = avgSessionDurationSeconds,
+        devices = devices.map { it.toResponse() },
+    )
+
+fun ConcurrentResult.toResponse(): ConcurrentResponse = ConcurrentResponse(current = current, max = max, avg = avg)
+
+fun DeviceStatResult.toResponse(): DeviceStatResponse = DeviceStatResponse(type = type, count = count, ratio = ratio)
+
+fun ApiStatsResult.toResponse(): ApiStatsResponse =
+    ApiStatsResponse(
+        totalRequests = totalRequests,
+        successCount = successCount,
+        failureCount = failureCount,
+        failureRate = failureRate,
+    )
+
+fun BusinessStatsResult.toResponse(): BusinessStatsResponse =
+    BusinessStatsResponse(applicationSubmit = applicationSubmit.toResponse(), pdfDownload = pdfDownload.toResponse())
+
+fun OutcomeCountResult.toResponse(): OutcomeCountResponse = OutcomeCountResponse(success = success, failure = failure)
+
+fun ServiceActivityResult.toResponse(): ServiceActivityResponse =
+    ServiceActivityResponse(windowSeconds = windowSeconds, items = items.map { it.toResponse() })
+
+fun ServiceActivityItemResult.toResponse(): ServiceActivityItemResponse =
+    ServiceActivityItemResponse(service = service, label = label, activeUsers = activeUsers, status = status)
+
+fun ClientLogCountResult.toResponse(): ClientLogCountResponse =
+    ClientLogCountResponse(errorCount = errorCount, warnCount = warnCount)
+
+fun ResourceUsageBriefResult.toResponse(): ResourceUsageBriefResponse =
+    ResourceUsageBriefResponse(dbUsedBytes = dbUsedBytes, bucketUsedBytes = bucketUsedBytes, measuredAt = measuredAt)

--- a/systems/observability/observability-adapter-in/src/main/kotlin/hs/kr/entrydsm/observability/adapterin/web/dto/common/ResponseMapper.kt
+++ b/systems/observability/observability-adapter-in/src/main/kotlin/hs/kr/entrydsm/observability/adapterin/web/dto/common/ResponseMapper.kt
@@ -1,0 +1,7 @@
+package hs.kr.entrydsm.observability.adapterin.web.dto.common
+
+import hs.kr.entrydsm.observability.adapterin.web.dto.response.SessionEventResponse
+import hs.kr.entrydsm.observability.application.port.`in`.result.SessionEventResult
+
+fun SessionEventResult.toResponse(): SessionEventResponse =
+    SessionEventResponse(sessionId = sessionId, heartbeatIntervalSeconds = heartbeatIntervalSeconds)

--- a/systems/observability/observability-adapter-in/src/main/kotlin/hs/kr/entrydsm/observability/adapterin/web/dto/common/ResponseMapper.kt
+++ b/systems/observability/observability-adapter-in/src/main/kotlin/hs/kr/entrydsm/observability/adapterin/web/dto/common/ResponseMapper.kt
@@ -4,6 +4,8 @@ import hs.kr.entrydsm.observability.adapterin.web.dto.response.ApiStatsResponse
 import hs.kr.entrydsm.observability.adapterin.web.dto.response.BusinessStatsResponse
 import hs.kr.entrydsm.observability.adapterin.web.dto.response.ClientLogAcceptResponse
 import hs.kr.entrydsm.observability.adapterin.web.dto.response.ClientLogCountResponse
+import hs.kr.entrydsm.observability.adapterin.web.dto.response.ClientLogItemResponse
+import hs.kr.entrydsm.observability.adapterin.web.dto.response.ClientLogPageResponse
 import hs.kr.entrydsm.observability.adapterin.web.dto.response.ConcurrentResponse
 import hs.kr.entrydsm.observability.adapterin.web.dto.response.DashboardSnapshotResponse
 import hs.kr.entrydsm.observability.adapterin.web.dto.response.DependencyStatusResponse
@@ -24,6 +26,8 @@ import hs.kr.entrydsm.observability.application.port.`in`.result.ApiStatsResult
 import hs.kr.entrydsm.observability.application.port.`in`.result.BusinessStatsResult
 import hs.kr.entrydsm.observability.application.port.`in`.result.ClientLogAcceptResult
 import hs.kr.entrydsm.observability.application.port.`in`.result.ClientLogCountResult
+import hs.kr.entrydsm.observability.application.port.out.ClientLogEntry
+import hs.kr.entrydsm.observability.application.port.out.ClientLogPage
 import hs.kr.entrydsm.observability.application.port.`in`.result.ConcurrentResult
 import hs.kr.entrydsm.observability.application.port.`in`.result.DashboardSnapshotResult
 import hs.kr.entrydsm.observability.application.port.`in`.result.DependencyStatusResult
@@ -124,3 +128,27 @@ fun MetricSeriesResult.toResponse(): MetricSeriesResponse =
 fun MetricPointResult.toResponse(): MetricPointResponse = MetricPointResponse(t = t, v = v)
 
 fun ClientLogAcceptResult.toResponse(): ClientLogAcceptResponse = ClientLogAcceptResponse(accepted = accepted, rejected = rejected)
+
+fun ClientLogPage.toResponse(): ClientLogPageResponse =
+    ClientLogPageResponse(
+        totalCount = totalCount,
+        errorCount = errorCount,
+        warnCount = warnCount,
+        items = items.map { it.toResponse() },
+        nextCursor = nextCursor?.encode(),
+        hasNext = hasNext,
+    )
+
+fun ClientLogEntry.toResponse(): ClientLogItemResponse =
+    ClientLogItemResponse(
+        fingerprint = fingerprint,
+        level = level,
+        message = message,
+        source = source,
+        pageUrl = pageUrl,
+        browser = browser,
+        os = os,
+        count = count,
+        firstOccurredAt = firstOccurredAt,
+        lastOccurredAt = lastOccurredAt,
+    )

--- a/systems/observability/observability-adapter-in/src/main/kotlin/hs/kr/entrydsm/observability/adapterin/web/dto/request/ClientLogCollectRequest.kt
+++ b/systems/observability/observability-adapter-in/src/main/kotlin/hs/kr/entrydsm/observability/adapterin/web/dto/request/ClientLogCollectRequest.kt
@@ -1,0 +1,22 @@
+package hs.kr.entrydsm.observability.adapterin.web.dto.request
+
+import hs.kr.entrydsm.observability.domain.enum.LogLevel
+import hs.kr.entrydsm.observability.domain.enum.LogSource
+import jakarta.validation.constraints.NotBlank
+import jakarta.validation.constraints.NotEmpty
+import jakarta.validation.constraints.NotNull
+import java.time.Instant
+
+data class ClientLogCollectRequest(
+    @field:NotBlank val sessionId: String,
+    @field:NotEmpty val logs: List<ClientLogItemRequest>,
+)
+
+data class ClientLogItemRequest(
+    @field:NotNull val level: LogLevel,
+    @field:NotNull val source: LogSource,
+    @field:NotBlank val message: String,
+    val stack: String?,
+    @field:NotBlank val pageUrl: String,
+    @field:NotNull val occurredAt: Instant,
+)

--- a/systems/observability/observability-adapter-in/src/main/kotlin/hs/kr/entrydsm/observability/adapterin/web/dto/request/SessionEventRequest.kt
+++ b/systems/observability/observability-adapter-in/src/main/kotlin/hs/kr/entrydsm/observability/adapterin/web/dto/request/SessionEventRequest.kt
@@ -1,0 +1,12 @@
+package hs.kr.entrydsm.observability.adapterin.web.dto.request
+
+import hs.kr.entrydsm.observability.domain.enum.ServiceName
+import hs.kr.entrydsm.observability.domain.enum.SessionEventType
+import jakarta.validation.constraints.NotNull
+
+data class SessionEventRequest(
+    @field:NotNull val event: SessionEventType,
+    val sessionId: String?,
+    @field:NotNull val service: ServiceName,
+    val pageUrl: String?,
+)

--- a/systems/observability/observability-adapter-in/src/main/kotlin/hs/kr/entrydsm/observability/adapterin/web/dto/response/ClientLogAcceptResponse.kt
+++ b/systems/observability/observability-adapter-in/src/main/kotlin/hs/kr/entrydsm/observability/adapterin/web/dto/response/ClientLogAcceptResponse.kt
@@ -1,0 +1,3 @@
+package hs.kr.entrydsm.observability.adapterin.web.dto.response
+
+data class ClientLogAcceptResponse(val accepted: Int, val rejected: Int)

--- a/systems/observability/observability-adapter-in/src/main/kotlin/hs/kr/entrydsm/observability/adapterin/web/dto/response/ClientLogPageResponse.kt
+++ b/systems/observability/observability-adapter-in/src/main/kotlin/hs/kr/entrydsm/observability/adapterin/web/dto/response/ClientLogPageResponse.kt
@@ -1,0 +1,27 @@
+package hs.kr.entrydsm.observability.adapterin.web.dto.response
+
+import hs.kr.entrydsm.observability.domain.enum.LogLevel
+import hs.kr.entrydsm.observability.domain.enum.LogSource
+import java.time.Instant
+
+data class ClientLogPageResponse(
+    val totalCount: Long,
+    val errorCount: Long,
+    val warnCount: Long,
+    val items: List<ClientLogItemResponse>,
+    val nextCursor: String?,
+    val hasNext: Boolean,
+)
+
+data class ClientLogItemResponse(
+    val fingerprint: String,
+    val level: LogLevel,
+    val message: String,
+    val source: LogSource,
+    val pageUrl: String,
+    val browser: String?,
+    val os: String?,
+    val count: Long,
+    val firstOccurredAt: Instant,
+    val lastOccurredAt: Instant,
+)

--- a/systems/observability/observability-adapter-in/src/main/kotlin/hs/kr/entrydsm/observability/adapterin/web/dto/response/DashboardSnapshotResponse.kt
+++ b/systems/observability/observability-adapter-in/src/main/kotlin/hs/kr/entrydsm/observability/adapterin/web/dto/response/DashboardSnapshotResponse.kt
@@ -1,0 +1,60 @@
+package hs.kr.entrydsm.observability.adapterin.web.dto.response
+
+import hs.kr.entrydsm.observability.domain.enum.DeviceType
+import hs.kr.entrydsm.observability.domain.enum.ServiceStatus
+import java.time.Instant
+
+data class DashboardSnapshotResponse(
+    val generatedAt: Instant,
+    val period: PeriodResponse,
+    val traffic: TrafficResponse,
+    val api: ApiStatsResponse,
+    val business: BusinessStatsResponse,
+    val services: ServiceActivityResponse,
+    val clientLog: ClientLogCountResponse,
+    val resource: ResourceUsageBriefResponse,
+)
+
+data class PeriodResponse(val type: String, val round: String, val from: Instant, val to: Instant)
+
+data class TrafficResponse(
+    val totalVisitors: Long,
+    val concurrent: ConcurrentResponse,
+    val avgSessionDurationSeconds: Long,
+    val devices: List<DeviceStatResponse>,
+)
+
+data class ConcurrentResponse(val current: Int, val max: Int, val avg: Int)
+
+data class DeviceStatResponse(val type: DeviceType, val count: Long, val ratio: Double)
+
+data class ApiStatsResponse(
+    val totalRequests: Long,
+    val successCount: Long,
+    val failureCount: Long,
+    val failureRate: Double,
+)
+
+data class BusinessStatsResponse(
+    val applicationSubmit: OutcomeCountResponse,
+    val pdfDownload: OutcomeCountResponse,
+)
+
+data class OutcomeCountResponse(val success: Long, val failure: Long)
+
+data class ServiceActivityResponse(val windowSeconds: Long, val items: List<ServiceActivityItemResponse>)
+
+data class ServiceActivityItemResponse(
+    val service: String,
+    val label: String,
+    val activeUsers: Int,
+    val status: ServiceStatus,
+)
+
+data class ClientLogCountResponse(val errorCount: Long, val warnCount: Long)
+
+data class ResourceUsageBriefResponse(
+    val dbUsedBytes: Long,
+    val bucketUsedBytes: Long,
+    val measuredAt: Instant,
+)

--- a/systems/observability/observability-adapter-in/src/main/kotlin/hs/kr/entrydsm/observability/adapterin/web/dto/response/LiveLogEventResponse.kt
+++ b/systems/observability/observability-adapter-in/src/main/kotlin/hs/kr/entrydsm/observability/adapterin/web/dto/response/LiveLogEventResponse.kt
@@ -1,0 +1,12 @@
+package hs.kr.entrydsm.observability.adapterin.web.dto.response
+
+import java.time.Instant
+
+data class LiveLogEventResponse(
+    val kind: String,
+    val level: String,
+    val source: String,
+    val message: String,
+    val pageUrl: String,
+    val occurredAt: Instant,
+)

--- a/systems/observability/observability-adapter-in/src/main/kotlin/hs/kr/entrydsm/observability/adapterin/web/dto/response/MetricsSeriesResponse.kt
+++ b/systems/observability/observability-adapter-in/src/main/kotlin/hs/kr/entrydsm/observability/adapterin/web/dto/response/MetricsSeriesResponse.kt
@@ -1,0 +1,15 @@
+package hs.kr.entrydsm.observability.adapterin.web.dto.response
+
+import hs.kr.entrydsm.observability.domain.enum.MetricType
+import java.time.Instant
+
+data class MetricsSeriesResponse(
+    val from: Instant,
+    val to: Instant,
+    val interval: String,
+    val series: List<MetricSeriesResponse>,
+)
+
+data class MetricSeriesResponse(val metric: MetricType, val points: List<MetricPointResponse>)
+
+data class MetricPointResponse(val t: Instant, val v: Long)

--- a/systems/observability/observability-adapter-in/src/main/kotlin/hs/kr/entrydsm/observability/adapterin/web/dto/response/ReportGeneratedResponse.kt
+++ b/systems/observability/observability-adapter-in/src/main/kotlin/hs/kr/entrydsm/observability/adapterin/web/dto/response/ReportGeneratedResponse.kt
@@ -1,0 +1,11 @@
+package hs.kr.entrydsm.observability.adapterin.web.dto.response
+
+import java.time.Instant
+
+data class ReportGeneratedResponse(
+    val status: String,
+    val downloadUrl: String,
+    val fileName: String,
+    val sizeBytes: Long,
+    val expiresAt: Instant,
+)

--- a/systems/observability/observability-adapter-in/src/main/kotlin/hs/kr/entrydsm/observability/adapterin/web/dto/response/ServerLogPageResponse.kt
+++ b/systems/observability/observability-adapter-in/src/main/kotlin/hs/kr/entrydsm/observability/adapterin/web/dto/response/ServerLogPageResponse.kt
@@ -1,0 +1,25 @@
+package hs.kr.entrydsm.observability.adapterin.web.dto.response
+
+import hs.kr.entrydsm.observability.domain.enum.ServiceName
+import java.time.Instant
+
+data class ServerLogPageResponse(
+    val totalCount: Long,
+    val items: List<ServerLogItemResponse>,
+    val nextCursor: String?,
+    val hasNext: Boolean,
+)
+
+data class ServerLogItemResponse(
+    val fingerprint: String,
+    val service: ServiceName,
+    val method: String,
+    val path: String,
+    val status: Int,
+    val code: String,
+    val grpcStatus: String?,
+    val message: String,
+    val count: Long,
+    val firstOccurredAt: Instant,
+    val lastOccurredAt: Instant,
+)

--- a/systems/observability/observability-adapter-in/src/main/kotlin/hs/kr/entrydsm/observability/adapterin/web/dto/response/ServiceHealthResponse.kt
+++ b/systems/observability/observability-adapter-in/src/main/kotlin/hs/kr/entrydsm/observability/adapterin/web/dto/response/ServiceHealthResponse.kt
@@ -1,0 +1,25 @@
+package hs.kr.entrydsm.observability.adapterin.web.dto.response
+
+import hs.kr.entrydsm.observability.domain.enum.ServiceName
+import hs.kr.entrydsm.observability.domain.enum.ServiceStatus
+import java.time.Instant
+
+data class ServiceHealthResponse(
+    val overall: ServiceStatus,
+    val checkedAt: Instant,
+    val services: List<ServiceHealthItemResponse>,
+)
+
+data class ServiceHealthItemResponse(
+    val service: ServiceName,
+    val label: String,
+    val status: ServiceStatus,
+    val responseTimeMs: Long?,
+    val version: String?,
+    val dependencies: List<DependencyStatusResponse>,
+)
+
+data class DependencyStatusResponse(
+    val name: String,
+    val status: ServiceStatus,
+)

--- a/systems/observability/observability-adapter-in/src/main/kotlin/hs/kr/entrydsm/observability/adapterin/web/dto/response/SessionEventResponse.kt
+++ b/systems/observability/observability-adapter-in/src/main/kotlin/hs/kr/entrydsm/observability/adapterin/web/dto/response/SessionEventResponse.kt
@@ -1,0 +1,6 @@
+package hs.kr.entrydsm.observability.adapterin.web.dto.response
+
+data class SessionEventResponse(
+    val sessionId: String,
+    val heartbeatIntervalSeconds: Int,
+)

--- a/systems/observability/observability-adapter-in/src/main/kotlin/hs/kr/entrydsm/observability/adapterin/web/dto/response/StorageUsageResponse.kt
+++ b/systems/observability/observability-adapter-in/src/main/kotlin/hs/kr/entrydsm/observability/adapterin/web/dto/response/StorageUsageResponse.kt
@@ -1,0 +1,22 @@
+package hs.kr.entrydsm.observability.adapterin.web.dto.response
+
+import java.time.Instant
+
+data class StorageUsageResponse(
+    val database: DatabaseUsageResponse,
+    val bucket: BucketUsageResponse,
+    val cacheTtlSeconds: Int,
+)
+
+data class DatabaseUsageResponse(
+    val usedBytes: Long,
+    val totalBytes: Long?,
+    val usageRatio: Double?,
+    val measuredAt: Instant,
+)
+
+data class BucketUsageResponse(
+    val usedBytes: Long,
+    val objectCount: Long,
+    val measuredAt: Instant,
+)

--- a/systems/observability/observability-adapter-in/src/main/kotlin/hs/kr/entrydsm/observability/adapterin/web/exception/GlobalExceptionHandler.kt
+++ b/systems/observability/observability-adapter-in/src/main/kotlin/hs/kr/entrydsm/observability/adapterin/web/exception/GlobalExceptionHandler.kt
@@ -1,0 +1,62 @@
+package hs.kr.entrydsm.observability.adapterin.web.exception
+
+import hs.kr.entrydsm.observability.adapterin.web.dto.common.ErrorDetail
+import hs.kr.entrydsm.observability.adapterin.web.dto.common.ErrorResponse
+import hs.kr.entrydsm.observability.domain.enum.ErrorCode
+import hs.kr.entrydsm.observability.domain.exception.MonitorException
+import jakarta.validation.ConstraintViolationException
+import org.slf4j.LoggerFactory
+import org.slf4j.MDC
+import org.springframework.http.ResponseEntity
+import org.springframework.http.converter.HttpMessageNotReadableException
+import org.springframework.validation.BindException
+import org.springframework.web.bind.MethodArgumentNotValidException
+import org.springframework.web.bind.MissingPathVariableException
+import org.springframework.web.bind.MissingRequestHeaderException
+import org.springframework.web.bind.MissingServletRequestParameterException
+import org.springframework.web.bind.annotation.ExceptionHandler
+import org.springframework.web.bind.annotation.RestControllerAdvice
+import org.springframework.web.method.annotation.MethodArgumentTypeMismatchException
+import org.springframework.web.multipart.support.MissingServletRequestPartException
+
+@RestControllerAdvice
+class GlobalExceptionHandler {
+    private val logger = LoggerFactory.getLogger(javaClass)
+
+    @ExceptionHandler(MonitorException::class)
+    fun handleMonitorException(exception: MonitorException): ResponseEntity<ErrorResponse> =
+        response(exception.errorCode)
+
+    @ExceptionHandler(
+        HttpMessageNotReadableException::class,
+        BindException::class,
+        ConstraintViolationException::class,
+        MethodArgumentNotValidException::class,
+        MissingPathVariableException::class,
+        MissingRequestHeaderException::class,
+        MissingServletRequestParameterException::class,
+        MissingServletRequestPartException::class,
+        MethodArgumentTypeMismatchException::class,
+    )
+    fun handleInvalidRequest(exception: Exception): ResponseEntity<ErrorResponse> =
+        response(ErrorCode.INVALID_PAYLOAD)
+
+    @ExceptionHandler(Exception::class)
+    fun handleUnhandledException(exception: Exception): ResponseEntity<ErrorResponse> =
+        response(ErrorCode.INTERNAL_SERVER_ERROR).also {
+            logger.error(
+                "Unhandled exception [X-trace-Id={}]",
+                MDC.get("X-trace-Id") ?: "unknown",
+                exception,
+            )
+        }
+
+    private fun response(errorCode: ErrorCode): ResponseEntity<ErrorResponse> =
+        ResponseEntity
+            .status(errorCode.status)
+            .body(
+                ErrorResponse(
+                    error = ErrorDetail.from(errorCode)
+                ),
+            )
+}

--- a/systems/observability/observability-adapter-in/src/main/kotlin/hs/kr/entrydsm/observability/adapterin/web/security/JwtAuthInterceptor.kt
+++ b/systems/observability/observability-adapter-in/src/main/kotlin/hs/kr/entrydsm/observability/adapterin/web/security/JwtAuthInterceptor.kt
@@ -1,0 +1,55 @@
+package hs.kr.entrydsm.observability.adapterin.web.security
+
+import hs.kr.entrydsm.observability.domain.enum.ErrorCode
+import hs.kr.entrydsm.observability.domain.exception.MonitorDomainException
+import io.jsonwebtoken.JwtException
+import io.jsonwebtoken.Jwts
+import io.jsonwebtoken.security.Keys
+import jakarta.servlet.http.HttpServletRequest
+import jakarta.servlet.http.HttpServletResponse
+import java.nio.charset.StandardCharsets
+import org.springframework.stereotype.Component
+import org.springframework.web.servlet.HandlerInterceptor
+
+/**
+ * ponytail: 이 저장소엔 아직 Spring Security/JWT 발급 체계가 병합되어 있지 않아,
+ * 전체 Security 스택 대신 Bearer 토큰 서명·발급자·role 클레임만 확인하는 경량 인터셉터로 둔다.
+ * identity의 정식 인증이 병합되면 같은 시크릿을 공유하도록 설정만 맞추면 된다.
+ */
+@Component
+class JwtAuthInterceptor(
+    private val properties: JwtAuthProperties,
+) : HandlerInterceptor {
+    private val key by lazy { Keys.hmacShaKeyFor(properties.secret.toByteArray(StandardCharsets.UTF_8)) }
+
+    override fun preHandle(request: HttpServletRequest, response: HttpServletResponse, handler: Any): Boolean {
+        val token = bearerToken(request) ?: throw MonitorDomainException(ErrorCode.UNAUTHORIZED)
+        val claims = try {
+            Jwts.parser()
+                .verifyWith(key)
+                .requireIssuer(properties.issuer)
+                .build()
+                .parseSignedClaims(token)
+                .payload
+        } catch (exception: JwtException) {
+            throw MonitorDomainException(ErrorCode.UNAUTHORIZED)
+        } catch (exception: IllegalArgumentException) {
+            throw MonitorDomainException(ErrorCode.UNAUTHORIZED)
+        }
+        if (claims["role"] as? String != ADMIN_ROLE) {
+            throw MonitorDomainException(ErrorCode.FORBIDDEN)
+        }
+        return true
+    }
+
+    private fun bearerToken(request: HttpServletRequest): String? {
+        val header = request.getHeader("Authorization") ?: return null
+        if (!header.startsWith(BEARER_PREFIX)) return null
+        return header.removePrefix(BEARER_PREFIX).trim().takeIf { it.isNotEmpty() }
+    }
+
+    companion object {
+        private const val BEARER_PREFIX = "Bearer "
+        private const val ADMIN_ROLE = "ADMIN"
+    }
+}

--- a/systems/observability/observability-adapter-in/src/main/kotlin/hs/kr/entrydsm/observability/adapterin/web/security/JwtAuthProperties.kt
+++ b/systems/observability/observability-adapter-in/src/main/kotlin/hs/kr/entrydsm/observability/adapterin/web/security/JwtAuthProperties.kt
@@ -1,0 +1,15 @@
+package hs.kr.entrydsm.observability.adapterin.web.security
+
+import org.springframework.boot.context.properties.ConfigurationProperties
+import org.springframework.stereotype.Component
+
+/**
+ * identity의 auth.jwt.secret/issuer와 설정 키 이름을 통일해, 정식 인증이 병합되면
+ * 같은 시크릿을 가리키도록 맞추기만 하면 되게 한다.
+ */
+@Component
+@ConfigurationProperties(prefix = "auth.jwt")
+class JwtAuthProperties {
+    lateinit var secret: String
+    lateinit var issuer: String
+}

--- a/systems/observability/observability-adapter-in/src/main/kotlin/hs/kr/entrydsm/observability/adapterin/web/security/WebMvcConfig.kt
+++ b/systems/observability/observability-adapter-in/src/main/kotlin/hs/kr/entrydsm/observability/adapterin/web/security/WebMvcConfig.kt
@@ -1,0 +1,19 @@
+package hs.kr.entrydsm.observability.adapterin.web.security
+
+import org.springframework.context.annotation.Configuration
+import org.springframework.web.servlet.config.annotation.InterceptorRegistry
+import org.springframework.web.servlet.config.annotation.WebMvcConfigurer
+
+@Configuration
+class WebMvcConfig(
+    private val jwtAuthInterceptor: JwtAuthInterceptor,
+) : WebMvcConfigurer {
+    override fun addInterceptors(registry: InterceptorRegistry) {
+        registry.addInterceptor(jwtAuthInterceptor)
+            .addPathPatterns("/api/monitor/v11/**")
+            .excludePathPatterns(
+                "/api/monitor/v11/collect/session",
+                "/api/monitor/v11/collect/client-log",
+            )
+    }
+}

--- a/systems/observability/observability-adapter-in/src/main/kotlin/hs/kr/entrydsm/observability/adapterin/web/sse/SseBroadcaster.kt
+++ b/systems/observability/observability-adapter-in/src/main/kotlin/hs/kr/entrydsm/observability/adapterin/web/sse/SseBroadcaster.kt
@@ -1,0 +1,78 @@
+package hs.kr.entrydsm.observability.adapterin.web.sse
+
+import hs.kr.entrydsm.observability.adapterin.web.dto.common.toResponse
+import hs.kr.entrydsm.observability.application.port.`in`.GetDashboardSnapshotUseCase
+import java.util.concurrent.CopyOnWriteArrayList
+import java.util.concurrent.atomic.AtomicLong
+import org.springframework.scheduling.annotation.Scheduled
+import org.springframework.stereotype.Component
+import org.springframework.web.servlet.mvc.method.annotation.SseEmitter
+
+/**
+ * ponytail: 커넥션 목록을 인메모리로만 들고 있어 다중 인스턴스에서는 인스턴스별로 브로드캐스트가 갈린다.
+ * 수평 확장이 필요해지면 Redis Pub/Sub로 교체한다.
+ */
+@Component
+class SseBroadcaster(
+    private val getDashboardSnapshotUseCase: GetDashboardSnapshotUseCase,
+) {
+    private val emitters = CopyOnWriteArrayList<SseEmitter>()
+    private val eventIdSeq = AtomicLong(System.currentTimeMillis())
+
+    fun register(emitter: SseEmitter) {
+        emitters.add(emitter)
+        emitter.onCompletion { emitters.remove(emitter) }
+        emitter.onTimeout { emitters.remove(emitter) }
+        emitter.onError { emitters.remove(emitter) }
+        sendInitialSnapshot(emitter)
+    }
+
+    fun publishLog(payload: Any) {
+        broadcast("log", payload)
+    }
+
+    @Scheduled(fixedRate = 5000)
+    fun broadcastFrequent() {
+        if (emitters.isEmpty()) return
+        val snapshot = getDashboardSnapshotUseCase.getSnapshot(null)
+        broadcast("traffic", snapshot.traffic.toResponse())
+        broadcast("api", snapshot.api.toResponse())
+        broadcast("business", snapshot.business.toResponse())
+        broadcast("service", snapshot.services.toResponse())
+    }
+
+    @Scheduled(fixedRate = 300000)
+    fun broadcastResource() {
+        if (emitters.isEmpty()) return
+        broadcast("resource", getDashboardSnapshotUseCase.getSnapshot(null).resource.toResponse())
+    }
+
+    @Scheduled(fixedRate = 15000)
+    fun ping() {
+        emitters.forEach { emitter ->
+            runCatching { emitter.send(SseEmitter.event().comment("ping")) }
+                .onFailure { emitters.remove(emitter) }
+        }
+    }
+
+    private fun sendInitialSnapshot(emitter: SseEmitter) {
+        runCatching {
+            emitter.send(SseEmitter.event().reconnectTime(RECONNECT_TIME_MS))
+            val snapshot = getDashboardSnapshotUseCase.getSnapshot(null)
+            emitter.send(SseEmitter.event().id(nextId()).name("snapshot").data(snapshot.toResponse()))
+        }.onFailure { emitters.remove(emitter) }
+    }
+
+    private fun broadcast(eventName: String, data: Any) {
+        emitters.forEach { emitter ->
+            runCatching { emitter.send(SseEmitter.event().id(nextId()).name(eventName).data(data)) }
+                .onFailure { emitters.remove(emitter) }
+        }
+    }
+
+    private fun nextId(): String = eventIdSeq.incrementAndGet().toString()
+
+    companion object {
+        private const val RECONNECT_TIME_MS = 5000L
+    }
+}

--- a/systems/observability/observability-adapter-in/src/main/kotlin/hs/kr/entrydsm/observability/adapterin/web/sse/SseConnectionLimiter.kt
+++ b/systems/observability/observability-adapter-in/src/main/kotlin/hs/kr/entrydsm/observability/adapterin/web/sse/SseConnectionLimiter.kt
@@ -1,0 +1,29 @@
+package hs.kr.entrydsm.observability.adapterin.web.sse
+
+import java.util.concurrent.ConcurrentHashMap
+import java.util.concurrent.atomic.AtomicInteger
+import org.springframework.stereotype.Component
+
+/**
+ * ponytail: 단일 인스턴스 가정의 인메모리 카운터. 인증 붙기 전이라 계정 대신 IP 기준으로 제한한다.
+ * JWT 인증이 연결되면 계정 단위로 교체한다.
+ */
+@Component
+class SseConnectionLimiter {
+    private val counts = ConcurrentHashMap<String, AtomicInteger>()
+
+    fun tryAcquire(key: String): Boolean {
+        val count = counts.computeIfAbsent(key) { AtomicInteger(0) }
+        if (count.incrementAndGet() <= MAX_CONNECTIONS_PER_KEY) return true
+        count.decrementAndGet()
+        return false
+    }
+
+    fun release(key: String) {
+        counts[key]?.decrementAndGet()
+    }
+
+    companion object {
+        private const val MAX_CONNECTIONS_PER_KEY = 3
+    }
+}

--- a/systems/observability/observability-adapter-in/src/main/kotlin/hs/kr/entrydsm/observability/adapterin/web/sse/SseLiveLogPublisher.kt
+++ b/systems/observability/observability-adapter-in/src/main/kotlin/hs/kr/entrydsm/observability/adapterin/web/sse/SseLiveLogPublisher.kt
@@ -1,0 +1,24 @@
+package hs.kr.entrydsm.observability.adapterin.web.sse
+
+import hs.kr.entrydsm.observability.adapterin.web.dto.response.LiveLogEventResponse
+import hs.kr.entrydsm.observability.application.port.out.ClientLogInput
+import hs.kr.entrydsm.observability.application.port.out.LiveLogPublisherPort
+import org.springframework.stereotype.Component
+
+@Component
+class SseLiveLogPublisher(
+    private val sseBroadcaster: SseBroadcaster,
+) : LiveLogPublisherPort {
+    override fun publishClientLog(input: ClientLogInput) {
+        sseBroadcaster.publishLog(
+            LiveLogEventResponse(
+                kind = "CLIENT",
+                level = input.level.name,
+                source = input.source.name,
+                message = input.message,
+                pageUrl = input.pageUrl,
+                occurredAt = input.occurredAt,
+            ),
+        )
+    }
+}

--- a/systems/observability/observability-adapter-in/src/test/kotlin/hs/kr/entrydsm/TestMain.kt
+++ b/systems/observability/observability-adapter-in/src/test/kotlin/hs/kr/entrydsm/TestMain.kt
@@ -1,11 +1,13 @@
 package hs.kr.entrydsm.observability.adapterin
 
 import hs.kr.entrydsm.observability.adapterin.web.exception.GlobalExceptionHandlerTest
+import hs.kr.entrydsm.observability.adapterin.web.security.JwtAuthInterceptorTest
 import org.junit.runner.RunWith
 import org.junit.runners.Suite
 
 @RunWith(Suite::class)
 @Suite.SuiteClasses(
     GlobalExceptionHandlerTest::class,
+    JwtAuthInterceptorTest::class,
 )
 class ObservabilityAdapterInModuleTest

--- a/systems/observability/observability-adapter-in/src/test/kotlin/hs/kr/entrydsm/TestMain.kt
+++ b/systems/observability/observability-adapter-in/src/test/kotlin/hs/kr/entrydsm/TestMain.kt
@@ -1,11 +1,11 @@
 package hs.kr.entrydsm.observability.adapterin
 
-import org.junit.Assert.assertTrue
-import org.junit.Test
+import hs.kr.entrydsm.observability.adapterin.web.exception.GlobalExceptionHandlerTest
+import org.junit.runner.RunWith
+import org.junit.runners.Suite
 
-class ObservabilityAdapterInModuleTest {
-    @Test
-    fun moduleLoads() {
-        assertTrue(true)
-    }
-}
+@RunWith(Suite::class)
+@Suite.SuiteClasses(
+    GlobalExceptionHandlerTest::class,
+)
+class ObservabilityAdapterInModuleTest

--- a/systems/observability/observability-adapter-in/src/test/kotlin/hs/kr/entrydsm/observability/adapterin/web/exception/GlobalExceptionHandlerTest.kt
+++ b/systems/observability/observability-adapter-in/src/test/kotlin/hs/kr/entrydsm/observability/adapterin/web/exception/GlobalExceptionHandlerTest.kt
@@ -1,0 +1,57 @@
+package hs.kr.entrydsm.observability.adapterin.web.exception
+
+import hs.kr.entrydsm.observability.domain.enum.ErrorCode
+import hs.kr.entrydsm.observability.domain.exception.MonitorDomainException
+import jakarta.validation.ConstraintViolationException
+import org.junit.Assert.assertEquals
+import org.junit.Test
+import org.slf4j.MDC
+import org.springframework.validation.BindException
+
+class GlobalExceptionHandlerTest {
+    private val handler = GlobalExceptionHandler()
+
+    @Test
+    fun mapsMonitorExceptionToItsErrorResponse() {
+        val response = handler.handleMonitorException(MonitorDomainException(ErrorCode.SESSION_NOT_FOUND))
+
+        assertEquals(404, response.statusCode.value())
+        assertEquals("SESSION_NOT_FOUND", response.body?.error?.code)
+        assertEquals(ErrorCode.SESSION_NOT_FOUND.message, response.body?.error?.message)
+    }
+
+    @Test
+    fun mapsInvalidRequestToBadRequestResponse() {
+        val response = handler.handleInvalidRequest(IllegalArgumentException())
+
+        assertEquals(400, response.statusCode.value())
+        assertEquals("INVALID_PAYLOAD", response.body?.error?.code)
+    }
+
+    @Test
+    fun mapsValidationExceptionsToBadRequestResponse() {
+        val responses = listOf(
+            handler.handleInvalidRequest(BindException(this, "request")),
+            handler.handleInvalidRequest(ConstraintViolationException(emptySet())),
+        )
+
+        responses.forEach { response ->
+            assertEquals(400, response.statusCode.value())
+            assertEquals("INVALID_PAYLOAD", response.body?.error?.code)
+        }
+    }
+
+    @Test
+    fun keepsGenericResponseAndLogsCorrelationContextForUnhandledException() {
+        MDC.put("X-trace-Id", "test-trace-id")
+        try {
+            val response = handler.handleUnhandledException(IllegalStateException("internal detail"))
+
+            assertEquals(500, response.statusCode.value())
+            assertEquals("INTERNAL_SERVER_ERROR", response.body?.error?.code)
+            assertEquals(ErrorCode.INTERNAL_SERVER_ERROR.message, response.body?.error?.message)
+        } finally {
+            MDC.remove("X-trace-Id")
+        }
+    }
+}

--- a/systems/observability/observability-adapter-in/src/test/kotlin/hs/kr/entrydsm/observability/adapterin/web/security/JwtAuthInterceptorTest.kt
+++ b/systems/observability/observability-adapter-in/src/test/kotlin/hs/kr/entrydsm/observability/adapterin/web/security/JwtAuthInterceptorTest.kt
@@ -1,0 +1,70 @@
+package hs.kr.entrydsm.observability.adapterin.web.security
+
+import hs.kr.entrydsm.observability.domain.exception.MonitorDomainException
+import io.jsonwebtoken.Jwts
+import io.jsonwebtoken.security.Keys
+import java.nio.charset.StandardCharsets
+import java.util.Date
+import org.junit.Assert.assertThrows
+import org.junit.Assert.assertTrue
+import org.junit.Test
+import org.springframework.mock.web.MockHttpServletRequest
+import org.springframework.mock.web.MockHttpServletResponse
+
+class JwtAuthInterceptorTest {
+    private val secret = "test-secret-key-at-least-32-bytes-long!!"
+    private val issuer = "entrydsm-test"
+    private val key = Keys.hmacShaKeyFor(secret.toByteArray(StandardCharsets.UTF_8))
+    private val properties = JwtAuthProperties().apply {
+        this.secret = this@JwtAuthInterceptorTest.secret
+        this.issuer = this@JwtAuthInterceptorTest.issuer
+    }
+    private val interceptor = JwtAuthInterceptor(properties)
+
+    private fun token(role: String, expiresInMillis: Long = 60_000): String =
+        Jwts.builder()
+            .issuer(issuer)
+            .claim("role", role)
+            .expiration(Date(System.currentTimeMillis() + expiresInMillis))
+            .signWith(key)
+            .compact()
+
+    private fun requestWithToken(token: String?): MockHttpServletRequest =
+        MockHttpServletRequest().apply { token?.let { addHeader("Authorization", "Bearer $it") } }
+
+    @Test
+    fun allowsAdminToken() {
+        val allowed = interceptor.preHandle(requestWithToken(token("ADMIN")), MockHttpServletResponse(), Any())
+        assertTrue(allowed)
+    }
+
+    @Test
+    fun rejectsMissingTokenWithUnauthorized() {
+        assertThrows(MonitorDomainException::class.java) {
+            interceptor.preHandle(requestWithToken(null), MockHttpServletResponse(), Any())
+        }
+    }
+
+    @Test
+    fun rejectsNonAdminRoleWithForbidden() {
+        assertThrows(MonitorDomainException::class.java) {
+            interceptor.preHandle(requestWithToken(token("USER")), MockHttpServletResponse(), Any())
+        }
+    }
+
+    @Test
+    fun rejectsExpiredTokenWithUnauthorized() {
+        assertThrows(MonitorDomainException::class.java) {
+            interceptor.preHandle(requestWithToken(token("ADMIN", expiresInMillis = -1000)), MockHttpServletResponse(), Any())
+        }
+    }
+
+    @Test
+    fun rejectsWrongSignatureWithUnauthorized() {
+        val otherKey = Keys.hmacShaKeyFor("another-secret-key-at-least-32-bytes!!".toByteArray(StandardCharsets.UTF_8))
+        val forged = Jwts.builder().issuer(issuer).claim("role", "ADMIN").signWith(otherKey).compact()
+        assertThrows(MonitorDomainException::class.java) {
+            interceptor.preHandle(requestWithToken(forged), MockHttpServletResponse(), Any())
+        }
+    }
+}

--- a/systems/observability/observability-adapter-out/BUILD.bazel
+++ b/systems/observability/observability-adapter-out/BUILD.bazel
@@ -17,5 +17,5 @@ kt_jvm_test(
     javac_opts = "//:javac_options",
     kotlinc_opts = "//:kotlinc_options",
     test_class = "hs.kr.entrydsm.observability.adapterout.ObservabilityAdapterOutModuleTest",
-    deps = MODULE_DEPS + TEST_DEPS,
+    deps = [":main"] + MODULE_DEPS + TEST_DEPS,
 )

--- a/systems/observability/observability-adapter-out/deps.bzl
+++ b/systems/observability/observability-adapter-out/deps.bzl
@@ -1,6 +1,8 @@
 KOTLIN_DEPS = [
     "@maven//:org_springframework_boot_spring_boot_starter_data_redis",
     "@maven//:com_fasterxml_jackson_core_jackson_databind",
+    "@maven//:org_apache_poi_poi",
+    "@maven//:org_apache_poi_poi_ooxml",
     "//systems/observability/observability-application:main",
     "//systems/observability/observability-domain:main",
 ]

--- a/systems/observability/observability-adapter-out/deps.bzl
+++ b/systems/observability/observability-adapter-out/deps.bzl
@@ -1,4 +1,8 @@
-KOTLIN_DEPS = []
+KOTLIN_DEPS = [
+    "@maven//:org_springframework_boot_spring_boot_starter_data_redis",
+    "//systems/observability/observability-application:main",
+    "//systems/observability/observability-domain:main",
+]
 
 TEST_DEPS = [
     "@maven//:junit_junit",

--- a/systems/observability/observability-adapter-out/deps.bzl
+++ b/systems/observability/observability-adapter-out/deps.bzl
@@ -1,5 +1,6 @@
 KOTLIN_DEPS = [
     "@maven//:org_springframework_boot_spring_boot_starter_data_redis",
+    "@maven//:com_fasterxml_jackson_core_jackson_databind",
     "//systems/observability/observability-application:main",
     "//systems/observability/observability-domain:main",
 ]

--- a/systems/observability/observability-adapter-out/src/main/kotlin/hs/kr/entrydsm/observability/adapterout/health/ActuatorHealthCheckAdapter.kt
+++ b/systems/observability/observability-adapter-out/src/main/kotlin/hs/kr/entrydsm/observability/adapterout/health/ActuatorHealthCheckAdapter.kt
@@ -1,0 +1,53 @@
+package hs.kr.entrydsm.observability.adapterout.health
+
+import com.fasterxml.jackson.databind.ObjectMapper
+import hs.kr.entrydsm.observability.application.port.out.HealthCheckPort
+import hs.kr.entrydsm.observability.application.port.out.ServiceHealthCheck
+import hs.kr.entrydsm.observability.domain.enum.ServiceName
+import java.net.URI
+import java.net.http.HttpClient
+import java.net.http.HttpRequest
+import java.net.http.HttpResponse
+import java.time.Duration
+import org.springframework.stereotype.Component
+
+/**
+ * 각 서비스의 actuator 헬스체크 엔드포인트를 호출해 상태를 판정한다.
+ * ponytail: JDK 내장 HttpClient만 사용, adapter-out에 spring-web 의존성을 새로 추가하지 않는다.
+ */
+@Component
+class ActuatorHealthCheckAdapter(
+    private val properties: MonitorServiceProperties,
+) : HealthCheckPort {
+    private val client: HttpClient = HttpClient.newBuilder().connectTimeout(TIMEOUT).build()
+    private val objectMapper = ObjectMapper()
+
+    override fun check(service: ServiceName): ServiceHealthCheck {
+        val baseUrl = properties.services[service.name.lowercase()]?.baseUrl
+            ?: return ServiceHealthCheck(responseTimeMs = null, version = null, dependencies = emptyMap())
+
+        val request = HttpRequest.newBuilder(URI.create("$baseUrl/actuator/health"))
+            .timeout(TIMEOUT)
+            .GET()
+            .build()
+        val start = System.nanoTime()
+        return try {
+            val response = client.send(request, HttpResponse.BodyHandlers.ofString())
+            val elapsedMs = (System.nanoTime() - start) / 1_000_000
+            if (response.statusCode() !in 200..299) {
+                return ServiceHealthCheck(responseTimeMs = null, version = null, dependencies = emptyMap())
+            }
+            val body = objectMapper.readTree(response.body())
+            val dependencies = body["components"]?.fields()?.asSequence()
+                ?.associate { it.key to (it.value["status"]?.asText() == "UP") }
+                ?: emptyMap()
+            ServiceHealthCheck(responseTimeMs = elapsedMs, version = null, dependencies = dependencies)
+        } catch (e: Exception) {
+            ServiceHealthCheck(responseTimeMs = null, version = null, dependencies = emptyMap())
+        }
+    }
+
+    companion object {
+        private val TIMEOUT: Duration = Duration.ofSeconds(3)
+    }
+}

--- a/systems/observability/observability-adapter-out/src/main/kotlin/hs/kr/entrydsm/observability/adapterout/health/MonitorServiceProperties.kt
+++ b/systems/observability/observability-adapter-out/src/main/kotlin/hs/kr/entrydsm/observability/adapterout/health/MonitorServiceProperties.kt
@@ -1,0 +1,13 @@
+package hs.kr.entrydsm.observability.adapterout.health
+
+import org.springframework.boot.context.properties.ConfigurationProperties
+import org.springframework.stereotype.Component
+
+/** monitor.services.<lowercase 서비스명>.base-url 로 헬스체크 대상 서비스를 설정한다. */
+@Component
+@ConfigurationProperties(prefix = "monitor")
+data class MonitorServiceProperties(
+    val services: Map<String, ServiceEndpoint> = emptyMap(),
+) {
+    data class ServiceEndpoint(val baseUrl: String)
+}

--- a/systems/observability/observability-adapter-out/src/main/kotlin/hs/kr/entrydsm/observability/adapterout/log/EmptyServerLogStoreAdapter.kt
+++ b/systems/observability/observability-adapter-out/src/main/kotlin/hs/kr/entrydsm/observability/adapterout/log/EmptyServerLogStoreAdapter.kt
@@ -1,0 +1,25 @@
+package hs.kr.entrydsm.observability.adapterout.log
+
+import hs.kr.entrydsm.observability.application.port.out.ServerLogPage
+import hs.kr.entrydsm.observability.application.port.out.ServerLogStorePort
+import hs.kr.entrydsm.observability.application.port.out.StatusFilter
+import hs.kr.entrydsm.observability.domain.enum.ServiceName
+import hs.kr.entrydsm.observability.domain.model.Cursor
+import java.time.Instant
+import org.springframework.stereotype.Component
+
+/**
+ * 서버 API 오류를 이 서비스로 보고하는 수집 경로가 문서에 정의되어 있지 않아 항상 빈 결과를 반환한다.
+ * 각 서비스에 오류 리포팅 연동(예: gRPC/HTTP 인터셉터)이 추가되면 Redis 기반 어댑터로 교체한다.
+ */
+@Component
+class EmptyServerLogStoreAdapter : ServerLogStorePort {
+    override fun list(
+        from: Instant,
+        to: Instant,
+        service: ServiceName?,
+        status: StatusFilter?,
+        cursor: Cursor?,
+        size: Int,
+    ): ServerLogPage = ServerLogPage(totalCount = 0, items = emptyList(), nextCursor = null, hasNext = false)
+}

--- a/systems/observability/observability-adapter-out/src/main/kotlin/hs/kr/entrydsm/observability/adapterout/redis/FingerprintLogStore.kt
+++ b/systems/observability/observability-adapter-out/src/main/kotlin/hs/kr/entrydsm/observability/adapterout/redis/FingerprintLogStore.kt
@@ -1,0 +1,61 @@
+package hs.kr.entrydsm.observability.adapterout.redis
+
+import hs.kr.entrydsm.observability.domain.model.Cursor
+import java.time.Instant
+import org.springframework.data.redis.core.StringRedisTemplate
+
+/**
+ * fingerprint 단위로 묶이는 이벤트 로그(클라이언트/서버 오류)를 Redis Hash+ZSet으로 저장하는 공용 헬퍼.
+ * ZSet의 score는 lastOccurredAt(epoch millis), member는 fingerprint.
+ * ponytail: 커서 경계에서 동일 밀리초 score가 겹치면 항목이 한 번 더 보일 수 있다. 운영 로그 열람용이라 감내 가능한 수준.
+ */
+class FingerprintLogStore(
+    private val redis: StringRedisTemplate,
+    private val keyPrefix: String,
+) {
+    fun upsert(fingerprint: String, occurredAt: Instant, fields: Map<String, String>, groupKeys: List<String>) {
+        val entryKey = entryKey(fingerprint)
+        val hashOps = redis.opsForHash<String, String>()
+        val nowMillis = occurredAt.toEpochMilli().toString()
+        if (redis.hasKey(entryKey)) {
+            hashOps.increment(entryKey, FIELD_COUNT, 1)
+            hashOps.put(entryKey, FIELD_LAST_OCCURRED_AT, nowMillis)
+        } else {
+            hashOps.putAll(
+                entryKey,
+                fields + mapOf(FIELD_COUNT to "1", FIELD_FIRST_OCCURRED_AT to nowMillis, FIELD_LAST_OCCURRED_AT to nowMillis),
+            )
+        }
+        val score = occurredAt.toEpochMilli().toDouble()
+        redis.opsForZSet().add(indexKey(ALL), fingerprint, score)
+        groupKeys.forEach { redis.opsForZSet().add(indexKey(it), fingerprint, score) }
+    }
+
+    fun entry(fingerprint: String): Map<String, String> = redis.opsForHash<String, String>().entries(entryKey(fingerprint))
+
+    fun count(group: String, from: Instant, to: Instant): Long =
+        redis.opsForZSet().count(indexKey(group), from.toEpochMilli().toDouble(), to.toEpochMilli().toDouble()) ?: 0L
+
+    /** @return (최신순 fingerprint 목록, 다음 페이지 존재 여부) */
+    fun page(group: String, from: Instant, to: Instant, cursor: Cursor?, size: Int): Pair<List<String>, Boolean> {
+        val maxScore = cursor?.lastScore?.toDouble() ?: to.toEpochMilli().toDouble()
+        val fetched = redis.opsForZSet()
+            .reverseRangeByScore(indexKey(group), from.toEpochMilli().toDouble(), maxScore, 0, (size + 1).toLong())
+            ?.toList()
+            ?: emptyList()
+        val filtered = if (cursor != null) fetched.filterNot { it == cursor.lastId } else fetched
+        val hasNext = filtered.size > size
+        return filtered.take(size) to hasNext
+    }
+
+    private fun entryKey(fingerprint: String) = "$keyPrefix:entry:$fingerprint"
+
+    private fun indexKey(group: String) = "$keyPrefix:index:$group"
+
+    companion object {
+        const val ALL = "ALL"
+        const val FIELD_COUNT = "count"
+        const val FIELD_FIRST_OCCURRED_AT = "firstOccurredAt"
+        const val FIELD_LAST_OCCURRED_AT = "lastOccurredAt"
+    }
+}

--- a/systems/observability/observability-adapter-out/src/main/kotlin/hs/kr/entrydsm/observability/adapterout/redis/RedisClientLogStoreAdapter.kt
+++ b/systems/observability/observability-adapter-out/src/main/kotlin/hs/kr/entrydsm/observability/adapterout/redis/RedisClientLogStoreAdapter.kt
@@ -1,0 +1,81 @@
+package hs.kr.entrydsm.observability.adapterout.redis
+
+import hs.kr.entrydsm.observability.application.port.out.ClientLogEntry
+import hs.kr.entrydsm.observability.application.port.out.ClientLogInput
+import hs.kr.entrydsm.observability.application.port.out.ClientLogPage
+import hs.kr.entrydsm.observability.application.port.out.ClientLogStorePort
+import hs.kr.entrydsm.observability.domain.enum.LogLevel
+import hs.kr.entrydsm.observability.domain.enum.LogSource
+import hs.kr.entrydsm.observability.domain.model.Cursor
+import hs.kr.entrydsm.observability.domain.service.Fingerprint
+import java.time.Instant
+import org.springframework.data.redis.core.StringRedisTemplate
+import org.springframework.stereotype.Component
+
+@Component
+class RedisClientLogStoreAdapter(
+    redis: StringRedisTemplate,
+) : ClientLogStorePort {
+    private val store = FingerprintLogStore(redis, "monitor:clientlog")
+
+    override fun record(input: ClientLogInput) {
+        val fingerprint = Fingerprint.of(input.source.name, input.message, input.pageUrl)
+        store.upsert(
+            fingerprint = fingerprint,
+            occurredAt = input.occurredAt,
+            fields = mapOf(
+                FIELD_LEVEL to input.level.name,
+                FIELD_SOURCE to input.source.name,
+                FIELD_MESSAGE to input.message,
+                FIELD_PAGE_URL to input.pageUrl,
+                FIELD_BROWSER to (input.browser ?: ""),
+                FIELD_OS to (input.os ?: ""),
+            ),
+            groupKeys = listOf(input.level.name),
+        )
+    }
+
+    override fun countByLevel(from: Instant, to: Instant): Map<LogLevel, Long> =
+        LogLevel.entries.associateWith { store.count(it.name, from, to) }
+
+    override fun list(from: Instant, to: Instant, levels: Set<LogLevel>?, cursor: Cursor?, size: Int): ClientLogPage {
+        val group = if (levels?.size == 1) levels.first().name else FingerprintLogStore.ALL
+        val (fingerprints, hasNext) = store.page(group, from, to, cursor, size)
+        val items = fingerprints.mapNotNull { toEntry(it, store.entry(it)) }
+            .let { entries -> if (levels != null && levels.size > 1) entries.filter { it.level in levels } else entries }
+        val counts = countByLevel(from, to)
+        return ClientLogPage(
+            totalCount = counts.values.sum(),
+            errorCount = counts[LogLevel.ERROR] ?: 0,
+            warnCount = counts[LogLevel.WARN] ?: 0,
+            items = items,
+            nextCursor = items.lastOrNull()?.let { Cursor(it.lastOccurredAt.toEpochMilli(), it.fingerprint) },
+            hasNext = hasNext,
+        )
+    }
+
+    private fun toEntry(fingerprint: String, fields: Map<String, String>): ClientLogEntry? {
+        if (fields.isEmpty()) return null
+        return ClientLogEntry(
+            fingerprint = fingerprint,
+            level = LogLevel.valueOf(fields.getValue(FIELD_LEVEL)),
+            message = fields.getValue(FIELD_MESSAGE),
+            source = LogSource.valueOf(fields.getValue(FIELD_SOURCE)),
+            pageUrl = fields.getValue(FIELD_PAGE_URL),
+            browser = fields[FIELD_BROWSER]?.takeIf { it.isNotEmpty() },
+            os = fields[FIELD_OS]?.takeIf { it.isNotEmpty() },
+            count = fields.getValue(FingerprintLogStore.FIELD_COUNT).toLong(),
+            firstOccurredAt = Instant.ofEpochMilli(fields.getValue(FingerprintLogStore.FIELD_FIRST_OCCURRED_AT).toLong()),
+            lastOccurredAt = Instant.ofEpochMilli(fields.getValue(FingerprintLogStore.FIELD_LAST_OCCURRED_AT).toLong()),
+        )
+    }
+
+    companion object {
+        private const val FIELD_LEVEL = "level"
+        private const val FIELD_SOURCE = "source"
+        private const val FIELD_MESSAGE = "message"
+        private const val FIELD_PAGE_URL = "pageUrl"
+        private const val FIELD_BROWSER = "browser"
+        private const val FIELD_OS = "os"
+    }
+}

--- a/systems/observability/observability-adapter-out/src/main/kotlin/hs/kr/entrydsm/observability/adapterout/redis/RedisMetricsStoreAdapter.kt
+++ b/systems/observability/observability-adapter-out/src/main/kotlin/hs/kr/entrydsm/observability/adapterout/redis/RedisMetricsStoreAdapter.kt
@@ -1,0 +1,62 @@
+package hs.kr.entrydsm.observability.adapterout.redis
+
+import hs.kr.entrydsm.observability.application.port.out.MetricsStorePort
+import java.time.Duration
+import java.time.Instant
+import java.util.UUID
+import org.springframework.data.redis.core.StringRedisTemplate
+import org.springframework.stereotype.Component
+
+/**
+ * 방문자 수를 항상 5분 단위(GRANULARITY)로 기록해두고, 조회 시 요청된 interval에 맞춰
+ * 여러 5분 버킷을 합집합(SUNIONSTORE)해 고유 방문자 수를 계산한다.
+ * ponytail: 넓은 범위(예: 90일 x 1d)를 조회하면 유니온 대상 키가 많아질 수 있다.
+ * 관리자 조회용 API라 빈도가 낮아 감내 가능, 느려지면 인터벌별 사전 집계로 교체한다.
+ */
+@Component
+class RedisMetricsStoreAdapter(
+    private val redis: StringRedisTemplate,
+) : MetricsStorePort {
+
+    override fun recordVisitor(sessionId: String, at: Instant) {
+        val key = bucketKey(bucketStart(at))
+        redis.opsForSet().add(key, sessionId)
+        redis.expire(key, TTL)
+    }
+
+    override fun visitorCount(from: Instant, to: Instant): Long {
+        val keys = bucketsBetween(from, to).map { bucketKey(it) }
+        if (keys.isEmpty()) return 0L
+        if (keys.size == 1) return redis.opsForSet().size(keys.first()) ?: 0L
+
+        val tempKey = "monitor:metric:visitor:tmp:${UUID.randomUUID()}"
+        return try {
+            redis.opsForSet().unionAndStore(keys.first(), keys.drop(1), tempKey)
+            redis.opsForSet().size(tempKey) ?: 0L
+        } finally {
+            redis.delete(tempKey)
+        }
+    }
+
+    private fun bucketStart(at: Instant): Instant {
+        val granularityMillis = GRANULARITY.toMillis()
+        return Instant.ofEpochMilli(at.toEpochMilli() / granularityMillis * granularityMillis)
+    }
+
+    private fun bucketsBetween(from: Instant, to: Instant): List<Instant> {
+        val buckets = mutableListOf<Instant>()
+        var cursor = bucketStart(from)
+        while (cursor.isBefore(to)) {
+            buckets.add(cursor)
+            cursor = cursor.plus(GRANULARITY)
+        }
+        return buckets
+    }
+
+    private fun bucketKey(bucketStart: Instant) = "monitor:metric:visitor:${bucketStart.toEpochMilli()}"
+
+    companion object {
+        private val GRANULARITY: Duration = Duration.ofMinutes(5)
+        private val TTL: Duration = Duration.ofDays(91)
+    }
+}

--- a/systems/observability/observability-adapter-out/src/main/kotlin/hs/kr/entrydsm/observability/adapterout/redis/RedisRateLimitAdapter.kt
+++ b/systems/observability/observability-adapter-out/src/main/kotlin/hs/kr/entrydsm/observability/adapterout/redis/RedisRateLimitAdapter.kt
@@ -1,0 +1,22 @@
+package hs.kr.entrydsm.observability.adapterout.redis
+
+import hs.kr.entrydsm.observability.application.port.out.RateLimitPort
+import java.time.Duration
+import org.springframework.data.redis.core.StringRedisTemplate
+import org.springframework.stereotype.Component
+
+/** IP 기준 고정 윈도우 카운터. 이미 Redis를 쓰므로 별도 rate-limit 라이브러리 없이 INCR+EXPIRE로 구현한다. */
+@Component
+class RedisRateLimitAdapter(
+    private val redis: StringRedisTemplate,
+) : RateLimitPort {
+    override fun tryAcquire(key: String, limit: Long, windowSeconds: Long): Boolean {
+        val bucket = System.currentTimeMillis() / (windowSeconds * 1000)
+        val redisKey = "monitor:ratelimit:$key:$bucket"
+        val count = redis.opsForValue().increment(redisKey) ?: 1L
+        if (count == 1L) {
+            redis.expire(redisKey, Duration.ofSeconds(windowSeconds))
+        }
+        return count <= limit
+    }
+}

--- a/systems/observability/observability-adapter-out/src/main/kotlin/hs/kr/entrydsm/observability/adapterout/redis/RedisSessionStoreAdapter.kt
+++ b/systems/observability/observability-adapter-out/src/main/kotlin/hs/kr/entrydsm/observability/adapterout/redis/RedisSessionStoreAdapter.kt
@@ -1,0 +1,124 @@
+package hs.kr.entrydsm.observability.adapterout.redis
+
+import hs.kr.entrydsm.observability.application.port.out.SessionStorePort
+import hs.kr.entrydsm.observability.domain.enum.DeviceType
+import hs.kr.entrydsm.observability.domain.enum.ServiceName
+import java.time.Duration
+import java.time.Instant
+import org.springframework.data.redis.core.StringRedisTemplate
+import org.springframework.stereotype.Component
+
+/**
+ * 세션·트래픽 집계를 Redis에 저장한다.
+ * ponytail: 다중 인스턴스에서도 Redis가 단일 소스라 별도 확장 작업 없이 그대로 동작한다.
+ */
+@Component
+class RedisSessionStoreAdapter(
+    private val redis: StringRedisTemplate,
+) : SessionStorePort {
+
+    override fun enter(sessionId: String, service: ServiceName, deviceType: DeviceType, now: Instant) {
+        val nowMillis = now.toEpochMilli()
+        val hashOps = redis.opsForHash<String, String>()
+        hashOps.putAll(
+            metaKey(sessionId),
+            mapOf(
+                FIELD_SERVICE to service.name,
+                FIELD_ENTERED_AT to nowMillis.toString(),
+                FIELD_LAST_HEARTBEAT_AT to nowMillis.toString(),
+            ),
+        )
+        redis.expire(metaKey(sessionId), SESSION_TTL)
+        touchWindow(sessionId, service, nowMillis)
+        redis.opsForSet().add(VISITORS_KEY, sessionId)
+        hashOps.increment(DEVICE_COUNTS_KEY, deviceType.name, 1)
+    }
+
+    override fun heartbeat(sessionId: String, service: ServiceName, now: Instant): Boolean {
+        if (!redis.hasKey(metaKey(sessionId))) return false
+        val nowMillis = now.toEpochMilli()
+        val hashOps = redis.opsForHash<String, String>()
+        hashOps.put(metaKey(sessionId), FIELD_SERVICE, service.name)
+        hashOps.put(metaKey(sessionId), FIELD_LAST_HEARTBEAT_AT, nowMillis.toString())
+        redis.expire(metaKey(sessionId), SESSION_TTL)
+        touchWindow(sessionId, service, nowMillis)
+        return true
+    }
+
+    override fun leave(sessionId: String, service: ServiceName, now: Instant): Boolean {
+        val meta = redis.opsForHash<String, String>().entries(metaKey(sessionId))
+        if (meta.isEmpty()) return false
+        meta[FIELD_ENTERED_AT]?.toLongOrNull()?.let { enteredAt ->
+            val durationSeconds = (now.toEpochMilli() - enteredAt) / 1000
+            redis.opsForValue().increment(DURATION_SUM_KEY, durationSeconds)
+            redis.opsForValue().increment(DURATION_COUNT_KEY)
+        }
+        redis.delete(metaKey(sessionId))
+        ServiceName.entries.forEach { redis.opsForZSet().remove(windowKey(it), sessionId) }
+        redis.opsForZSet().remove(ALL_WINDOW_KEY, sessionId)
+        return true
+    }
+
+    override fun concurrentUsers(service: ServiceName?, now: Instant, windowSeconds: Long): Int {
+        val key = service?.let { windowKey(it) } ?: ALL_WINDOW_KEY
+        val min = (now.toEpochMilli() - windowSeconds * 1000).toDouble()
+        return (redis.opsForZSet().count(key, min, Double.MAX_VALUE) ?: 0L).toInt()
+    }
+
+    override fun totalVisitors(): Long = redis.opsForSet().size(VISITORS_KEY) ?: 0L
+
+    override fun avgSessionDurationSeconds(): Long {
+        val sum = redis.opsForValue().get(DURATION_SUM_KEY)?.toLongOrNull() ?: 0L
+        val count = redis.opsForValue().get(DURATION_COUNT_KEY)?.toLongOrNull() ?: 0L
+        return if (count == 0L) 0L else sum / count
+    }
+
+    override fun deviceBreakdown(): Map<DeviceType, Long> {
+        val entries = redis.opsForHash<String, String>().entries(DEVICE_COUNTS_KEY)
+        return DeviceType.entries.associateWith { entries[it.name]?.toLongOrNull() ?: 0L }
+    }
+
+    override fun sampleConcurrency(now: Instant, windowSeconds: Long) {
+        val current = concurrentUsers(null, now, windowSeconds)
+        val currentMax = redis.opsForValue().get(CONCURRENT_MAX_KEY)?.toIntOrNull() ?: 0
+        if (current > currentMax) {
+            redis.opsForValue().set(CONCURRENT_MAX_KEY, current.toString())
+        }
+        redis.opsForValue().increment(CONCURRENT_SUM_KEY, current.toLong())
+        redis.opsForValue().increment(CONCURRENT_SAMPLES_KEY)
+    }
+
+    override fun concurrentMax(): Int = redis.opsForValue().get(CONCURRENT_MAX_KEY)?.toIntOrNull() ?: 0
+
+    override fun concurrentAvg(): Int {
+        val sum = redis.opsForValue().get(CONCURRENT_SUM_KEY)?.toLongOrNull() ?: 0L
+        val samples = redis.opsForValue().get(CONCURRENT_SAMPLES_KEY)?.toLongOrNull() ?: 0L
+        return if (samples == 0L) 0 else (sum / samples).toInt()
+    }
+
+    private fun touchWindow(sessionId: String, service: ServiceName, nowMillis: Long) {
+        redis.opsForZSet().add(windowKey(service), sessionId, nowMillis.toDouble())
+        redis.opsForZSet().add(ALL_WINDOW_KEY, sessionId, nowMillis.toDouble())
+        redis.expire(windowKey(service), SESSION_TTL)
+        redis.expire(ALL_WINDOW_KEY, SESSION_TTL)
+    }
+
+    private fun metaKey(sessionId: String) = "monitor:session:meta:$sessionId"
+
+    private fun windowKey(service: ServiceName) = "monitor:session:window:${service.name}"
+
+    companion object {
+        private const val VISITORS_KEY = "monitor:visitors:all"
+        private const val DEVICE_COUNTS_KEY = "monitor:device:counts"
+        private const val DURATION_SUM_KEY = "monitor:duration:sum"
+        private const val DURATION_COUNT_KEY = "monitor:duration:count"
+        private const val CONCURRENT_MAX_KEY = "monitor:concurrent:max"
+        private const val CONCURRENT_SUM_KEY = "monitor:concurrent:sum"
+        private const val CONCURRENT_SAMPLES_KEY = "monitor:concurrent:samples"
+        private const val ALL_WINDOW_KEY = "monitor:session:window:ALL"
+        private const val FIELD_SERVICE = "service"
+        private const val FIELD_ENTERED_AT = "enteredAt"
+        private const val FIELD_LAST_HEARTBEAT_AT = "lastHeartbeatAt"
+        private val SESSION_TTL: Duration = Duration.ofHours(6)
+    }
+}

--- a/systems/observability/observability-adapter-out/src/main/kotlin/hs/kr/entrydsm/observability/adapterout/report/LocalFileReportObjectStorageAdapter.kt
+++ b/systems/observability/observability-adapter-out/src/main/kotlin/hs/kr/entrydsm/observability/adapterout/report/LocalFileReportObjectStorageAdapter.kt
@@ -1,0 +1,50 @@
+package hs.kr.entrydsm.observability.adapterout.report
+
+import hs.kr.entrydsm.observability.application.port.out.DownloadedReport
+import hs.kr.entrydsm.observability.application.port.out.ReportObjectStoragePort
+import hs.kr.entrydsm.observability.application.port.out.StoredReport
+import java.io.File
+import java.time.Clock
+import java.time.Duration
+import java.time.Instant
+import java.util.UUID
+import org.springframework.beans.factory.annotation.Value
+import org.springframework.data.redis.core.StringRedisTemplate
+import org.springframework.stereotype.Component
+
+/**
+ * S3 presigned URL 자리를 로컬 디스크 + Redis 만료 토큰으로 대체한다.
+ * 나중에 실제 S3로 교체할 때는 이 어댑터만 바꾸면 된다(포트는 그대로).
+ */
+@Component
+class LocalFileReportObjectStorageAdapter(
+    @Value("\${monitor.report.storage-dir}") private val storageDir: String,
+    private val redis: StringRedisTemplate,
+    private val clock: Clock,
+) : ReportObjectStoragePort {
+
+    override fun store(fileName: String, bytes: ByteArray): StoredReport {
+        val dir = File(storageDir).apply { mkdirs() }
+        File(dir, fileName).writeBytes(bytes)
+
+        val token = UUID.randomUUID().toString()
+        redis.opsForValue().set(tokenKey(token), File(dir, fileName).absolutePath, TTL)
+        return StoredReport(
+            downloadUrl = "/api/monitor/v11/reports/download?token=$token",
+            expiresAt = Instant.now(clock).plus(TTL),
+        )
+    }
+
+    override fun resolve(token: String): DownloadedReport? {
+        val path = redis.opsForValue().get(tokenKey(token)) ?: return null
+        val file = File(path)
+        if (!file.exists()) return null
+        return DownloadedReport(fileName = file.name, bytes = file.readBytes())
+    }
+
+    private fun tokenKey(token: String) = "monitor:report:token:$token"
+
+    companion object {
+        private val TTL: Duration = Duration.ofMinutes(5)
+    }
+}

--- a/systems/observability/observability-adapter-out/src/main/kotlin/hs/kr/entrydsm/observability/adapterout/report/XlsxCsvReportGenerator.kt
+++ b/systems/observability/observability-adapter-out/src/main/kotlin/hs/kr/entrydsm/observability/adapterout/report/XlsxCsvReportGenerator.kt
@@ -1,0 +1,65 @@
+package hs.kr.entrydsm.observability.adapterout.report
+
+import hs.kr.entrydsm.observability.application.port.`in`.result.DashboardSnapshotResult
+import hs.kr.entrydsm.observability.application.port.out.ReportGeneratorPort
+import hs.kr.entrydsm.observability.domain.enum.ReportFormat
+import java.io.ByteArrayOutputStream
+import org.apache.poi.xssf.usermodel.XSSFWorkbook
+import org.springframework.stereotype.Component
+
+@Component
+class XlsxCsvReportGenerator : ReportGeneratorPort {
+
+    override fun generate(format: ReportFormat, snapshot: DashboardSnapshotResult): ByteArray =
+        when (format) {
+            ReportFormat.XLSX -> toXlsx(snapshot)
+            ReportFormat.CSV -> toCsv(snapshot).toByteArray()
+        }
+
+    private fun rows(snapshot: DashboardSnapshotResult): List<Pair<String, String>> =
+        listOf(
+            "generatedAt" to snapshot.generatedAt.toString(),
+            "round" to snapshot.period.round,
+            "totalVisitors" to snapshot.traffic.totalVisitors.toString(),
+            "concurrentCurrent" to snapshot.traffic.concurrent.current.toString(),
+            "concurrentMax" to snapshot.traffic.concurrent.max.toString(),
+            "concurrentAvg" to snapshot.traffic.concurrent.avg.toString(),
+            "avgSessionDurationSeconds" to snapshot.traffic.avgSessionDurationSeconds.toString(),
+            "apiTotalRequests" to snapshot.api.totalRequests.toString(),
+            "apiSuccessCount" to snapshot.api.successCount.toString(),
+            "apiFailureCount" to snapshot.api.failureCount.toString(),
+            "applicationSubmitSuccess" to snapshot.business.applicationSubmit.success.toString(),
+            "applicationSubmitFailure" to snapshot.business.applicationSubmit.failure.toString(),
+            "pdfDownloadSuccess" to snapshot.business.pdfDownload.success.toString(),
+            "pdfDownloadFailure" to snapshot.business.pdfDownload.failure.toString(),
+            "clientLogErrorCount" to snapshot.clientLog.errorCount.toString(),
+            "clientLogWarnCount" to snapshot.clientLog.warnCount.toString(),
+            "dbUsedBytes" to snapshot.resource.dbUsedBytes.toString(),
+            "bucketUsedBytes" to snapshot.resource.bucketUsedBytes.toString(),
+        ) + snapshot.services.items.map { "activeUsers_${it.service}" to it.activeUsers.toString() }
+
+    private fun toCsv(snapshot: DashboardSnapshotResult): String =
+        buildString {
+            appendLine("metric,value")
+            rows(snapshot).forEach { (key, value) -> appendLine("$key,$value") }
+        }
+
+    private fun toXlsx(snapshot: DashboardSnapshotResult): ByteArray {
+        XSSFWorkbook().use { workbook ->
+            val sheet = workbook.createSheet("monitor")
+            sheet.createRow(0).apply {
+                createCell(0).setCellValue("metric")
+                createCell(1).setCellValue("value")
+            }
+            rows(snapshot).forEachIndexed { index, (key, value) ->
+                sheet.createRow(index + 1).apply {
+                    createCell(0).setCellValue(key)
+                    createCell(1).setCellValue(value)
+                }
+            }
+            val out = ByteArrayOutputStream()
+            workbook.write(out)
+            return out.toByteArray()
+        }
+    }
+}

--- a/systems/observability/observability-adapter-out/src/main/kotlin/hs/kr/entrydsm/observability/adapterout/round/MonitorRoundProperties.kt
+++ b/systems/observability/observability-adapter-out/src/main/kotlin/hs/kr/entrydsm/observability/adapterout/round/MonitorRoundProperties.kt
@@ -1,0 +1,14 @@
+package hs.kr.entrydsm.observability.adapterout.round
+
+import java.time.Instant
+import org.springframework.boot.context.properties.ConfigurationProperties
+import org.springframework.stereotype.Component
+
+/** 진행 중인 접수 회차를 관측 서비스 자체는 알지 못하므로 배포 설정으로 지정한다. */
+@Component
+@ConfigurationProperties(prefix = "monitor.round")
+class MonitorRoundProperties {
+    var name: String = "current"
+    var from: Instant = Instant.EPOCH
+    var to: Instant = Instant.EPOCH
+}

--- a/systems/observability/observability-adapter-out/src/main/kotlin/hs/kr/entrydsm/observability/adapterout/round/StaticRoundAdapter.kt
+++ b/systems/observability/observability-adapter-out/src/main/kotlin/hs/kr/entrydsm/observability/adapterout/round/StaticRoundAdapter.kt
@@ -1,0 +1,12 @@
+package hs.kr.entrydsm.observability.adapterout.round
+
+import hs.kr.entrydsm.observability.application.port.out.Round
+import hs.kr.entrydsm.observability.application.port.out.RoundPort
+import org.springframework.stereotype.Component
+
+@Component
+class StaticRoundAdapter(
+    private val properties: MonitorRoundProperties,
+) : RoundPort {
+    override fun current(): Round = Round(properties.name, properties.from, properties.to)
+}

--- a/systems/observability/observability-adapter-out/src/main/kotlin/hs/kr/entrydsm/observability/adapterout/storage/LocalDiskStorageUsageAdapter.kt
+++ b/systems/observability/observability-adapter-out/src/main/kotlin/hs/kr/entrydsm/observability/adapterout/storage/LocalDiskStorageUsageAdapter.kt
@@ -1,0 +1,31 @@
+package hs.kr.entrydsm.observability.adapterout.storage
+
+import hs.kr.entrydsm.observability.application.port.out.StorageUsage
+import hs.kr.entrydsm.observability.application.port.out.StorageUsagePort
+import java.io.File
+import java.time.Clock
+import java.time.Instant
+import org.springframework.beans.factory.annotation.Value
+import org.springframework.stereotype.Component
+
+/**
+ * ponytail: 이 서비스는 DB 접속 권한도, 실제 S3 접근 권한도 없다.
+ * bucket 사용량은 리포트 로컬 저장 디렉터리 크기로 대체하고, database는 배치가 없어 0/null로 반환한다.
+ * 실제 DB/S3 사용량이 필요해지면 각 관측 대상의 admin API를 붙인다.
+ */
+@Component
+class LocalDiskStorageUsageAdapter(
+    @Value("\${monitor.report.storage-dir}") private val storageDir: String,
+    private val clock: Clock,
+) : StorageUsagePort {
+    override fun measure(): StorageUsage {
+        val files = File(storageDir).listFiles()?.filter { it.isFile } ?: emptyList()
+        return StorageUsage(
+            databaseUsedBytes = 0,
+            databaseTotalBytes = null,
+            bucketUsedBytes = files.sumOf { it.length() },
+            bucketObjectCount = files.size.toLong(),
+            measuredAt = Instant.now(clock),
+        )
+    }
+}

--- a/systems/observability/observability-application/BUILD.bazel
+++ b/systems/observability/observability-application/BUILD.bazel
@@ -17,5 +17,5 @@ kt_jvm_test(
     javac_opts = "//:javac_options",
     kotlinc_opts = "//:kotlinc_options",
     test_class = "hs.kr.entrydsm.observability.application.ObservabilityApplicationModuleTest",
-    deps = MODULE_DEPS + TEST_DEPS,
+    deps = [":main"] + MODULE_DEPS + TEST_DEPS,
 )

--- a/systems/observability/observability-application/deps.bzl
+++ b/systems/observability/observability-application/deps.bzl
@@ -1,4 +1,7 @@
-KOTLIN_DEPS = []
+KOTLIN_DEPS = [
+    "@maven//:org_springframework_boot_spring_boot_starter",
+    "//systems/observability/observability-domain:main",
+]
 
 TEST_DEPS = [
     "@maven//:junit_junit",

--- a/systems/observability/observability-application/src/main/kotlin/hs/kr/entrydsm/observability/application/ClientLogCollectionService.kt
+++ b/systems/observability/observability-application/src/main/kotlin/hs/kr/entrydsm/observability/application/ClientLogCollectionService.kt
@@ -1,0 +1,51 @@
+package hs.kr.entrydsm.observability.application
+
+import hs.kr.entrydsm.observability.application.port.`in`.ClientLogItem
+import hs.kr.entrydsm.observability.application.port.`in`.RecordClientLogUseCase
+import hs.kr.entrydsm.observability.application.port.`in`.result.ClientLogAcceptResult
+import hs.kr.entrydsm.observability.application.port.out.ClientLogInput
+import hs.kr.entrydsm.observability.application.port.out.ClientLogStorePort
+import hs.kr.entrydsm.observability.application.port.out.RateLimitPort
+import hs.kr.entrydsm.observability.domain.enum.ErrorCode
+import hs.kr.entrydsm.observability.domain.exception.MonitorDomainException
+import hs.kr.entrydsm.observability.domain.service.UserAgentParser
+import org.springframework.stereotype.Service
+
+@Service
+class ClientLogCollectionService(
+    private val clientLogStorePort: ClientLogStorePort,
+    private val rateLimitPort: RateLimitPort,
+) : RecordClientLogUseCase {
+
+    override fun record(sessionId: String, logs: List<ClientLogItem>, userAgent: String?, clientIp: String): ClientLogAcceptResult {
+        if (!rateLimitPort.tryAcquire("clientlog:$clientIp", RATE_LIMIT, RATE_LIMIT_WINDOW_SECONDS)) {
+            throw MonitorDomainException(ErrorCode.TOO_MANY_REQUESTS)
+        }
+        if (logs.isEmpty() || logs.size > MAX_BATCH_SIZE) {
+            throw MonitorDomainException(ErrorCode.INVALID_PAYLOAD)
+        }
+        val browser = UserAgentParser.browser(userAgent)
+        val os = UserAgentParser.os(userAgent)
+        logs.forEach { item ->
+            clientLogStorePort.record(
+                ClientLogInput(
+                    level = item.level,
+                    source = item.source,
+                    message = item.message.take(MAX_MESSAGE_LENGTH),
+                    pageUrl = item.pageUrl,
+                    browser = browser,
+                    os = os,
+                    occurredAt = item.occurredAt,
+                ),
+            )
+        }
+        return ClientLogAcceptResult(accepted = logs.size, rejected = 0)
+    }
+
+    companion object {
+        private const val MAX_BATCH_SIZE = 20
+        private const val MAX_MESSAGE_LENGTH = 500
+        private const val RATE_LIMIT = 60L
+        private const val RATE_LIMIT_WINDOW_SECONDS = 60L
+    }
+}

--- a/systems/observability/observability-application/src/main/kotlin/hs/kr/entrydsm/observability/application/ClientLogCollectionService.kt
+++ b/systems/observability/observability-application/src/main/kotlin/hs/kr/entrydsm/observability/application/ClientLogCollectionService.kt
@@ -5,6 +5,7 @@ import hs.kr.entrydsm.observability.application.port.`in`.RecordClientLogUseCase
 import hs.kr.entrydsm.observability.application.port.`in`.result.ClientLogAcceptResult
 import hs.kr.entrydsm.observability.application.port.out.ClientLogInput
 import hs.kr.entrydsm.observability.application.port.out.ClientLogStorePort
+import hs.kr.entrydsm.observability.application.port.out.LiveLogPublisherPort
 import hs.kr.entrydsm.observability.application.port.out.RateLimitPort
 import hs.kr.entrydsm.observability.domain.enum.ErrorCode
 import hs.kr.entrydsm.observability.domain.exception.MonitorDomainException
@@ -15,6 +16,7 @@ import org.springframework.stereotype.Service
 class ClientLogCollectionService(
     private val clientLogStorePort: ClientLogStorePort,
     private val rateLimitPort: RateLimitPort,
+    private val liveLogPublisherPort: LiveLogPublisherPort,
 ) : RecordClientLogUseCase {
 
     override fun record(sessionId: String, logs: List<ClientLogItem>, userAgent: String?, clientIp: String): ClientLogAcceptResult {
@@ -27,17 +29,17 @@ class ClientLogCollectionService(
         val browser = UserAgentParser.browser(userAgent)
         val os = UserAgentParser.os(userAgent)
         logs.forEach { item ->
-            clientLogStorePort.record(
-                ClientLogInput(
-                    level = item.level,
-                    source = item.source,
-                    message = item.message.take(MAX_MESSAGE_LENGTH),
-                    pageUrl = item.pageUrl,
-                    browser = browser,
-                    os = os,
-                    occurredAt = item.occurredAt,
-                ),
+            val input = ClientLogInput(
+                level = item.level,
+                source = item.source,
+                message = item.message.take(MAX_MESSAGE_LENGTH),
+                pageUrl = item.pageUrl,
+                browser = browser,
+                os = os,
+                occurredAt = item.occurredAt,
             )
+            clientLogStorePort.record(input)
+            liveLogPublisherPort.publishClientLog(input)
         }
         return ClientLogAcceptResult(accepted = logs.size, rejected = 0)
     }

--- a/systems/observability/observability-application/src/main/kotlin/hs/kr/entrydsm/observability/application/ClientLogQueryService.kt
+++ b/systems/observability/observability-application/src/main/kotlin/hs/kr/entrydsm/observability/application/ClientLogQueryService.kt
@@ -1,0 +1,36 @@
+package hs.kr.entrydsm.observability.application
+
+import hs.kr.entrydsm.observability.application.port.`in`.GetClientLogsUseCase
+import hs.kr.entrydsm.observability.application.port.out.ClientLogPage
+import hs.kr.entrydsm.observability.application.port.out.ClientLogStorePort
+import hs.kr.entrydsm.observability.domain.enum.ErrorCode
+import hs.kr.entrydsm.observability.domain.enum.LogLevel
+import hs.kr.entrydsm.observability.domain.exception.MonitorDomainException
+import hs.kr.entrydsm.observability.domain.model.Cursor
+import java.time.Clock
+import java.time.Duration
+import java.time.Instant
+import org.springframework.stereotype.Service
+
+@Service
+class ClientLogQueryService(
+    private val clientLogStorePort: ClientLogStorePort,
+    private val clock: Clock,
+) : GetClientLogsUseCase {
+
+    override fun getLogs(levels: Set<LogLevel>?, from: Instant?, to: Instant?, size: Int, cursor: Cursor?): ClientLogPage {
+        val now = Instant.now(clock)
+        val resolvedTo = to ?: now
+        val resolvedFrom = from ?: now.minus(DEFAULT_LOOKBACK)
+        if (resolvedFrom.isAfter(resolvedTo) || Duration.between(resolvedFrom, resolvedTo) > MAX_RANGE) {
+            throw MonitorDomainException(ErrorCode.INVALID_TIME_RANGE)
+        }
+        return clientLogStorePort.list(resolvedFrom, resolvedTo, levels, cursor, size.coerceIn(1, MAX_SIZE))
+    }
+
+    companion object {
+        private val DEFAULT_LOOKBACK: Duration = Duration.ofHours(1)
+        private val MAX_RANGE: Duration = Duration.ofDays(7)
+        private const val MAX_SIZE = 100
+    }
+}

--- a/systems/observability/observability-application/src/main/kotlin/hs/kr/entrydsm/observability/application/MetricsSeriesService.kt
+++ b/systems/observability/observability-application/src/main/kotlin/hs/kr/entrydsm/observability/application/MetricsSeriesService.kt
@@ -1,0 +1,58 @@
+package hs.kr.entrydsm.observability.application
+
+import hs.kr.entrydsm.observability.application.port.`in`.GetMetricsSeriesUseCase
+import hs.kr.entrydsm.observability.application.port.`in`.result.MetricPointResult
+import hs.kr.entrydsm.observability.application.port.`in`.result.MetricSeriesResult
+import hs.kr.entrydsm.observability.application.port.`in`.result.MetricsSeriesResult
+import hs.kr.entrydsm.observability.application.port.out.MetricsStorePort
+import hs.kr.entrydsm.observability.domain.enum.ErrorCode
+import hs.kr.entrydsm.observability.domain.enum.MetricType
+import hs.kr.entrydsm.observability.domain.exception.MonitorDomainException
+import hs.kr.entrydsm.observability.domain.service.TimeBucketer
+import java.time.Clock
+import java.time.Duration
+import java.time.Instant
+import java.time.ZoneId
+import org.springframework.stereotype.Service
+
+@Service
+class MetricsSeriesService(
+    private val metricsStorePort: MetricsStorePort,
+    private val clock: Clock,
+) : GetMetricsSeriesUseCase {
+
+    override fun getSeries(metrics: List<MetricType>, from: Instant?, to: Instant?, interval: String?): MetricsSeriesResult {
+        if (metrics.isEmpty()) throw MonitorDomainException(ErrorCode.INVALID_METRIC)
+
+        val now = Instant.now(clock)
+        val resolvedTo = to ?: now
+        val resolvedFrom = from ?: now.atZone(ZONE).toLocalDate().atStartOfDay(ZONE).toInstant()
+        if (resolvedFrom.isAfter(resolvedTo) || Duration.between(resolvedFrom, resolvedTo) > MAX_RANGE) {
+            throw MonitorDomainException(ErrorCode.INVALID_TIME_RANGE)
+        }
+
+        val resolvedInterval = interval ?: "1h"
+        val duration = TimeBucketer.durationOf(resolvedInterval) ?: throw MonitorDomainException(ErrorCode.INVALID_INTERVAL)
+        val buckets = TimeBucketer.bucketStarts(resolvedFrom, resolvedTo, duration)
+        if (buckets.size > MAX_BUCKETS) throw MonitorDomainException(ErrorCode.INVALID_INTERVAL)
+
+        val series = metrics.map { metric ->
+            val points = buckets.map { bucketStart ->
+                val value = when (metric) {
+                    MetricType.VISITOR -> metricsStorePort.visitorCount(bucketStart, bucketStart.plus(duration))
+                    // 다른 서비스로부터 API 요청 지표를 받는 수집 경로가 아직 없어 0으로 고정한다.
+                    MetricType.API_REQUEST -> 0L
+                }
+                MetricPointResult(bucketStart, value)
+            }
+            MetricSeriesResult(metric, points)
+        }
+        return MetricsSeriesResult(resolvedFrom, resolvedTo, resolvedInterval, series)
+    }
+
+    companion object {
+        private val ZONE: ZoneId = ZoneId.of("Asia/Seoul")
+        private val MAX_RANGE: Duration = Duration.ofDays(90)
+        private const val MAX_BUCKETS = 1000
+    }
+}

--- a/systems/observability/observability-application/src/main/kotlin/hs/kr/entrydsm/observability/application/MonitorDashboardService.kt
+++ b/systems/observability/observability-application/src/main/kotlin/hs/kr/entrydsm/observability/application/MonitorDashboardService.kt
@@ -1,0 +1,122 @@
+package hs.kr.entrydsm.observability.application
+
+import hs.kr.entrydsm.observability.application.port.`in`.GetDashboardSnapshotUseCase
+import hs.kr.entrydsm.observability.application.port.`in`.result.ApiStatsResult
+import hs.kr.entrydsm.observability.application.port.`in`.result.BusinessStatsResult
+import hs.kr.entrydsm.observability.application.port.`in`.result.ClientLogCountResult
+import hs.kr.entrydsm.observability.application.port.`in`.result.ConcurrentResult
+import hs.kr.entrydsm.observability.application.port.`in`.result.DashboardSnapshotResult
+import hs.kr.entrydsm.observability.application.port.`in`.result.DeviceStatResult
+import hs.kr.entrydsm.observability.application.port.`in`.result.OutcomeCountResult
+import hs.kr.entrydsm.observability.application.port.`in`.result.PeriodResult
+import hs.kr.entrydsm.observability.application.port.`in`.result.ResourceUsageBriefResult
+import hs.kr.entrydsm.observability.application.port.`in`.result.ServiceActivityItemResult
+import hs.kr.entrydsm.observability.application.port.`in`.result.ServiceActivityResult
+import hs.kr.entrydsm.observability.application.port.`in`.result.TrafficResult
+import hs.kr.entrydsm.observability.application.port.out.ClientLogStorePort
+import hs.kr.entrydsm.observability.application.port.out.HealthCheckPort
+import hs.kr.entrydsm.observability.application.port.out.RoundPort
+import hs.kr.entrydsm.observability.application.port.out.SessionStorePort
+import hs.kr.entrydsm.observability.application.port.out.StorageUsagePort
+import hs.kr.entrydsm.observability.domain.enum.DeviceType
+import hs.kr.entrydsm.observability.domain.enum.ErrorCode
+import hs.kr.entrydsm.observability.domain.enum.LogLevel
+import hs.kr.entrydsm.observability.domain.enum.ServiceName
+import hs.kr.entrydsm.observability.domain.exception.MonitorDomainException
+import hs.kr.entrydsm.observability.domain.service.HealthStatusClassifier
+import hs.kr.entrydsm.observability.domain.service.ServiceLabels
+import java.time.Clock
+import java.time.Duration
+import java.time.Instant
+import org.springframework.stereotype.Service
+
+@Service
+class MonitorDashboardService(
+    private val sessionStorePort: SessionStorePort,
+    private val healthCheckPort: HealthCheckPort,
+    private val clientLogStorePort: ClientLogStorePort,
+    private val storageUsagePort: StorageUsagePort,
+    private val roundPort: RoundPort,
+    private val clock: Clock,
+) : GetDashboardSnapshotUseCase {
+
+    override fun getSnapshot(round: String?): DashboardSnapshotResult {
+        val currentRound = roundPort.current()
+        if (round != null && !round.equals(currentRound.name, ignoreCase = true)) {
+            throw MonitorDomainException(ErrorCode.ROUND_NOT_FOUND)
+        }
+        val now = Instant.now(clock)
+
+        val totalVisitors = sessionStorePort.totalVisitors()
+        val deviceCounts = sessionStorePort.deviceBreakdown()
+        val devices = DeviceType.entries.map { type ->
+            val count = deviceCounts[type] ?: 0L
+            DeviceStatResult(type, count, ratio(count, totalVisitors))
+        }
+
+        val perServiceItems = ServiceName.entries.map { service ->
+            val check = healthCheckPort.check(service)
+            val status = HealthStatusClassifier.classify(check.responseTimeMs, check.dependencies.values.all { it })
+            ServiceActivityItemResult(
+                service = service.name,
+                label = ServiceLabels.of(service),
+                activeUsers = sessionStorePort.concurrentUsers(service, now, WINDOW_SECONDS),
+                status = status,
+            )
+        }
+        val totalActiveUsers = sessionStorePort.concurrentUsers(null, now, WINDOW_SECONDS)
+        val totalItem = ServiceActivityItemResult(
+            service = "TOTAL",
+            label = "종합",
+            activeUsers = totalActiveUsers,
+            status = HealthStatusClassifier.overall(perServiceItems.map { it.status }),
+        )
+
+        val logCounts = clientLogStorePort.countByLevel(now.minus(CLIENT_LOG_WINDOW), now)
+        val storage = storageUsagePort.measure()
+
+        return DashboardSnapshotResult(
+            generatedAt = now,
+            period = PeriodResult(
+                type = "ADMISSION",
+                round = currentRound.name,
+                from = currentRound.from,
+                to = currentRound.to,
+            ),
+            traffic = TrafficResult(
+                totalVisitors = totalVisitors,
+                concurrent = ConcurrentResult(
+                    current = totalActiveUsers,
+                    max = sessionStorePort.concurrentMax(),
+                    avg = sessionStorePort.concurrentAvg(),
+                ),
+                avgSessionDurationSeconds = sessionStorePort.avgSessionDurationSeconds(),
+                devices = devices,
+            ),
+            // 다른 서비스의 API 요청 지표를 받는 수집 경로가 아직 없어 0으로 고정한다.
+            api = ApiStatsResult(totalRequests = 0, successCount = 0, failureCount = 0, failureRate = 0.0),
+            // 원서접수/PDF다운로드 도메인 이벤트를 받는 수집 경로가 아직 없어 0으로 고정한다.
+            business = BusinessStatsResult(
+                applicationSubmit = OutcomeCountResult(0, 0),
+                pdfDownload = OutcomeCountResult(0, 0),
+            ),
+            services = ServiceActivityResult(windowSeconds = WINDOW_SECONDS, items = listOf(totalItem) + perServiceItems),
+            clientLog = ClientLogCountResult(
+                errorCount = logCounts[LogLevel.ERROR] ?: 0,
+                warnCount = logCounts[LogLevel.WARN] ?: 0,
+            ),
+            resource = ResourceUsageBriefResult(
+                dbUsedBytes = storage.databaseUsedBytes,
+                bucketUsedBytes = storage.bucketUsedBytes,
+                measuredAt = storage.measuredAt,
+            ),
+        )
+    }
+
+    private fun ratio(count: Long, total: Long): Double = if (total == 0L) 0.0 else count.toDouble() / total
+
+    companion object {
+        private const val WINDOW_SECONDS = 30L
+        private val CLIENT_LOG_WINDOW: Duration = Duration.ofHours(1)
+    }
+}

--- a/systems/observability/observability-application/src/main/kotlin/hs/kr/entrydsm/observability/application/MonitorHealthService.kt
+++ b/systems/observability/observability-application/src/main/kotlin/hs/kr/entrydsm/observability/application/MonitorHealthService.kt
@@ -1,0 +1,43 @@
+package hs.kr.entrydsm.observability.application
+
+import hs.kr.entrydsm.observability.application.port.`in`.GetServiceHealthUseCase
+import hs.kr.entrydsm.observability.application.port.`in`.result.DependencyStatusResult
+import hs.kr.entrydsm.observability.application.port.`in`.result.ServiceHealthItemResult
+import hs.kr.entrydsm.observability.application.port.`in`.result.ServiceHealthResult
+import hs.kr.entrydsm.observability.application.port.out.HealthCheckPort
+import hs.kr.entrydsm.observability.domain.enum.ServiceName
+import hs.kr.entrydsm.observability.domain.enum.ServiceStatus
+import hs.kr.entrydsm.observability.domain.service.HealthStatusClassifier
+import hs.kr.entrydsm.observability.domain.service.ServiceLabels
+import java.time.Clock
+import java.time.Instant
+import org.springframework.stereotype.Service
+
+@Service
+class MonitorHealthService(
+    private val healthCheckPort: HealthCheckPort,
+    private val clock: Clock,
+) : GetServiceHealthUseCase {
+
+    override fun getHealth(): ServiceHealthResult {
+        val services = ServiceName.entries.map { service ->
+            val check = healthCheckPort.check(service)
+            val allDependenciesUp = check.dependencies.values.all { it }
+            ServiceHealthItemResult(
+                service = service,
+                label = ServiceLabels.of(service),
+                status = HealthStatusClassifier.classify(check.responseTimeMs, allDependenciesUp),
+                responseTimeMs = check.responseTimeMs,
+                version = check.version,
+                dependencies = check.dependencies.map { (name, up) ->
+                    DependencyStatusResult(name, if (up) ServiceStatus.UP else ServiceStatus.DOWN)
+                },
+            )
+        }
+        return ServiceHealthResult(
+            overall = HealthStatusClassifier.overall(services.map { it.status }),
+            checkedAt = Instant.now(clock),
+            services = services,
+        )
+    }
+}

--- a/systems/observability/observability-application/src/main/kotlin/hs/kr/entrydsm/observability/application/ReportService.kt
+++ b/systems/observability/observability-application/src/main/kotlin/hs/kr/entrydsm/observability/application/ReportService.kt
@@ -1,0 +1,45 @@
+package hs.kr.entrydsm.observability.application
+
+import hs.kr.entrydsm.observability.application.port.`in`.GenerateReportUseCase
+import hs.kr.entrydsm.observability.application.port.`in`.GetDashboardSnapshotUseCase
+import hs.kr.entrydsm.observability.application.port.`in`.result.ReportResult
+import hs.kr.entrydsm.observability.application.port.out.ReportGeneratorPort
+import hs.kr.entrydsm.observability.application.port.out.ReportObjectStoragePort
+import hs.kr.entrydsm.observability.application.port.out.RoundPort
+import hs.kr.entrydsm.observability.domain.enum.ReportFormat
+import java.time.Clock
+import java.time.Instant
+import java.time.ZoneId
+import java.time.format.DateTimeFormatter
+import org.springframework.stereotype.Service
+
+/** ponytail: 데이터량이 적어 동기 생성만 지원한다(202 GENERATING/폴링 큐 없음). 느려지면 잡 큐로 교체. */
+@Service
+class ReportService(
+    private val getDashboardSnapshotUseCase: GetDashboardSnapshotUseCase,
+    private val reportGeneratorPort: ReportGeneratorPort,
+    private val reportObjectStoragePort: ReportObjectStoragePort,
+    private val roundPort: RoundPort,
+    private val clock: Clock,
+) : GenerateReportUseCase {
+
+    override fun generate(format: ReportFormat): ReportResult {
+        val snapshot = getDashboardSnapshotUseCase.getSnapshot(null)
+        val bytes = reportGeneratorPort.generate(format, snapshot)
+        val round = roundPort.current()
+        val dateStamp = DATE_FORMATTER.format(Instant.now(clock).atZone(ZONE))
+        val fileName = "entrymonitor_${round.name}_$dateStamp.${format.name.lowercase()}"
+        val stored = reportObjectStoragePort.store(fileName, bytes)
+        return ReportResult(
+            downloadUrl = stored.downloadUrl,
+            fileName = fileName,
+            sizeBytes = bytes.size.toLong(),
+            expiresAt = stored.expiresAt,
+        )
+    }
+
+    companion object {
+        private val ZONE: ZoneId = ZoneId.of("Asia/Seoul")
+        private val DATE_FORMATTER: DateTimeFormatter = DateTimeFormatter.ofPattern("yyyyMMdd")
+    }
+}

--- a/systems/observability/observability-application/src/main/kotlin/hs/kr/entrydsm/observability/application/ServerLogQueryService.kt
+++ b/systems/observability/observability-application/src/main/kotlin/hs/kr/entrydsm/observability/application/ServerLogQueryService.kt
@@ -1,0 +1,55 @@
+package hs.kr.entrydsm.observability.application
+
+import hs.kr.entrydsm.observability.application.port.`in`.GetServerLogsUseCase
+import hs.kr.entrydsm.observability.application.port.out.ServerLogPage
+import hs.kr.entrydsm.observability.application.port.out.ServerLogStorePort
+import hs.kr.entrydsm.observability.application.port.out.StatusFilter
+import hs.kr.entrydsm.observability.domain.enum.ErrorCode
+import hs.kr.entrydsm.observability.domain.enum.ServiceName
+import hs.kr.entrydsm.observability.domain.exception.MonitorDomainException
+import hs.kr.entrydsm.observability.domain.model.Cursor
+import java.time.Clock
+import java.time.Duration
+import java.time.Instant
+import org.springframework.stereotype.Service
+
+@Service
+class ServerLogQueryService(
+    private val serverLogStorePort: ServerLogStorePort,
+    private val clock: Clock,
+) : GetServerLogsUseCase {
+
+    override fun getLogs(
+        service: ServiceName?,
+        status: String?,
+        from: Instant?,
+        to: Instant?,
+        size: Int,
+        cursor: Cursor?,
+    ): ServerLogPage {
+        val now = Instant.now(clock)
+        val resolvedTo = to ?: now
+        val resolvedFrom = from ?: now.minus(DEFAULT_LOOKBACK)
+        if (resolvedFrom.isAfter(resolvedTo) || Duration.between(resolvedFrom, resolvedTo) > MAX_RANGE) {
+            throw MonitorDomainException(ErrorCode.INVALID_TIME_RANGE)
+        }
+        val statusFilter = parseStatus(status)
+        return serverLogStorePort.list(resolvedFrom, resolvedTo, service, statusFilter, cursor, size.coerceIn(1, MAX_SIZE))
+    }
+
+    private fun parseStatus(status: String?): StatusFilter? {
+        if (status == null) return null
+        val trimmed = status.trim()
+        if (trimmed.length == 3 && trimmed[1] == 'x' && trimmed[2] == 'x' && trimmed[0].isDigit()) {
+            return StatusFilter.StatusClass(trimmed[0])
+        }
+        return trimmed.toIntOrNull()?.let { StatusFilter.Exact(it) }
+            ?: throw MonitorDomainException(ErrorCode.INVALID_PAYLOAD)
+    }
+
+    companion object {
+        private val DEFAULT_LOOKBACK: Duration = Duration.ofHours(1)
+        private val MAX_RANGE: Duration = Duration.ofDays(7)
+        private const val MAX_SIZE = 100
+    }
+}

--- a/systems/observability/observability-application/src/main/kotlin/hs/kr/entrydsm/observability/application/SessionCollectionService.kt
+++ b/systems/observability/observability-application/src/main/kotlin/hs/kr/entrydsm/observability/application/SessionCollectionService.kt
@@ -1,0 +1,66 @@
+package hs.kr.entrydsm.observability.application
+
+import hs.kr.entrydsm.observability.application.port.`in`.RecordSessionEventUseCase
+import hs.kr.entrydsm.observability.application.port.`in`.result.SessionEventResult
+import hs.kr.entrydsm.observability.application.port.out.RateLimitPort
+import hs.kr.entrydsm.observability.application.port.out.SessionStorePort
+import hs.kr.entrydsm.observability.domain.enum.ErrorCode
+import hs.kr.entrydsm.observability.domain.enum.ServiceName
+import hs.kr.entrydsm.observability.domain.enum.SessionEventType
+import hs.kr.entrydsm.observability.domain.exception.MonitorDomainException
+import hs.kr.entrydsm.observability.domain.service.DeviceTypeParser
+import java.time.Clock
+import java.time.Instant
+import java.util.UUID
+import org.springframework.stereotype.Service
+
+@Service
+class SessionCollectionService(
+    private val sessionStorePort: SessionStorePort,
+    private val rateLimitPort: RateLimitPort,
+    private val clock: Clock,
+) : RecordSessionEventUseCase {
+
+    override fun record(
+        event: SessionEventType,
+        sessionId: String?,
+        service: ServiceName,
+        userAgent: String?,
+        clientIp: String,
+    ): SessionEventResult {
+        if (!rateLimitPort.tryAcquire("session:$clientIp", RATE_LIMIT, RATE_LIMIT_WINDOW_SECONDS)) {
+            throw MonitorDomainException(ErrorCode.TOO_MANY_REQUESTS)
+        }
+        val now = Instant.now(clock)
+        val resolvedSessionId = when (event) {
+            SessionEventType.ENTER -> {
+                val newSessionId = generateSessionId()
+                sessionStorePort.enter(newSessionId, service, DeviceTypeParser.parse(userAgent), now)
+                newSessionId
+            }
+            SessionEventType.HEARTBEAT -> {
+                val id = sessionId ?: throw MonitorDomainException(ErrorCode.INVALID_PAYLOAD)
+                if (!sessionStorePort.heartbeat(id, service, now)) {
+                    throw MonitorDomainException(ErrorCode.SESSION_NOT_FOUND)
+                }
+                id
+            }
+            SessionEventType.LEAVE -> {
+                val id = sessionId ?: throw MonitorDomainException(ErrorCode.INVALID_PAYLOAD)
+                if (!sessionStorePort.leave(id, service, now)) {
+                    throw MonitorDomainException(ErrorCode.SESSION_NOT_FOUND)
+                }
+                id
+            }
+        }
+        return SessionEventResult(resolvedSessionId, HEARTBEAT_INTERVAL_SECONDS)
+    }
+
+    private fun generateSessionId(): String = "sess_" + UUID.randomUUID().toString().replace("-", "").take(20)
+
+    companion object {
+        private const val HEARTBEAT_INTERVAL_SECONDS = 15
+        private const val RATE_LIMIT = 60L
+        private const val RATE_LIMIT_WINDOW_SECONDS = 60L
+    }
+}

--- a/systems/observability/observability-application/src/main/kotlin/hs/kr/entrydsm/observability/application/SessionCollectionService.kt
+++ b/systems/observability/observability-application/src/main/kotlin/hs/kr/entrydsm/observability/application/SessionCollectionService.kt
@@ -2,6 +2,7 @@ package hs.kr.entrydsm.observability.application
 
 import hs.kr.entrydsm.observability.application.port.`in`.RecordSessionEventUseCase
 import hs.kr.entrydsm.observability.application.port.`in`.result.SessionEventResult
+import hs.kr.entrydsm.observability.application.port.out.MetricsStorePort
 import hs.kr.entrydsm.observability.application.port.out.RateLimitPort
 import hs.kr.entrydsm.observability.application.port.out.SessionStorePort
 import hs.kr.entrydsm.observability.domain.enum.ErrorCode
@@ -18,6 +19,7 @@ import org.springframework.stereotype.Service
 class SessionCollectionService(
     private val sessionStorePort: SessionStorePort,
     private val rateLimitPort: RateLimitPort,
+    private val metricsStorePort: MetricsStorePort,
     private val clock: Clock,
 ) : RecordSessionEventUseCase {
 
@@ -36,6 +38,7 @@ class SessionCollectionService(
             SessionEventType.ENTER -> {
                 val newSessionId = generateSessionId()
                 sessionStorePort.enter(newSessionId, service, DeviceTypeParser.parse(userAgent), now)
+                metricsStorePort.recordVisitor(newSessionId, now)
                 newSessionId
             }
             SessionEventType.HEARTBEAT -> {
@@ -43,6 +46,7 @@ class SessionCollectionService(
                 if (!sessionStorePort.heartbeat(id, service, now)) {
                     throw MonitorDomainException(ErrorCode.SESSION_NOT_FOUND)
                 }
+                metricsStorePort.recordVisitor(id, now)
                 id
             }
             SessionEventType.LEAVE -> {

--- a/systems/observability/observability-application/src/main/kotlin/hs/kr/entrydsm/observability/application/StorageUsageQueryService.kt
+++ b/systems/observability/observability-application/src/main/kotlin/hs/kr/entrydsm/observability/application/StorageUsageQueryService.kt
@@ -1,0 +1,29 @@
+package hs.kr.entrydsm.observability.application
+
+import hs.kr.entrydsm.observability.application.port.`in`.GetStorageUsageUseCase
+import hs.kr.entrydsm.observability.application.port.`in`.result.BucketUsageResult
+import hs.kr.entrydsm.observability.application.port.`in`.result.DatabaseUsageResult
+import hs.kr.entrydsm.observability.application.port.`in`.result.StorageUsageResult
+import hs.kr.entrydsm.observability.application.port.out.StorageUsagePort
+import org.springframework.stereotype.Service
+
+/** ponytail: 실시간으로 측정하므로 서버 자체 캐시는 두지 않는다. cacheTtlSeconds는 클라이언트에 권장하는 캐시 기간이다. */
+@Service
+class StorageUsageQueryService(
+    private val storageUsagePort: StorageUsagePort,
+) : GetStorageUsageUseCase {
+
+    override fun getUsage(): StorageUsageResult {
+        val usage = storageUsagePort.measure()
+        val ratio = usage.databaseTotalBytes?.takeIf { it > 0 }?.let { usage.databaseUsedBytes.toDouble() / it }
+        return StorageUsageResult(
+            database = DatabaseUsageResult(usage.databaseUsedBytes, usage.databaseTotalBytes, ratio, usage.measuredAt),
+            bucket = BucketUsageResult(usage.bucketUsedBytes, usage.bucketObjectCount, usage.measuredAt),
+            cacheTtlSeconds = CACHE_TTL_SECONDS,
+        )
+    }
+
+    companion object {
+        private const val CACHE_TTL_SECONDS = 300
+    }
+}

--- a/systems/observability/observability-application/src/main/kotlin/hs/kr/entrydsm/observability/application/port/in/GenerateReportUseCase.kt
+++ b/systems/observability/observability-application/src/main/kotlin/hs/kr/entrydsm/observability/application/port/in/GenerateReportUseCase.kt
@@ -1,0 +1,8 @@
+package hs.kr.entrydsm.observability.application.port.`in`
+
+import hs.kr.entrydsm.observability.application.port.`in`.result.ReportResult
+import hs.kr.entrydsm.observability.domain.enum.ReportFormat
+
+interface GenerateReportUseCase {
+    fun generate(format: ReportFormat): ReportResult
+}

--- a/systems/observability/observability-application/src/main/kotlin/hs/kr/entrydsm/observability/application/port/in/GetClientLogsUseCase.kt
+++ b/systems/observability/observability-application/src/main/kotlin/hs/kr/entrydsm/observability/application/port/in/GetClientLogsUseCase.kt
@@ -1,0 +1,11 @@
+package hs.kr.entrydsm.observability.application.port.`in`
+
+import hs.kr.entrydsm.observability.application.port.out.ClientLogPage
+import hs.kr.entrydsm.observability.domain.enum.LogLevel
+import hs.kr.entrydsm.observability.domain.model.Cursor
+import java.time.Instant
+
+interface GetClientLogsUseCase {
+    /** @param levels null이면 전체 */
+    fun getLogs(levels: Set<LogLevel>?, from: Instant?, to: Instant?, size: Int, cursor: Cursor?): ClientLogPage
+}

--- a/systems/observability/observability-application/src/main/kotlin/hs/kr/entrydsm/observability/application/port/in/GetDashboardSnapshotUseCase.kt
+++ b/systems/observability/observability-application/src/main/kotlin/hs/kr/entrydsm/observability/application/port/in/GetDashboardSnapshotUseCase.kt
@@ -2,7 +2,7 @@ package hs.kr.entrydsm.observability.application.port.`in`
 
 import hs.kr.entrydsm.observability.application.port.`in`.result.DashboardSnapshotResult
 
-interface GetDashboardSnapshotUseCase {
+fun interface GetDashboardSnapshotUseCase {
     /** @param round 생략 시 진행 중인 회차 */
     fun getSnapshot(round: String?): DashboardSnapshotResult
 }

--- a/systems/observability/observability-application/src/main/kotlin/hs/kr/entrydsm/observability/application/port/in/GetDashboardSnapshotUseCase.kt
+++ b/systems/observability/observability-application/src/main/kotlin/hs/kr/entrydsm/observability/application/port/in/GetDashboardSnapshotUseCase.kt
@@ -1,0 +1,8 @@
+package hs.kr.entrydsm.observability.application.port.`in`
+
+import hs.kr.entrydsm.observability.application.port.`in`.result.DashboardSnapshotResult
+
+interface GetDashboardSnapshotUseCase {
+    /** @param round 생략 시 진행 중인 회차 */
+    fun getSnapshot(round: String?): DashboardSnapshotResult
+}

--- a/systems/observability/observability-application/src/main/kotlin/hs/kr/entrydsm/observability/application/port/in/GetMetricsSeriesUseCase.kt
+++ b/systems/observability/observability-application/src/main/kotlin/hs/kr/entrydsm/observability/application/port/in/GetMetricsSeriesUseCase.kt
@@ -1,0 +1,9 @@
+package hs.kr.entrydsm.observability.application.port.`in`
+
+import hs.kr.entrydsm.observability.application.port.`in`.result.MetricsSeriesResult
+import hs.kr.entrydsm.observability.domain.enum.MetricType
+import java.time.Instant
+
+interface GetMetricsSeriesUseCase {
+    fun getSeries(metrics: List<MetricType>, from: Instant?, to: Instant?, interval: String?): MetricsSeriesResult
+}

--- a/systems/observability/observability-application/src/main/kotlin/hs/kr/entrydsm/observability/application/port/in/GetServerLogsUseCase.kt
+++ b/systems/observability/observability-application/src/main/kotlin/hs/kr/entrydsm/observability/application/port/in/GetServerLogsUseCase.kt
@@ -1,0 +1,17 @@
+package hs.kr.entrydsm.observability.application.port.`in`
+
+import hs.kr.entrydsm.observability.application.port.out.ServerLogPage
+import hs.kr.entrydsm.observability.domain.enum.ServiceName
+import hs.kr.entrydsm.observability.domain.model.Cursor
+import java.time.Instant
+
+interface GetServerLogsUseCase {
+    fun getLogs(
+        service: ServiceName?,
+        status: String?,
+        from: Instant?,
+        to: Instant?,
+        size: Int,
+        cursor: Cursor?,
+    ): ServerLogPage
+}

--- a/systems/observability/observability-application/src/main/kotlin/hs/kr/entrydsm/observability/application/port/in/GetServiceHealthUseCase.kt
+++ b/systems/observability/observability-application/src/main/kotlin/hs/kr/entrydsm/observability/application/port/in/GetServiceHealthUseCase.kt
@@ -1,0 +1,7 @@
+package hs.kr.entrydsm.observability.application.port.`in`
+
+import hs.kr.entrydsm.observability.application.port.`in`.result.ServiceHealthResult
+
+interface GetServiceHealthUseCase {
+    fun getHealth(): ServiceHealthResult
+}

--- a/systems/observability/observability-application/src/main/kotlin/hs/kr/entrydsm/observability/application/port/in/GetStorageUsageUseCase.kt
+++ b/systems/observability/observability-application/src/main/kotlin/hs/kr/entrydsm/observability/application/port/in/GetStorageUsageUseCase.kt
@@ -1,0 +1,7 @@
+package hs.kr.entrydsm.observability.application.port.`in`
+
+import hs.kr.entrydsm.observability.application.port.`in`.result.StorageUsageResult
+
+interface GetStorageUsageUseCase {
+    fun getUsage(): StorageUsageResult
+}

--- a/systems/observability/observability-application/src/main/kotlin/hs/kr/entrydsm/observability/application/port/in/RecordClientLogUseCase.kt
+++ b/systems/observability/observability-application/src/main/kotlin/hs/kr/entrydsm/observability/application/port/in/RecordClientLogUseCase.kt
@@ -1,0 +1,19 @@
+package hs.kr.entrydsm.observability.application.port.`in`
+
+import hs.kr.entrydsm.observability.application.port.`in`.result.ClientLogAcceptResult
+import hs.kr.entrydsm.observability.domain.enum.LogLevel
+import hs.kr.entrydsm.observability.domain.enum.LogSource
+import java.time.Instant
+
+interface RecordClientLogUseCase {
+    fun record(sessionId: String, logs: List<ClientLogItem>, userAgent: String?, clientIp: String): ClientLogAcceptResult
+}
+
+data class ClientLogItem(
+    val level: LogLevel,
+    val source: LogSource,
+    val message: String,
+    val stack: String?,
+    val pageUrl: String,
+    val occurredAt: Instant,
+)

--- a/systems/observability/observability-application/src/main/kotlin/hs/kr/entrydsm/observability/application/port/in/RecordSessionEventUseCase.kt
+++ b/systems/observability/observability-application/src/main/kotlin/hs/kr/entrydsm/observability/application/port/in/RecordSessionEventUseCase.kt
@@ -1,0 +1,15 @@
+package hs.kr.entrydsm.observability.application.port.`in`
+
+import hs.kr.entrydsm.observability.application.port.`in`.result.SessionEventResult
+import hs.kr.entrydsm.observability.domain.enum.ServiceName
+import hs.kr.entrydsm.observability.domain.enum.SessionEventType
+
+interface RecordSessionEventUseCase {
+    fun record(
+        event: SessionEventType,
+        sessionId: String?,
+        service: ServiceName,
+        userAgent: String?,
+        clientIp: String,
+    ): SessionEventResult
+}

--- a/systems/observability/observability-application/src/main/kotlin/hs/kr/entrydsm/observability/application/port/in/result/ClientLogAcceptResult.kt
+++ b/systems/observability/observability-application/src/main/kotlin/hs/kr/entrydsm/observability/application/port/in/result/ClientLogAcceptResult.kt
@@ -1,0 +1,3 @@
+package hs.kr.entrydsm.observability.application.port.`in`.result
+
+data class ClientLogAcceptResult(val accepted: Int, val rejected: Int)

--- a/systems/observability/observability-application/src/main/kotlin/hs/kr/entrydsm/observability/application/port/in/result/DashboardSnapshotResult.kt
+++ b/systems/observability/observability-application/src/main/kotlin/hs/kr/entrydsm/observability/application/port/in/result/DashboardSnapshotResult.kt
@@ -1,0 +1,67 @@
+package hs.kr.entrydsm.observability.application.port.`in`.result
+
+import hs.kr.entrydsm.observability.domain.enum.DeviceType
+import hs.kr.entrydsm.observability.domain.enum.ServiceStatus
+import java.time.Instant
+
+data class DashboardSnapshotResult(
+    val generatedAt: Instant,
+    val period: PeriodResult,
+    val traffic: TrafficResult,
+    val api: ApiStatsResult,
+    val business: BusinessStatsResult,
+    val services: ServiceActivityResult,
+    val clientLog: ClientLogCountResult,
+    val resource: ResourceUsageBriefResult,
+)
+
+data class PeriodResult(
+    val type: String,
+    val round: String,
+    val from: Instant,
+    val to: Instant,
+)
+
+data class TrafficResult(
+    val totalVisitors: Long,
+    val concurrent: ConcurrentResult,
+    val avgSessionDurationSeconds: Long,
+    val devices: List<DeviceStatResult>,
+)
+
+data class ConcurrentResult(val current: Int, val max: Int, val avg: Int)
+
+data class DeviceStatResult(val type: DeviceType, val count: Long, val ratio: Double)
+
+/** 다른 서비스로부터 API 요청 지표를 받는 수집 경로가 아직 없어 항상 0으로 반환된다. */
+data class ApiStatsResult(
+    val totalRequests: Long,
+    val successCount: Long,
+    val failureCount: Long,
+    val failureRate: Double,
+)
+
+/** 원서접수/PDF다운로드 도메인 이벤트를 받는 수집 경로가 아직 없어 항상 0으로 반환된다. */
+data class BusinessStatsResult(
+    val applicationSubmit: OutcomeCountResult,
+    val pdfDownload: OutcomeCountResult,
+)
+
+data class OutcomeCountResult(val success: Long, val failure: Long)
+
+data class ServiceActivityResult(val windowSeconds: Long, val items: List<ServiceActivityItemResult>)
+
+data class ServiceActivityItemResult(
+    val service: String,
+    val label: String,
+    val activeUsers: Int,
+    val status: ServiceStatus,
+)
+
+data class ClientLogCountResult(val errorCount: Long, val warnCount: Long)
+
+data class ResourceUsageBriefResult(
+    val dbUsedBytes: Long,
+    val bucketUsedBytes: Long,
+    val measuredAt: Instant,
+)

--- a/systems/observability/observability-application/src/main/kotlin/hs/kr/entrydsm/observability/application/port/in/result/MetricsSeriesResult.kt
+++ b/systems/observability/observability-application/src/main/kotlin/hs/kr/entrydsm/observability/application/port/in/result/MetricsSeriesResult.kt
@@ -1,0 +1,15 @@
+package hs.kr.entrydsm.observability.application.port.`in`.result
+
+import hs.kr.entrydsm.observability.domain.enum.MetricType
+import java.time.Instant
+
+data class MetricsSeriesResult(
+    val from: Instant,
+    val to: Instant,
+    val interval: String,
+    val series: List<MetricSeriesResult>,
+)
+
+data class MetricSeriesResult(val metric: MetricType, val points: List<MetricPointResult>)
+
+data class MetricPointResult(val t: Instant, val v: Long)

--- a/systems/observability/observability-application/src/main/kotlin/hs/kr/entrydsm/observability/application/port/in/result/ReportResult.kt
+++ b/systems/observability/observability-application/src/main/kotlin/hs/kr/entrydsm/observability/application/port/in/result/ReportResult.kt
@@ -1,0 +1,10 @@
+package hs.kr.entrydsm.observability.application.port.`in`.result
+
+import java.time.Instant
+
+data class ReportResult(
+    val downloadUrl: String,
+    val fileName: String,
+    val sizeBytes: Long,
+    val expiresAt: Instant,
+)

--- a/systems/observability/observability-application/src/main/kotlin/hs/kr/entrydsm/observability/application/port/in/result/ServiceHealthResult.kt
+++ b/systems/observability/observability-application/src/main/kotlin/hs/kr/entrydsm/observability/application/port/in/result/ServiceHealthResult.kt
@@ -1,0 +1,25 @@
+package hs.kr.entrydsm.observability.application.port.`in`.result
+
+import hs.kr.entrydsm.observability.domain.enum.ServiceName
+import hs.kr.entrydsm.observability.domain.enum.ServiceStatus
+import java.time.Instant
+
+data class ServiceHealthResult(
+    val overall: ServiceStatus,
+    val checkedAt: Instant,
+    val services: List<ServiceHealthItemResult>,
+)
+
+data class ServiceHealthItemResult(
+    val service: ServiceName,
+    val label: String,
+    val status: ServiceStatus,
+    val responseTimeMs: Long?,
+    val version: String?,
+    val dependencies: List<DependencyStatusResult>,
+)
+
+data class DependencyStatusResult(
+    val name: String,
+    val status: ServiceStatus,
+)

--- a/systems/observability/observability-application/src/main/kotlin/hs/kr/entrydsm/observability/application/port/in/result/SessionEventResult.kt
+++ b/systems/observability/observability-application/src/main/kotlin/hs/kr/entrydsm/observability/application/port/in/result/SessionEventResult.kt
@@ -1,0 +1,6 @@
+package hs.kr.entrydsm.observability.application.port.`in`.result
+
+data class SessionEventResult(
+    val sessionId: String,
+    val heartbeatIntervalSeconds: Int,
+)

--- a/systems/observability/observability-application/src/main/kotlin/hs/kr/entrydsm/observability/application/port/in/result/StorageUsageResult.kt
+++ b/systems/observability/observability-application/src/main/kotlin/hs/kr/entrydsm/observability/application/port/in/result/StorageUsageResult.kt
@@ -1,0 +1,22 @@
+package hs.kr.entrydsm.observability.application.port.`in`.result
+
+import java.time.Instant
+
+data class StorageUsageResult(
+    val database: DatabaseUsageResult,
+    val bucket: BucketUsageResult,
+    val cacheTtlSeconds: Int,
+)
+
+data class DatabaseUsageResult(
+    val usedBytes: Long,
+    val totalBytes: Long?,
+    val usageRatio: Double?,
+    val measuredAt: Instant,
+)
+
+data class BucketUsageResult(
+    val usedBytes: Long,
+    val objectCount: Long,
+    val measuredAt: Instant,
+)

--- a/systems/observability/observability-application/src/main/kotlin/hs/kr/entrydsm/observability/application/port/out/ClientLogStorePort.kt
+++ b/systems/observability/observability-application/src/main/kotlin/hs/kr/entrydsm/observability/application/port/out/ClientLogStorePort.kt
@@ -1,0 +1,47 @@
+package hs.kr.entrydsm.observability.application.port.out
+
+import hs.kr.entrydsm.observability.domain.enum.LogLevel
+import hs.kr.entrydsm.observability.domain.enum.LogSource
+import hs.kr.entrydsm.observability.domain.model.Cursor
+import java.time.Instant
+
+interface ClientLogStorePort {
+    fun record(input: ClientLogInput)
+
+    /** 그룹(fingerprint) 단위 개수를 레벨별로 반환한다. */
+    fun countByLevel(from: Instant, to: Instant): Map<LogLevel, Long>
+
+    fun list(from: Instant, to: Instant, levels: Set<LogLevel>?, cursor: Cursor?, size: Int): ClientLogPage
+}
+
+data class ClientLogInput(
+    val level: LogLevel,
+    val source: LogSource,
+    val message: String,
+    val pageUrl: String,
+    val browser: String?,
+    val os: String?,
+    val occurredAt: Instant,
+)
+
+data class ClientLogEntry(
+    val fingerprint: String,
+    val level: LogLevel,
+    val message: String,
+    val source: LogSource,
+    val pageUrl: String,
+    val browser: String?,
+    val os: String?,
+    val count: Long,
+    val firstOccurredAt: Instant,
+    val lastOccurredAt: Instant,
+)
+
+data class ClientLogPage(
+    val totalCount: Long,
+    val errorCount: Long,
+    val warnCount: Long,
+    val items: List<ClientLogEntry>,
+    val nextCursor: Cursor?,
+    val hasNext: Boolean,
+)

--- a/systems/observability/observability-application/src/main/kotlin/hs/kr/entrydsm/observability/application/port/out/HealthCheckPort.kt
+++ b/systems/observability/observability-application/src/main/kotlin/hs/kr/entrydsm/observability/application/port/out/HealthCheckPort.kt
@@ -1,0 +1,13 @@
+package hs.kr.entrydsm.observability.application.port.out
+
+import hs.kr.entrydsm.observability.domain.enum.ServiceName
+
+fun interface HealthCheckPort {
+    fun check(service: ServiceName): ServiceHealthCheck
+}
+
+data class ServiceHealthCheck(
+    val responseTimeMs: Long?,
+    val version: String?,
+    val dependencies: Map<String, Boolean>,
+)

--- a/systems/observability/observability-application/src/main/kotlin/hs/kr/entrydsm/observability/application/port/out/LiveLogPublisherPort.kt
+++ b/systems/observability/observability-application/src/main/kotlin/hs/kr/entrydsm/observability/application/port/out/LiveLogPublisherPort.kt
@@ -1,0 +1,6 @@
+package hs.kr.entrydsm.observability.application.port.out
+
+fun interface LiveLogPublisherPort {
+    /** SSE log 이벤트로 즉시 내보낸다. 구독자가 없으면 아무 일도 하지 않는다. */
+    fun publishClientLog(input: ClientLogInput)
+}

--- a/systems/observability/observability-application/src/main/kotlin/hs/kr/entrydsm/observability/application/port/out/MetricsStorePort.kt
+++ b/systems/observability/observability-application/src/main/kotlin/hs/kr/entrydsm/observability/application/port/out/MetricsStorePort.kt
@@ -1,0 +1,11 @@
+package hs.kr.entrydsm.observability.application.port.out
+
+import java.time.Instant
+
+interface MetricsStorePort {
+    /** 세션의 ENTER/HEARTBEAT 시각을 5분 단위 버킷에 기록한다. */
+    fun recordVisitor(sessionId: String, at: Instant)
+
+    /** [from, to) 구간의 고유 세션 수. */
+    fun visitorCount(from: Instant, to: Instant): Long
+}

--- a/systems/observability/observability-application/src/main/kotlin/hs/kr/entrydsm/observability/application/port/out/RateLimitPort.kt
+++ b/systems/observability/observability-application/src/main/kotlin/hs/kr/entrydsm/observability/application/port/out/RateLimitPort.kt
@@ -1,0 +1,6 @@
+package hs.kr.entrydsm.observability.application.port.out
+
+interface RateLimitPort {
+    /** @return windowSeconds 동안 key에 대해 limit회를 초과하지 않았으면 true */
+    fun tryAcquire(key: String, limit: Long, windowSeconds: Long): Boolean
+}

--- a/systems/observability/observability-application/src/main/kotlin/hs/kr/entrydsm/observability/application/port/out/ReportGeneratorPort.kt
+++ b/systems/observability/observability-application/src/main/kotlin/hs/kr/entrydsm/observability/application/port/out/ReportGeneratorPort.kt
@@ -1,0 +1,8 @@
+package hs.kr.entrydsm.observability.application.port.out
+
+import hs.kr.entrydsm.observability.application.port.`in`.result.DashboardSnapshotResult
+import hs.kr.entrydsm.observability.domain.enum.ReportFormat
+
+fun interface ReportGeneratorPort {
+    fun generate(format: ReportFormat, snapshot: DashboardSnapshotResult): ByteArray
+}

--- a/systems/observability/observability-application/src/main/kotlin/hs/kr/entrydsm/observability/application/port/out/ReportObjectStoragePort.kt
+++ b/systems/observability/observability-application/src/main/kotlin/hs/kr/entrydsm/observability/application/port/out/ReportObjectStoragePort.kt
@@ -1,0 +1,13 @@
+package hs.kr.entrydsm.observability.application.port.out
+
+import java.time.Instant
+
+interface ReportObjectStoragePort {
+    fun store(fileName: String, bytes: ByteArray): StoredReport
+
+    fun resolve(token: String): DownloadedReport?
+}
+
+data class StoredReport(val downloadUrl: String, val expiresAt: Instant)
+
+data class DownloadedReport(val fileName: String, val bytes: ByteArray)

--- a/systems/observability/observability-application/src/main/kotlin/hs/kr/entrydsm/observability/application/port/out/RoundPort.kt
+++ b/systems/observability/observability-application/src/main/kotlin/hs/kr/entrydsm/observability/application/port/out/RoundPort.kt
@@ -1,0 +1,9 @@
+package hs.kr.entrydsm.observability.application.port.out
+
+import java.time.Instant
+
+fun interface RoundPort {
+    fun current(): Round
+}
+
+data class Round(val name: String, val from: Instant, val to: Instant)

--- a/systems/observability/observability-application/src/main/kotlin/hs/kr/entrydsm/observability/application/port/out/ServerLogStorePort.kt
+++ b/systems/observability/observability-application/src/main/kotlin/hs/kr/entrydsm/observability/application/port/out/ServerLogStorePort.kt
@@ -1,0 +1,42 @@
+package hs.kr.entrydsm.observability.application.port.out
+
+import hs.kr.entrydsm.observability.domain.enum.ServiceName
+import hs.kr.entrydsm.observability.domain.model.Cursor
+import java.time.Instant
+
+interface ServerLogStorePort {
+    fun list(
+        from: Instant,
+        to: Instant,
+        service: ServiceName?,
+        status: StatusFilter?,
+        cursor: Cursor?,
+        size: Int,
+    ): ServerLogPage
+}
+
+sealed interface StatusFilter {
+    data class StatusClass(val leadingDigit: Char) : StatusFilter
+    data class Exact(val code: Int) : StatusFilter
+}
+
+data class ServerLogEntry(
+    val fingerprint: String,
+    val service: ServiceName,
+    val method: String,
+    val path: String,
+    val status: Int,
+    val code: String,
+    val grpcStatus: String?,
+    val message: String,
+    val count: Long,
+    val firstOccurredAt: Instant,
+    val lastOccurredAt: Instant,
+)
+
+data class ServerLogPage(
+    val totalCount: Long,
+    val items: List<ServerLogEntry>,
+    val nextCursor: Cursor?,
+    val hasNext: Boolean,
+)

--- a/systems/observability/observability-application/src/main/kotlin/hs/kr/entrydsm/observability/application/port/out/SessionStorePort.kt
+++ b/systems/observability/observability-application/src/main/kotlin/hs/kr/entrydsm/observability/application/port/out/SessionStorePort.kt
@@ -1,0 +1,30 @@
+package hs.kr.entrydsm.observability.application.port.out
+
+import hs.kr.entrydsm.observability.domain.enum.DeviceType
+import hs.kr.entrydsm.observability.domain.enum.ServiceName
+import java.time.Instant
+
+interface SessionStorePort {
+    fun enter(sessionId: String, service: ServiceName, deviceType: DeviceType, now: Instant)
+
+    /** @return 세션이 존재하지 않으면 false */
+    fun heartbeat(sessionId: String, service: ServiceName, now: Instant): Boolean
+
+    /** @return 세션이 존재하지 않으면 false */
+    fun leave(sessionId: String, service: ServiceName, now: Instant): Boolean
+
+    /** service가 null이면 서비스 중복 제거된 전체(TOTAL) 동시 접속자 수를 반환한다. */
+    fun concurrentUsers(service: ServiceName?, now: Instant, windowSeconds: Long): Int
+
+    fun totalVisitors(): Long
+
+    fun avgSessionDurationSeconds(): Long
+
+    fun deviceBreakdown(): Map<DeviceType, Long>
+
+    fun sampleConcurrency(now: Instant, windowSeconds: Long)
+
+    fun concurrentMax(): Int
+
+    fun concurrentAvg(): Int
+}

--- a/systems/observability/observability-application/src/main/kotlin/hs/kr/entrydsm/observability/application/port/out/StorageUsagePort.kt
+++ b/systems/observability/observability-application/src/main/kotlin/hs/kr/entrydsm/observability/application/port/out/StorageUsagePort.kt
@@ -1,0 +1,15 @@
+package hs.kr.entrydsm.observability.application.port.out
+
+import java.time.Instant
+
+fun interface StorageUsagePort {
+    fun measure(): StorageUsage
+}
+
+data class StorageUsage(
+    val databaseUsedBytes: Long,
+    val databaseTotalBytes: Long?,
+    val bucketUsedBytes: Long,
+    val bucketObjectCount: Long,
+    val measuredAt: Instant,
+)

--- a/systems/observability/observability-application/src/test/kotlin/hs/kr/entrydsm/TestMain.kt
+++ b/systems/observability/observability-application/src/test/kotlin/hs/kr/entrydsm/TestMain.kt
@@ -13,5 +13,6 @@ import org.junit.runners.Suite
     ClientLogQueryServiceTest::class,
     ServerLogQueryServiceTest::class,
     StorageUsageQueryServiceTest::class,
+    ReportServiceTest::class,
 )
 class ObservabilityApplicationModuleTest

--- a/systems/observability/observability-application/src/test/kotlin/hs/kr/entrydsm/TestMain.kt
+++ b/systems/observability/observability-application/src/test/kotlin/hs/kr/entrydsm/TestMain.kt
@@ -6,5 +6,6 @@ import org.junit.runners.Suite
 @RunWith(Suite::class)
 @Suite.SuiteClasses(
     SessionCollectionServiceTest::class,
+    MonitorHealthServiceTest::class,
 )
 class ObservabilityApplicationModuleTest

--- a/systems/observability/observability-application/src/test/kotlin/hs/kr/entrydsm/TestMain.kt
+++ b/systems/observability/observability-application/src/test/kotlin/hs/kr/entrydsm/TestMain.kt
@@ -8,5 +8,6 @@ import org.junit.runners.Suite
     SessionCollectionServiceTest::class,
     MonitorHealthServiceTest::class,
     MonitorDashboardServiceTest::class,
+    MetricsSeriesServiceTest::class,
 )
 class ObservabilityApplicationModuleTest

--- a/systems/observability/observability-application/src/test/kotlin/hs/kr/entrydsm/TestMain.kt
+++ b/systems/observability/observability-application/src/test/kotlin/hs/kr/entrydsm/TestMain.kt
@@ -7,5 +7,6 @@ import org.junit.runners.Suite
 @Suite.SuiteClasses(
     SessionCollectionServiceTest::class,
     MonitorHealthServiceTest::class,
+    MonitorDashboardServiceTest::class,
 )
 class ObservabilityApplicationModuleTest

--- a/systems/observability/observability-application/src/test/kotlin/hs/kr/entrydsm/TestMain.kt
+++ b/systems/observability/observability-application/src/test/kotlin/hs/kr/entrydsm/TestMain.kt
@@ -1,11 +1,10 @@
 package hs.kr.entrydsm.observability.application
 
-import org.junit.Assert.assertTrue
-import org.junit.Test
+import org.junit.runner.RunWith
+import org.junit.runners.Suite
 
-class ObservabilityApplicationModuleTest {
-    @Test
-    fun moduleLoads() {
-        assertTrue(true)
-    }
-}
+@RunWith(Suite::class)
+@Suite.SuiteClasses(
+    SessionCollectionServiceTest::class,
+)
+class ObservabilityApplicationModuleTest

--- a/systems/observability/observability-application/src/test/kotlin/hs/kr/entrydsm/TestMain.kt
+++ b/systems/observability/observability-application/src/test/kotlin/hs/kr/entrydsm/TestMain.kt
@@ -12,5 +12,6 @@ import org.junit.runners.Suite
     ClientLogCollectionServiceTest::class,
     ClientLogQueryServiceTest::class,
     ServerLogQueryServiceTest::class,
+    StorageUsageQueryServiceTest::class,
 )
 class ObservabilityApplicationModuleTest

--- a/systems/observability/observability-application/src/test/kotlin/hs/kr/entrydsm/TestMain.kt
+++ b/systems/observability/observability-application/src/test/kotlin/hs/kr/entrydsm/TestMain.kt
@@ -10,5 +10,6 @@ import org.junit.runners.Suite
     MonitorDashboardServiceTest::class,
     MetricsSeriesServiceTest::class,
     ClientLogCollectionServiceTest::class,
+    ClientLogQueryServiceTest::class,
 )
 class ObservabilityApplicationModuleTest

--- a/systems/observability/observability-application/src/test/kotlin/hs/kr/entrydsm/TestMain.kt
+++ b/systems/observability/observability-application/src/test/kotlin/hs/kr/entrydsm/TestMain.kt
@@ -9,5 +9,6 @@ import org.junit.runners.Suite
     MonitorHealthServiceTest::class,
     MonitorDashboardServiceTest::class,
     MetricsSeriesServiceTest::class,
+    ClientLogCollectionServiceTest::class,
 )
 class ObservabilityApplicationModuleTest

--- a/systems/observability/observability-application/src/test/kotlin/hs/kr/entrydsm/TestMain.kt
+++ b/systems/observability/observability-application/src/test/kotlin/hs/kr/entrydsm/TestMain.kt
@@ -11,5 +11,6 @@ import org.junit.runners.Suite
     MetricsSeriesServiceTest::class,
     ClientLogCollectionServiceTest::class,
     ClientLogQueryServiceTest::class,
+    ServerLogQueryServiceTest::class,
 )
 class ObservabilityApplicationModuleTest

--- a/systems/observability/observability-application/src/test/kotlin/hs/kr/entrydsm/observability/application/ClientLogCollectionServiceTest.kt
+++ b/systems/observability/observability-application/src/test/kotlin/hs/kr/entrydsm/observability/application/ClientLogCollectionServiceTest.kt
@@ -1,0 +1,74 @@
+package hs.kr.entrydsm.observability.application
+
+import hs.kr.entrydsm.observability.application.port.`in`.ClientLogItem
+import hs.kr.entrydsm.observability.application.port.out.ClientLogEntry
+import hs.kr.entrydsm.observability.application.port.out.ClientLogInput
+import hs.kr.entrydsm.observability.application.port.out.ClientLogPage
+import hs.kr.entrydsm.observability.application.port.out.ClientLogStorePort
+import hs.kr.entrydsm.observability.application.port.out.RateLimitPort
+import hs.kr.entrydsm.observability.domain.enum.LogLevel
+import hs.kr.entrydsm.observability.domain.enum.LogSource
+import hs.kr.entrydsm.observability.domain.exception.MonitorDomainException
+import hs.kr.entrydsm.observability.domain.model.Cursor
+import java.time.Instant
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertThrows
+import org.junit.Test
+
+class ClientLogCollectionServiceTest {
+    private val store = FakeClientLogStorePort()
+
+    private fun item() = ClientLogItem(
+        level = LogLevel.ERROR,
+        source = LogSource.DOM,
+        message = "a".repeat(600),
+        stack = null,
+        pageUrl = "/application/personal",
+        occurredAt = Instant.parse("2026-07-28T13:58:41Z"),
+    )
+
+    @Test
+    fun truncatesOverlongMessageAndRecordsEachItem() {
+        val service = ClientLogCollectionService(store, FakeRateLimitPort(true))
+
+        val result = service.record("sess_1", listOf(item()), "Mozilla/5.0 (Windows NT 10.0) Chrome/138.0.0.0", "127.0.0.1")
+
+        assertEquals(1, result.accepted)
+        assertEquals(0, result.rejected)
+        assertEquals(500, store.recorded.single().message.length)
+        assertEquals("Chrome 138", store.recorded.single().browser)
+    }
+
+    @Test
+    fun rejectsEmptyOrOversizedBatch() {
+        val service = ClientLogCollectionService(store, FakeRateLimitPort(true))
+
+        assertThrows(MonitorDomainException::class.java) { service.record("sess_1", emptyList(), null, "127.0.0.1") }
+        assertThrows(MonitorDomainException::class.java) {
+            service.record("sess_1", List(21) { item() }, null, "127.0.0.1")
+        }
+    }
+
+    @Test
+    fun rateLimitExceededThrowsTooManyRequests() {
+        val service = ClientLogCollectionService(store, FakeRateLimitPort(false))
+
+        assertThrows(MonitorDomainException::class.java) {
+            service.record("sess_1", listOf(item()), null, "127.0.0.1")
+        }
+    }
+
+    private class FakeClientLogStorePort : ClientLogStorePort {
+        val recorded = mutableListOf<ClientLogInput>()
+        override fun record(input: ClientLogInput) {
+            recorded.add(input)
+        }
+        override fun countByLevel(from: Instant, to: Instant): Map<LogLevel, Long> = emptyMap()
+        override fun list(from: Instant, to: Instant, levels: Set<LogLevel>?, cursor: Cursor?, size: Int): ClientLogPage =
+            ClientLogPage(0, 0, 0, emptyList<ClientLogEntry>(), null, false)
+    }
+
+    private class FakeRateLimitPort(private val allow: Boolean) : RateLimitPort {
+        override fun tryAcquire(key: String, limit: Long, windowSeconds: Long) = allow
+    }
+}

--- a/systems/observability/observability-application/src/test/kotlin/hs/kr/entrydsm/observability/application/ClientLogCollectionServiceTest.kt
+++ b/systems/observability/observability-application/src/test/kotlin/hs/kr/entrydsm/observability/application/ClientLogCollectionServiceTest.kt
@@ -6,6 +6,7 @@ import hs.kr.entrydsm.observability.application.port.out.ClientLogInput
 import hs.kr.entrydsm.observability.application.port.out.ClientLogPage
 import hs.kr.entrydsm.observability.application.port.out.ClientLogStorePort
 import hs.kr.entrydsm.observability.application.port.out.RateLimitPort
+import hs.kr.entrydsm.observability.application.port.out.LiveLogPublisherPort
 import hs.kr.entrydsm.observability.domain.enum.LogLevel
 import hs.kr.entrydsm.observability.domain.enum.LogSource
 import hs.kr.entrydsm.observability.domain.exception.MonitorDomainException
@@ -29,7 +30,7 @@ class ClientLogCollectionServiceTest {
 
     @Test
     fun truncatesOverlongMessageAndRecordsEachItem() {
-        val service = ClientLogCollectionService(store, FakeRateLimitPort(true))
+        val service = ClientLogCollectionService(store, FakeRateLimitPort(true), LiveLogPublisherPort {})
 
         val result = service.record("sess_1", listOf(item()), "Mozilla/5.0 (Windows NT 10.0) Chrome/138.0.0.0", "127.0.0.1")
 
@@ -41,7 +42,7 @@ class ClientLogCollectionServiceTest {
 
     @Test
     fun rejectsEmptyOrOversizedBatch() {
-        val service = ClientLogCollectionService(store, FakeRateLimitPort(true))
+        val service = ClientLogCollectionService(store, FakeRateLimitPort(true), LiveLogPublisherPort {})
 
         assertThrows(MonitorDomainException::class.java) { service.record("sess_1", emptyList(), null, "127.0.0.1") }
         assertThrows(MonitorDomainException::class.java) {
@@ -51,7 +52,7 @@ class ClientLogCollectionServiceTest {
 
     @Test
     fun rateLimitExceededThrowsTooManyRequests() {
-        val service = ClientLogCollectionService(store, FakeRateLimitPort(false))
+        val service = ClientLogCollectionService(store, FakeRateLimitPort(false), LiveLogPublisherPort {})
 
         assertThrows(MonitorDomainException::class.java) {
             service.record("sess_1", listOf(item()), null, "127.0.0.1")

--- a/systems/observability/observability-application/src/test/kotlin/hs/kr/entrydsm/observability/application/ClientLogQueryServiceTest.kt
+++ b/systems/observability/observability-application/src/test/kotlin/hs/kr/entrydsm/observability/application/ClientLogQueryServiceTest.kt
@@ -1,0 +1,41 @@
+package hs.kr.entrydsm.observability.application
+
+import hs.kr.entrydsm.observability.application.port.out.ClientLogEntry
+import hs.kr.entrydsm.observability.application.port.out.ClientLogInput
+import hs.kr.entrydsm.observability.application.port.out.ClientLogPage
+import hs.kr.entrydsm.observability.application.port.out.ClientLogStorePort
+import hs.kr.entrydsm.observability.domain.enum.LogLevel
+import hs.kr.entrydsm.observability.domain.exception.MonitorDomainException
+import hs.kr.entrydsm.observability.domain.model.Cursor
+import java.time.Clock
+import java.time.Instant
+import java.time.ZoneOffset
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertThrows
+import org.junit.Test
+
+class ClientLogQueryServiceTest {
+    private val clock = Clock.fixed(Instant.parse("2026-07-28T14:00:00Z"), ZoneOffset.UTC)
+    private val service = ClientLogQueryService(FakeClientLogStorePort(), clock)
+
+    @Test
+    fun defaultsToOneHourLookbackAndClampsSize() {
+        val result = service.getLogs(null, null, null, 500, null)
+
+        assertEquals(1, result.totalCount)
+    }
+
+    @Test
+    fun rejectsRangeOverSevenDays() {
+        assertThrows(MonitorDomainException::class.java) {
+            service.getLogs(null, Instant.parse("2026-07-01T00:00:00Z"), Instant.parse("2026-07-28T00:00:00Z"), 20, null)
+        }
+    }
+
+    private class FakeClientLogStorePort : ClientLogStorePort {
+        override fun record(input: ClientLogInput) = Unit
+        override fun countByLevel(from: Instant, to: Instant): Map<LogLevel, Long> = emptyMap()
+        override fun list(from: Instant, to: Instant, levels: Set<LogLevel>?, cursor: Cursor?, size: Int): ClientLogPage =
+            ClientLogPage(1, 1, 0, emptyList<ClientLogEntry>(), null, false)
+    }
+}

--- a/systems/observability/observability-application/src/test/kotlin/hs/kr/entrydsm/observability/application/MetricsSeriesServiceTest.kt
+++ b/systems/observability/observability-application/src/test/kotlin/hs/kr/entrydsm/observability/application/MetricsSeriesServiceTest.kt
@@ -1,0 +1,66 @@
+package hs.kr.entrydsm.observability.application
+
+import hs.kr.entrydsm.observability.application.port.out.MetricsStorePort
+import hs.kr.entrydsm.observability.domain.enum.MetricType
+import hs.kr.entrydsm.observability.domain.exception.MonitorDomainException
+import java.time.Clock
+import java.time.Duration
+import java.time.Instant
+import java.time.ZoneOffset
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertThrows
+import org.junit.Test
+
+class MetricsSeriesServiceTest {
+    private val clock = Clock.fixed(Instant.parse("2026-07-28T14:00:00Z"), ZoneOffset.UTC)
+    private val service = MetricsSeriesService(FakeMetricsStorePort(), clock)
+
+    @Test
+    fun buildsZeroFilledPointsForApiRequestAndVisitorFromStore() {
+        val from = Instant.parse("2026-07-28T00:00:00Z")
+        val to = Instant.parse("2026-07-28T02:00:00Z")
+
+        val result = service.getSeries(listOf(MetricType.API_REQUEST, MetricType.VISITOR), from, to, "1h")
+
+        assertEquals(2, result.series.first { it.metric == MetricType.API_REQUEST }.points.size)
+        assertEquals(0L, result.series.first { it.metric == MetricType.API_REQUEST }.points[0].v)
+        assertEquals(7L, result.series.first { it.metric == MetricType.VISITOR }.points[0].v)
+    }
+
+    @Test
+    fun rejectsUnknownMetric() {
+        assertThrows(MonitorDomainException::class.java) {
+            service.getSeries(emptyList(), null, null, null)
+        }
+    }
+
+    @Test
+    fun rejectsInvertedTimeRange() {
+        assertThrows(MonitorDomainException::class.java) {
+            service.getSeries(
+                listOf(MetricType.VISITOR),
+                Instant.parse("2026-07-28T10:00:00Z"),
+                Instant.parse("2026-07-28T09:00:00Z"),
+                "1h",
+            )
+        }
+    }
+
+    @Test
+    fun rejectsTooManyBuckets() {
+        assertThrows(MonitorDomainException::class.java) {
+            service.getSeries(
+                listOf(MetricType.VISITOR),
+                Instant.parse("2026-01-01T00:00:00Z"),
+                Instant.parse("2026-01-10T00:00:00Z"),
+                "5m",
+            )
+        }
+    }
+
+    private class FakeMetricsStorePort : MetricsStorePort {
+        override fun recordVisitor(sessionId: String, at: Instant) = Unit
+        override fun visitorCount(from: Instant, to: Instant): Long =
+            if (Duration.between(from, to) == Duration.ofHours(1)) 7L else 0L
+    }
+}

--- a/systems/observability/observability-application/src/test/kotlin/hs/kr/entrydsm/observability/application/MonitorDashboardServiceTest.kt
+++ b/systems/observability/observability-application/src/test/kotlin/hs/kr/entrydsm/observability/application/MonitorDashboardServiceTest.kt
@@ -1,0 +1,88 @@
+package hs.kr.entrydsm.observability.application
+
+import hs.kr.entrydsm.observability.application.port.out.ClientLogStorePort
+import hs.kr.entrydsm.observability.application.port.out.HealthCheckPort
+import hs.kr.entrydsm.observability.application.port.out.Round
+import hs.kr.entrydsm.observability.application.port.out.ServiceHealthCheck
+import hs.kr.entrydsm.observability.application.port.out.StorageUsage
+import hs.kr.entrydsm.observability.domain.enum.DeviceType
+import hs.kr.entrydsm.observability.domain.enum.LogLevel
+import hs.kr.entrydsm.observability.domain.enum.ServiceName
+import hs.kr.entrydsm.observability.domain.exception.MonitorDomainException
+import java.time.Clock
+import java.time.Instant
+import java.time.ZoneOffset
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertThrows
+import org.junit.Test
+
+class MonitorDashboardServiceTest {
+    private val clock = Clock.fixed(Instant.parse("2026-07-28T14:00:00Z"), ZoneOffset.UTC)
+    private val round = Round("2026-1", Instant.parse("2026-07-01T00:00:00Z"), Instant.parse("2026-07-31T23:59:59Z"))
+
+    private fun service(): MonitorDashboardService = MonitorDashboardService(
+        sessionStorePort = FakeSessionStorePort(),
+        healthCheckPort = HealthCheckPort { ServiceHealthCheck(responseTimeMs = 12, version = null, dependencies = emptyMap()) },
+        clientLogStorePort = object : ClientLogStorePort by NotImplementedClientLogStorePort {
+            override fun countByLevel(from: Instant, to: Instant) = mapOf(LogLevel.ERROR to 2L, LogLevel.WARN to 1L)
+        },
+        storageUsagePort = {
+            StorageUsage(
+                databaseUsedBytes = 0,
+                databaseTotalBytes = null,
+                bucketUsedBytes = 1024,
+                bucketObjectCount = 1,
+                measuredAt = Instant.now(clock),
+            )
+        },
+        roundPort = { round },
+        clock = clock,
+    )
+
+    @Test
+    fun buildsSnapshotWithDeviceRatiosAndLogCounts() {
+        val result = service().getSnapshot(null)
+
+        assertEquals(round.name, result.period.round)
+        assertEquals(2L, result.clientLog.errorCount)
+        assertEquals(1L, result.clientLog.warnCount)
+        assertEquals(1024L, result.resource.bucketUsedBytes)
+        val android = result.traffic.devices.first { it.type == DeviceType.ANDROID }
+        assertEquals(0.5, android.ratio, 0.0001)
+        val total = result.services.items.first { it.service == "TOTAL" }
+        assertEquals(1, total.activeUsers)
+    }
+
+    @Test
+    fun rejectsUnknownRound() {
+        assertThrows(MonitorDomainException::class.java) {
+            service().getSnapshot("not-a-real-round")
+        }
+    }
+
+    private class FakeSessionStorePort : hs.kr.entrydsm.observability.application.port.out.SessionStorePort {
+        override fun enter(sessionId: String, service: ServiceName, deviceType: DeviceType, now: Instant) = Unit
+        override fun heartbeat(sessionId: String, service: ServiceName, now: Instant) = true
+        override fun leave(sessionId: String, service: ServiceName, now: Instant) = true
+        override fun concurrentUsers(service: ServiceName?, now: Instant, windowSeconds: Long) = 1
+        override fun totalVisitors() = 2L
+        override fun avgSessionDurationSeconds() = 120L
+        override fun deviceBreakdown(): Map<DeviceType, Long> = mapOf(DeviceType.ANDROID to 1L, DeviceType.IOS to 1L)
+        override fun sampleConcurrency(now: Instant, windowSeconds: Long) = Unit
+        override fun concurrentMax() = 5
+        override fun concurrentAvg() = 2
+    }
+
+    private object NotImplementedClientLogStorePort : ClientLogStorePort {
+        override fun record(input: hs.kr.entrydsm.observability.application.port.out.ClientLogInput) =
+            throw UnsupportedOperationException()
+        override fun countByLevel(from: Instant, to: Instant): Map<LogLevel, Long> = throw UnsupportedOperationException()
+        override fun list(
+            from: Instant,
+            to: Instant,
+            levels: Set<LogLevel>?,
+            cursor: hs.kr.entrydsm.observability.domain.model.Cursor?,
+            size: Int,
+        ) = throw UnsupportedOperationException()
+    }
+}

--- a/systems/observability/observability-application/src/test/kotlin/hs/kr/entrydsm/observability/application/MonitorHealthServiceTest.kt
+++ b/systems/observability/observability-application/src/test/kotlin/hs/kr/entrydsm/observability/application/MonitorHealthServiceTest.kt
@@ -1,0 +1,34 @@
+package hs.kr.entrydsm.observability.application
+
+import hs.kr.entrydsm.observability.application.port.out.HealthCheckPort
+import hs.kr.entrydsm.observability.application.port.out.ServiceHealthCheck
+import hs.kr.entrydsm.observability.domain.enum.ServiceName
+import hs.kr.entrydsm.observability.domain.enum.ServiceStatus
+import java.time.Clock
+import java.time.Instant
+import java.time.ZoneOffset
+import org.junit.Assert.assertEquals
+import org.junit.Test
+
+class MonitorHealthServiceTest {
+    private val clock = Clock.fixed(Instant.parse("2026-07-28T14:00:00Z"), ZoneOffset.UTC)
+
+    @Test
+    fun overallFollowsWorstServiceStatus() {
+        val healthCheckPort = HealthCheckPort { service ->
+            if (service == ServiceName.APPLICATION) {
+                ServiceHealthCheck(responseTimeMs = 1840, version = "1.4.0", dependencies = mapOf("s3" to false))
+            } else {
+                ServiceHealthCheck(responseTimeMs = 12, version = "1.4.2", dependencies = mapOf("postgres" to true))
+            }
+        }
+        val service = MonitorHealthService(healthCheckPort, clock)
+
+        val result = service.getHealth()
+
+        assertEquals(ServiceStatus.DEGRADED, result.overall)
+        val application = result.services.first { it.service == ServiceName.APPLICATION }
+        assertEquals(ServiceStatus.DEGRADED, application.status)
+        assertEquals(ServiceStatus.DOWN, application.dependencies.first().status)
+    }
+}

--- a/systems/observability/observability-application/src/test/kotlin/hs/kr/entrydsm/observability/application/ReportServiceTest.kt
+++ b/systems/observability/observability-application/src/test/kotlin/hs/kr/entrydsm/observability/application/ReportServiceTest.kt
@@ -1,0 +1,57 @@
+package hs.kr.entrydsm.observability.application
+
+import hs.kr.entrydsm.observability.application.port.`in`.GetDashboardSnapshotUseCase
+import hs.kr.entrydsm.observability.application.port.`in`.result.ApiStatsResult
+import hs.kr.entrydsm.observability.application.port.`in`.result.BusinessStatsResult
+import hs.kr.entrydsm.observability.application.port.`in`.result.ClientLogCountResult
+import hs.kr.entrydsm.observability.application.port.`in`.result.ConcurrentResult
+import hs.kr.entrydsm.observability.application.port.`in`.result.DashboardSnapshotResult
+import hs.kr.entrydsm.observability.application.port.`in`.result.OutcomeCountResult
+import hs.kr.entrydsm.observability.application.port.`in`.result.PeriodResult
+import hs.kr.entrydsm.observability.application.port.`in`.result.ResourceUsageBriefResult
+import hs.kr.entrydsm.observability.application.port.`in`.result.ServiceActivityResult
+import hs.kr.entrydsm.observability.application.port.`in`.result.TrafficResult
+import hs.kr.entrydsm.observability.application.port.out.Round
+import hs.kr.entrydsm.observability.application.port.out.StoredReport
+import hs.kr.entrydsm.observability.domain.enum.ReportFormat
+import java.time.Clock
+import java.time.Instant
+import java.time.ZoneOffset
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertTrue
+import org.junit.Test
+
+class ReportServiceTest {
+    private val clock = Clock.fixed(Instant.parse("2026-07-28T14:03:11Z"), ZoneOffset.UTC)
+    private val snapshot = DashboardSnapshotResult(
+        generatedAt = Instant.now(clock),
+        period = PeriodResult("ADMISSION", "2026-1", Instant.EPOCH, Instant.EPOCH),
+        traffic = TrafficResult(0, ConcurrentResult(0, 0, 0), 0, emptyList()),
+        api = ApiStatsResult(0, 0, 0, 0.0),
+        business = BusinessStatsResult(OutcomeCountResult(0, 0), OutcomeCountResult(0, 0)),
+        services = ServiceActivityResult(30, emptyList()),
+        clientLog = ClientLogCountResult(0, 0),
+        resource = ResourceUsageBriefResult(0, 0, Instant.now(clock)),
+    )
+
+    @Test
+    fun buildsFileNameFromRoundAndDate() {
+        val service = ReportService(
+            getDashboardSnapshotUseCase = GetDashboardSnapshotUseCase { snapshot },
+            reportGeneratorPort = { _, _ -> byteArrayOf(1, 2, 3) },
+            reportObjectStoragePort = object : hs.kr.entrydsm.observability.application.port.out.ReportObjectStoragePort {
+                override fun store(fileName: String, bytes: ByteArray) =
+                    StoredReport(downloadUrl = "/api/monitor/v11/reports/download?token=t", expiresAt = Instant.now(clock).plusSeconds(300))
+                override fun resolve(token: String) = null
+            },
+            roundPort = { Round("2026-1", Instant.EPOCH, Instant.EPOCH) },
+            clock = clock,
+        )
+
+        val result = service.generate(ReportFormat.XLSX)
+
+        assertEquals("entrymonitor_2026-1_20260728.xlsx", result.fileName)
+        assertEquals(3L, result.sizeBytes)
+        assertTrue(result.downloadUrl.startsWith("/api/monitor/v11/reports/download"))
+    }
+}

--- a/systems/observability/observability-application/src/test/kotlin/hs/kr/entrydsm/observability/application/ServerLogQueryServiceTest.kt
+++ b/systems/observability/observability-application/src/test/kotlin/hs/kr/entrydsm/observability/application/ServerLogQueryServiceTest.kt
@@ -1,0 +1,61 @@
+package hs.kr.entrydsm.observability.application
+
+import hs.kr.entrydsm.observability.application.port.out.ServerLogPage
+import hs.kr.entrydsm.observability.application.port.out.ServerLogStorePort
+import hs.kr.entrydsm.observability.application.port.out.StatusFilter
+import hs.kr.entrydsm.observability.domain.enum.ServiceName
+import hs.kr.entrydsm.observability.domain.exception.MonitorDomainException
+import hs.kr.entrydsm.observability.domain.model.Cursor
+import java.time.Clock
+import java.time.Instant
+import java.time.ZoneOffset
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertThrows
+import org.junit.Test
+
+class ServerLogQueryServiceTest {
+    private val clock = Clock.fixed(Instant.parse("2026-07-28T14:00:00Z"), ZoneOffset.UTC)
+    private var lastStatusFilter: StatusFilter? = null
+    private val service = ServerLogQueryService(
+        object : ServerLogStorePort {
+            override fun list(
+                from: Instant,
+                to: Instant,
+                service: ServiceName?,
+                status: StatusFilter?,
+                cursor: Cursor?,
+                size: Int,
+            ): ServerLogPage {
+                lastStatusFilter = status
+                return ServerLogPage(0, emptyList(), null, false)
+            }
+        },
+        clock,
+    )
+
+    @Test
+    fun parsesStatusClassShorthand() {
+        service.getLogs(ServiceName.APPLICATION, "5xx", null, null, 20, null)
+        assertEquals(StatusFilter.StatusClass('5'), lastStatusFilter)
+    }
+
+    @Test
+    fun parsesExactStatusCode() {
+        service.getLogs(null, "500", null, null, 20, null)
+        assertEquals(StatusFilter.Exact(500), lastStatusFilter)
+    }
+
+    @Test
+    fun rejectsMalformedStatus() {
+        assertThrows(MonitorDomainException::class.java) {
+            service.getLogs(null, "not-a-status", null, null, 20, null)
+        }
+    }
+
+    @Test
+    fun rejectsRangeOverSevenDays() {
+        assertThrows(MonitorDomainException::class.java) {
+            service.getLogs(null, null, Instant.parse("2026-07-01T00:00:00Z"), Instant.parse("2026-07-28T00:00:00Z"), 20, null)
+        }
+    }
+}

--- a/systems/observability/observability-application/src/test/kotlin/hs/kr/entrydsm/observability/application/SessionCollectionServiceTest.kt
+++ b/systems/observability/observability-application/src/test/kotlin/hs/kr/entrydsm/observability/application/SessionCollectionServiceTest.kt
@@ -1,0 +1,77 @@
+package hs.kr.entrydsm.observability.application
+
+import hs.kr.entrydsm.observability.application.port.out.RateLimitPort
+import hs.kr.entrydsm.observability.application.port.out.SessionStorePort
+import hs.kr.entrydsm.observability.domain.enum.DeviceType
+import hs.kr.entrydsm.observability.domain.enum.ServiceName
+import hs.kr.entrydsm.observability.domain.enum.SessionEventType
+import hs.kr.entrydsm.observability.domain.exception.MonitorDomainException
+import java.time.Clock
+import java.time.Instant
+import java.time.ZoneOffset
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertThrows
+import org.junit.Test
+
+class SessionCollectionServiceTest {
+    private val clock = Clock.fixed(Instant.parse("2026-07-28T14:00:00Z"), ZoneOffset.UTC)
+    private val sessionStore = FakeSessionStorePort()
+
+    @Test
+    fun enterIssuesNewSessionId() {
+        val service = SessionCollectionService(sessionStore, FakeRateLimitPort(true), clock)
+
+        val result = service.record(SessionEventType.ENTER, null, ServiceName.APPLICATION, "iPhone", "127.0.0.1")
+
+        assertEquals(true, result.sessionId.startsWith("sess_"))
+        assertEquals(15, result.heartbeatIntervalSeconds)
+    }
+
+    @Test
+    fun heartbeatOnUnknownSessionThrowsSessionNotFound() {
+        val service = SessionCollectionService(sessionStore, FakeRateLimitPort(true), clock)
+
+        assertThrows(MonitorDomainException::class.java) {
+            service.record(SessionEventType.HEARTBEAT, "sess_unknown", ServiceName.APPLICATION, null, "127.0.0.1")
+        }
+    }
+
+    @Test
+    fun rateLimitExceededThrowsTooManyRequests() {
+        val service = SessionCollectionService(sessionStore, FakeRateLimitPort(false), clock)
+
+        assertThrows(MonitorDomainException::class.java) {
+            service.record(SessionEventType.ENTER, null, ServiceName.APPLICATION, null, "127.0.0.1")
+        }
+    }
+
+    private class FakeSessionStorePort : SessionStorePort {
+        private val active = mutableSetOf<String>()
+
+        override fun enter(sessionId: String, service: ServiceName, deviceType: DeviceType, now: Instant) {
+            active.add(sessionId)
+        }
+
+        override fun heartbeat(sessionId: String, service: ServiceName, now: Instant) = active.contains(sessionId)
+
+        override fun leave(sessionId: String, service: ServiceName, now: Instant) = active.remove(sessionId)
+
+        override fun concurrentUsers(service: ServiceName?, now: Instant, windowSeconds: Long) = active.size
+
+        override fun totalVisitors() = active.size.toLong()
+
+        override fun avgSessionDurationSeconds() = 0L
+
+        override fun deviceBreakdown(): Map<DeviceType, Long> = emptyMap()
+
+        override fun sampleConcurrency(now: Instant, windowSeconds: Long) = Unit
+
+        override fun concurrentMax() = 0
+
+        override fun concurrentAvg() = 0
+    }
+
+    private class FakeRateLimitPort(private val allow: Boolean) : RateLimitPort {
+        override fun tryAcquire(key: String, limit: Long, windowSeconds: Long) = allow
+    }
+}

--- a/systems/observability/observability-application/src/test/kotlin/hs/kr/entrydsm/observability/application/SessionCollectionServiceTest.kt
+++ b/systems/observability/observability-application/src/test/kotlin/hs/kr/entrydsm/observability/application/SessionCollectionServiceTest.kt
@@ -1,5 +1,6 @@
 package hs.kr.entrydsm.observability.application
 
+import hs.kr.entrydsm.observability.application.port.out.MetricsStorePort
 import hs.kr.entrydsm.observability.application.port.out.RateLimitPort
 import hs.kr.entrydsm.observability.application.port.out.SessionStorePort
 import hs.kr.entrydsm.observability.domain.enum.DeviceType
@@ -19,7 +20,7 @@ class SessionCollectionServiceTest {
 
     @Test
     fun enterIssuesNewSessionId() {
-        val service = SessionCollectionService(sessionStore, FakeRateLimitPort(true), clock)
+        val service = SessionCollectionService(sessionStore, FakeRateLimitPort(true), FakeMetricsStorePort(), clock)
 
         val result = service.record(SessionEventType.ENTER, null, ServiceName.APPLICATION, "iPhone", "127.0.0.1")
 
@@ -29,7 +30,7 @@ class SessionCollectionServiceTest {
 
     @Test
     fun heartbeatOnUnknownSessionThrowsSessionNotFound() {
-        val service = SessionCollectionService(sessionStore, FakeRateLimitPort(true), clock)
+        val service = SessionCollectionService(sessionStore, FakeRateLimitPort(true), FakeMetricsStorePort(), clock)
 
         assertThrows(MonitorDomainException::class.java) {
             service.record(SessionEventType.HEARTBEAT, "sess_unknown", ServiceName.APPLICATION, null, "127.0.0.1")
@@ -38,7 +39,7 @@ class SessionCollectionServiceTest {
 
     @Test
     fun rateLimitExceededThrowsTooManyRequests() {
-        val service = SessionCollectionService(sessionStore, FakeRateLimitPort(false), clock)
+        val service = SessionCollectionService(sessionStore, FakeRateLimitPort(false), FakeMetricsStorePort(), clock)
 
         assertThrows(MonitorDomainException::class.java) {
             service.record(SessionEventType.ENTER, null, ServiceName.APPLICATION, null, "127.0.0.1")
@@ -73,5 +74,10 @@ class SessionCollectionServiceTest {
 
     private class FakeRateLimitPort(private val allow: Boolean) : RateLimitPort {
         override fun tryAcquire(key: String, limit: Long, windowSeconds: Long) = allow
+    }
+
+    private class FakeMetricsStorePort : MetricsStorePort {
+        override fun recordVisitor(sessionId: String, at: Instant) = Unit
+        override fun visitorCount(from: Instant, to: Instant) = 0L
     }
 }

--- a/systems/observability/observability-application/src/test/kotlin/hs/kr/entrydsm/observability/application/StorageUsageQueryServiceTest.kt
+++ b/systems/observability/observability-application/src/test/kotlin/hs/kr/entrydsm/observability/application/StorageUsageQueryServiceTest.kt
@@ -1,0 +1,42 @@
+package hs.kr.entrydsm.observability.application
+
+import hs.kr.entrydsm.observability.application.port.out.StorageUsage
+import java.time.Instant
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertNull
+import org.junit.Test
+
+class StorageUsageQueryServiceTest {
+    @Test
+    fun computesRatioWhenTotalKnown() {
+        val service = StorageUsageQueryService {
+            StorageUsage(
+                databaseUsedBytes = 50,
+                databaseTotalBytes = 200,
+                bucketUsedBytes = 1024,
+                bucketObjectCount = 3,
+                measuredAt = Instant.parse("2026-07-28T14:00:00Z"),
+            )
+        }
+
+        val result = service.getUsage()
+
+        assertEquals(0.25, result.database.usageRatio!!, 0.0001)
+        assertEquals(300, result.cacheTtlSeconds)
+    }
+
+    @Test
+    fun ratioIsNullWhenTotalUnknown() {
+        val service = StorageUsageQueryService {
+            StorageUsage(
+                databaseUsedBytes = 0,
+                databaseTotalBytes = null,
+                bucketUsedBytes = 0,
+                bucketObjectCount = 0,
+                measuredAt = Instant.parse("2026-07-28T14:00:00Z"),
+            )
+        }
+
+        assertNull(service.getUsage().database.usageRatio)
+    }
+}

--- a/systems/observability/observability-bootstrap/src/main/kotlin/hs/kr/entrydsm/ExampleApplication.kt
+++ b/systems/observability/observability-bootstrap/src/main/kotlin/hs/kr/entrydsm/ExampleApplication.kt
@@ -2,7 +2,9 @@ package hs.kr.entrydsm.observability
 
 import org.springframework.boot.autoconfigure.SpringBootApplication
 import org.springframework.boot.runApplication
+import org.springframework.scheduling.annotation.EnableScheduling
 
+@EnableScheduling
 @SpringBootApplication
 class ObservabilityBootstrapApplication
 

--- a/systems/observability/observability-bootstrap/src/main/kotlin/hs/kr/entrydsm/observability/config/ClockConfig.kt
+++ b/systems/observability/observability-bootstrap/src/main/kotlin/hs/kr/entrydsm/observability/config/ClockConfig.kt
@@ -1,0 +1,11 @@
+package hs.kr.entrydsm.observability.config
+
+import java.time.Clock
+import org.springframework.context.annotation.Bean
+import org.springframework.context.annotation.Configuration
+
+@Configuration(proxyBeanMethods = false)
+class ClockConfig {
+    @Bean
+    fun clock(): Clock = Clock.systemUTC()
+}

--- a/systems/observability/observability-bootstrap/src/main/resources/application.yaml
+++ b/systems/observability/observability-bootstrap/src/main/resources/application.yaml
@@ -5,6 +5,10 @@ spring:
     default: local
   main:
     lazy-initialization: true
+  data:
+    redis:
+      host: ${REDIS_HOST:localhost}
+      port: ${REDIS_PORT:6379}
 server:
   shutdown: graceful
 management:
@@ -19,3 +23,25 @@ management:
 logging:
   level:
     root: INFO
+auth:
+  jwt:
+    secret: ${JWT_SECRET:local-development-secret-key-change-me-0123456789}
+    issuer: ${JWT_ISSUER:entrydsm}
+monitor:
+  services:
+    identity:
+      base-url: ${IDENTITY_BASE_URL:http://localhost:8081}
+    auth:
+      base-url: ${AUTH_BASE_URL:http://localhost:8081}
+    application:
+      base-url: ${APPLICATION_BASE_URL:http://localhost:8082}
+    evaluation:
+      base-url: ${EVALUATION_BASE_URL:http://localhost:8083}
+    document:
+      base-url: ${DOCUMENT_BASE_URL:http://localhost:8084}
+    notification:
+      base-url: ${NOTIFICATION_BASE_URL:http://localhost:8085}
+    schedule:
+      base-url: ${SCHEDULE_BASE_URL:http://localhost:8086}
+  report:
+    storage-dir: ${MONITOR_REPORT_DIR:/tmp/entrydsm-monitor-reports}

--- a/systems/observability/observability-bootstrap/src/main/resources/application.yaml
+++ b/systems/observability/observability-bootstrap/src/main/resources/application.yaml
@@ -45,3 +45,7 @@ monitor:
       base-url: ${SCHEDULE_BASE_URL:http://localhost:8086}
   report:
     storage-dir: ${MONITOR_REPORT_DIR:/tmp/entrydsm-monitor-reports}
+  round:
+    name: ${MONITOR_ROUND_NAME:current}
+    from: ${MONITOR_ROUND_FROM:2026-01-01T00:00:00+09:00}
+    to: ${MONITOR_ROUND_TO:2026-12-31T23:59:59+09:00}

--- a/systems/observability/observability-domain/BUILD.bazel
+++ b/systems/observability/observability-domain/BUILD.bazel
@@ -17,5 +17,5 @@ kt_jvm_test(
     javac_opts = "//:javac_options",
     kotlinc_opts = "//:kotlinc_options",
     test_class = "hs.kr.entrydsm.observability.domain.ObservabilityDomainModuleTest",
-    deps = MODULE_DEPS + TEST_DEPS,
+    deps = [":main"] + MODULE_DEPS + TEST_DEPS,
 )

--- a/systems/observability/observability-domain/src/main/kotlin/hs/kr/entrydsm/observability/domain/enum/DeviceType.kt
+++ b/systems/observability/observability-domain/src/main/kotlin/hs/kr/entrydsm/observability/domain/enum/DeviceType.kt
@@ -1,0 +1,8 @@
+package hs.kr.entrydsm.observability.domain.enum
+
+enum class DeviceType {
+    ANDROID,
+    IOS,
+    WINDOWS,
+    ETC,
+}

--- a/systems/observability/observability-domain/src/main/kotlin/hs/kr/entrydsm/observability/domain/enum/ErrorCode.kt
+++ b/systems/observability/observability-domain/src/main/kotlin/hs/kr/entrydsm/observability/domain/enum/ErrorCode.kt
@@ -1,0 +1,30 @@
+package hs.kr.entrydsm.observability.domain.enum
+
+/**
+ * Monitor API에서 클라이언트에 노출하는 오류 코드입니다.
+ *
+ * @property status 오류에 대응하는 HTTP 상태 코드
+ * @property message 클라이언트에 전달할 기본 오류 메시지
+ */
+enum class ErrorCode(
+    val status: Int,
+    val message: String,
+) {
+    INVALID_PAYLOAD(400, "요청 본문이 올바르지 않습니다."),
+    INVALID_METRIC(400, "지원하지 않는 지표명입니다."),
+    INVALID_TIME_RANGE(400, "조회 시간 범위가 올바르지 않습니다."),
+    INVALID_INTERVAL(400, "범위 대비 버킷 수가 너무 많습니다."),
+    INVALID_CURSOR(400, "손상되거나 만료된 커서입니다."),
+    INVALID_SERVICE(400, "알 수 없는 서비스명입니다."),
+    INVALID_FORMAT(400, "지원하지 않는 파일 형식입니다."),
+    UNAUTHORIZED(401, "인증 토큰이 없거나 만료되었습니다."),
+    FORBIDDEN(403, "관리자 권한이 없습니다."),
+    ROUND_NOT_FOUND(404, "존재하지 않는 접수 회차입니다."),
+    SESSION_NOT_FOUND(404, "만료되거나 발급받지 않은 세션입니다."),
+    PAYLOAD_TOO_LARGE(413, "본문 크기가 너무 큽니다."),
+    TOO_MANY_REQUESTS(429, "요청이 너무 많습니다."),
+    TOO_MANY_CONNECTIONS(429, "동시 커넥션이 너무 많습니다."),
+    METRIC_UNAVAILABLE(503, "아직 측정된 지표가 없습니다."),
+    REPORT_GENERATION_FAILED(500, "리포트 생성에 실패했습니다."),
+    INTERNAL_SERVER_ERROR(500, "서버 내부 오류가 발생했습니다."),
+}

--- a/systems/observability/observability-domain/src/main/kotlin/hs/kr/entrydsm/observability/domain/enum/LogLevel.kt
+++ b/systems/observability/observability-domain/src/main/kotlin/hs/kr/entrydsm/observability/domain/enum/LogLevel.kt
@@ -1,0 +1,6 @@
+package hs.kr.entrydsm.observability.domain.enum
+
+enum class LogLevel {
+    ERROR,
+    WARN,
+}

--- a/systems/observability/observability-domain/src/main/kotlin/hs/kr/entrydsm/observability/domain/enum/LogSource.kt
+++ b/systems/observability/observability-domain/src/main/kotlin/hs/kr/entrydsm/observability/domain/enum/LogSource.kt
@@ -1,0 +1,8 @@
+package hs.kr.entrydsm.observability.domain.enum
+
+enum class LogSource {
+    DOM,
+    NETWORK,
+    PROMISE,
+    CONSOLE,
+}

--- a/systems/observability/observability-domain/src/main/kotlin/hs/kr/entrydsm/observability/domain/enum/MetricType.kt
+++ b/systems/observability/observability-domain/src/main/kotlin/hs/kr/entrydsm/observability/domain/enum/MetricType.kt
@@ -1,0 +1,6 @@
+package hs.kr.entrydsm.observability.domain.enum
+
+enum class MetricType {
+    API_REQUEST,
+    VISITOR,
+}

--- a/systems/observability/observability-domain/src/main/kotlin/hs/kr/entrydsm/observability/domain/enum/ReportFormat.kt
+++ b/systems/observability/observability-domain/src/main/kotlin/hs/kr/entrydsm/observability/domain/enum/ReportFormat.kt
@@ -1,0 +1,6 @@
+package hs.kr.entrydsm.observability.domain.enum
+
+enum class ReportFormat {
+    XLSX,
+    CSV,
+}

--- a/systems/observability/observability-domain/src/main/kotlin/hs/kr/entrydsm/observability/domain/enum/ReportStatus.kt
+++ b/systems/observability/observability-domain/src/main/kotlin/hs/kr/entrydsm/observability/domain/enum/ReportStatus.kt
@@ -1,0 +1,6 @@
+package hs.kr.entrydsm.observability.domain.enum
+
+enum class ReportStatus {
+    READY,
+    GENERATING,
+}

--- a/systems/observability/observability-domain/src/main/kotlin/hs/kr/entrydsm/observability/domain/enum/ServiceName.kt
+++ b/systems/observability/observability-domain/src/main/kotlin/hs/kr/entrydsm/observability/domain/enum/ServiceName.kt
@@ -1,0 +1,11 @@
+package hs.kr.entrydsm.observability.domain.enum
+
+enum class ServiceName {
+    IDENTITY,
+    AUTH,
+    APPLICATION,
+    EVALUATION,
+    DOCUMENT,
+    NOTIFICATION,
+    SCHEDULE,
+}

--- a/systems/observability/observability-domain/src/main/kotlin/hs/kr/entrydsm/observability/domain/enum/ServiceStatus.kt
+++ b/systems/observability/observability-domain/src/main/kotlin/hs/kr/entrydsm/observability/domain/enum/ServiceStatus.kt
@@ -1,0 +1,7 @@
+package hs.kr.entrydsm.observability.domain.enum
+
+enum class ServiceStatus {
+    UP,
+    DEGRADED,
+    DOWN,
+}

--- a/systems/observability/observability-domain/src/main/kotlin/hs/kr/entrydsm/observability/domain/enum/SessionEventType.kt
+++ b/systems/observability/observability-domain/src/main/kotlin/hs/kr/entrydsm/observability/domain/enum/SessionEventType.kt
@@ -1,0 +1,7 @@
+package hs.kr.entrydsm.observability.domain.enum
+
+enum class SessionEventType {
+    ENTER,
+    HEARTBEAT,
+    LEAVE,
+}

--- a/systems/observability/observability-domain/src/main/kotlin/hs/kr/entrydsm/observability/domain/exception/MonitorDomainException.kt
+++ b/systems/observability/observability-domain/src/main/kotlin/hs/kr/entrydsm/observability/domain/exception/MonitorDomainException.kt
@@ -1,0 +1,7 @@
+package hs.kr.entrydsm.observability.domain.exception
+
+import hs.kr.entrydsm.observability.domain.enum.ErrorCode
+
+class MonitorDomainException(
+    errorCode: ErrorCode,
+) : MonitorException(errorCode)

--- a/systems/observability/observability-domain/src/main/kotlin/hs/kr/entrydsm/observability/domain/exception/MonitorException.kt
+++ b/systems/observability/observability-domain/src/main/kotlin/hs/kr/entrydsm/observability/domain/exception/MonitorException.kt
@@ -1,0 +1,10 @@
+package hs.kr.entrydsm.observability.domain.exception
+
+import hs.kr.entrydsm.observability.domain.enum.ErrorCode
+
+/**
+ * Monitor 도메인에서 의도적으로 발생시키는 예외의 기본 타입입니다.
+ */
+abstract class MonitorException(
+    val errorCode: ErrorCode,
+) : RuntimeException(errorCode.message)

--- a/systems/observability/observability-domain/src/main/kotlin/hs/kr/entrydsm/observability/domain/model/Cursor.kt
+++ b/systems/observability/observability-domain/src/main/kotlin/hs/kr/entrydsm/observability/domain/model/Cursor.kt
@@ -1,0 +1,31 @@
+package hs.kr.entrydsm.observability.domain.model
+
+import hs.kr.entrydsm.observability.domain.enum.ErrorCode
+import hs.kr.entrydsm.observability.domain.exception.MonitorDomainException
+import java.util.Base64
+
+/**
+ * 로그 목록 조회의 페이지네이션 커서입니다. 정렬 기준 score(발생 시각 epoch millis)와
+ * 마지막으로 조회한 항목의 id를 불투명 토큰으로 인코딩합니다.
+ */
+data class Cursor(
+    val lastScore: Long,
+    val lastId: String,
+) {
+    fun encode(): String =
+        Base64.getUrlEncoder().withoutPadding().encodeToString("$lastScore:$lastId".toByteArray())
+
+    companion object {
+        fun decode(raw: String): Cursor {
+            val decoded = runCatching { String(Base64.getUrlDecoder().decode(raw)) }
+                .getOrElse { throw MonitorDomainException(ErrorCode.INVALID_CURSOR) }
+            val parts = decoded.split(":", limit = 2)
+            val score = parts.getOrNull(0)?.toLongOrNull()
+            val id = parts.getOrNull(1)
+            if (score == null || id.isNullOrEmpty()) {
+                throw MonitorDomainException(ErrorCode.INVALID_CURSOR)
+            }
+            return Cursor(score, id)
+        }
+    }
+}

--- a/systems/observability/observability-domain/src/main/kotlin/hs/kr/entrydsm/observability/domain/model/Session.kt
+++ b/systems/observability/observability-domain/src/main/kotlin/hs/kr/entrydsm/observability/domain/model/Session.kt
@@ -1,0 +1,17 @@
+package hs.kr.entrydsm.observability.domain.model
+
+import hs.kr.entrydsm.observability.domain.enum.ServiceName
+import java.time.Instant
+
+data class Session(
+    val sessionId: String,
+    val service: ServiceName,
+    val enteredAt: Instant,
+    val lastHeartbeatAt: Instant,
+) {
+    fun heartbeat(now: Instant, service: ServiceName): Session =
+        copy(service = service, lastHeartbeatAt = now)
+
+    fun isExpired(now: Instant, windowSeconds: Long): Boolean =
+        lastHeartbeatAt.plusSeconds(windowSeconds).isBefore(now)
+}

--- a/systems/observability/observability-domain/src/main/kotlin/hs/kr/entrydsm/observability/domain/service/DeviceTypeParser.kt
+++ b/systems/observability/observability-domain/src/main/kotlin/hs/kr/entrydsm/observability/domain/service/DeviceTypeParser.kt
@@ -1,0 +1,16 @@
+package hs.kr.entrydsm.observability.domain.service
+
+import hs.kr.entrydsm.observability.domain.enum.DeviceType
+
+/** User-Agent 문자열에서 접근 기기 종류를 판별합니다. */
+object DeviceTypeParser {
+    fun parse(userAgent: String?): DeviceType {
+        val ua = userAgent?.lowercase() ?: return DeviceType.ETC
+        return when {
+            "android" in ua -> DeviceType.ANDROID
+            "iphone" in ua || "ipad" in ua || "ios" in ua -> DeviceType.IOS
+            "windows" in ua -> DeviceType.WINDOWS
+            else -> DeviceType.ETC
+        }
+    }
+}

--- a/systems/observability/observability-domain/src/main/kotlin/hs/kr/entrydsm/observability/domain/service/Fingerprint.kt
+++ b/systems/observability/observability-domain/src/main/kotlin/hs/kr/entrydsm/observability/domain/service/Fingerprint.kt
@@ -1,0 +1,11 @@
+package hs.kr.entrydsm.observability.domain.service
+
+import java.security.MessageDigest
+
+/** 동일 오류를 그룹핑하기 위한 안정적인 짧은 해시를 만든다. */
+object Fingerprint {
+    fun of(vararg parts: String): String {
+        val digest = MessageDigest.getInstance("SHA-256").digest(parts.joinToString("|").toByteArray())
+        return digest.joinToString("") { "%02x".format(it) }.take(8)
+    }
+}

--- a/systems/observability/observability-domain/src/main/kotlin/hs/kr/entrydsm/observability/domain/service/HealthStatusClassifier.kt
+++ b/systems/observability/observability-domain/src/main/kotlin/hs/kr/entrydsm/observability/domain/service/HealthStatusClassifier.kt
@@ -1,0 +1,28 @@
+package hs.kr.entrydsm.observability.domain.service
+
+import hs.kr.entrydsm.observability.domain.enum.ServiceStatus
+
+/**
+ * 서비스 헬스체크 응답을 문서화된 판정 기준(UP/DEGRADED/DOWN)에 따라 분류합니다.
+ *
+ * - UP: 헬스체크 성공 + 응답 500ms 미만 + 모든 의존성 정상
+ * - DEGRADED: 응답 500ms 이상 또는 일부 의존성 장애
+ * - DOWN: 타임아웃 또는 연결 실패
+ */
+object HealthStatusClassifier {
+    private const val SLOW_RESPONSE_THRESHOLD_MS = 500
+
+    fun classify(responseTimeMs: Long?, allDependenciesUp: Boolean): ServiceStatus = when {
+        responseTimeMs == null -> ServiceStatus.DOWN
+        responseTimeMs >= SLOW_RESPONSE_THRESHOLD_MS || !allDependenciesUp -> ServiceStatus.DEGRADED
+        else -> ServiceStatus.UP
+    }
+
+    /** overall은 하위 서비스 중 가장 나쁜 상태를 따른다. */
+    fun overall(statuses: Collection<ServiceStatus>): ServiceStatus = when {
+        statuses.isEmpty() -> ServiceStatus.DOWN
+        statuses.any { it == ServiceStatus.DOWN } -> ServiceStatus.DOWN
+        statuses.any { it == ServiceStatus.DEGRADED } -> ServiceStatus.DEGRADED
+        else -> ServiceStatus.UP
+    }
+}

--- a/systems/observability/observability-domain/src/main/kotlin/hs/kr/entrydsm/observability/domain/service/ServiceLabels.kt
+++ b/systems/observability/observability-domain/src/main/kotlin/hs/kr/entrydsm/observability/domain/service/ServiceLabels.kt
@@ -1,0 +1,17 @@
+package hs.kr.entrydsm.observability.domain.service
+
+import hs.kr.entrydsm.observability.domain.enum.ServiceName
+
+object ServiceLabels {
+    private val LABELS = mapOf(
+        ServiceName.IDENTITY to "유저",
+        ServiceName.AUTH to "인증",
+        ServiceName.APPLICATION to "접수",
+        ServiceName.EVALUATION to "심사",
+        ServiceName.DOCUMENT to "서류",
+        ServiceName.NOTIFICATION to "알림",
+        ServiceName.SCHEDULE to "일정",
+    )
+
+    fun of(service: ServiceName): String = LABELS.getValue(service)
+}

--- a/systems/observability/observability-domain/src/main/kotlin/hs/kr/entrydsm/observability/domain/service/TimeBucketer.kt
+++ b/systems/observability/observability-domain/src/main/kotlin/hs/kr/entrydsm/observability/domain/service/TimeBucketer.kt
@@ -1,0 +1,27 @@
+package hs.kr.entrydsm.observability.domain.service
+
+import java.time.Duration
+import java.time.Instant
+
+/** 시간대별 지표 조회의 interval 문자열 <-> Duration 변환과 버킷 시작 시각 목록 생성을 담당한다. */
+object TimeBucketer {
+    private val INTERVALS = mapOf(
+        "5m" to Duration.ofMinutes(5),
+        "30m" to Duration.ofMinutes(30),
+        "1h" to Duration.ofHours(1),
+        "1d" to Duration.ofDays(1),
+    )
+
+    fun durationOf(interval: String): Duration? = INTERVALS[interval]
+
+    /** points의 t는 버킷의 시작 시각이다. */
+    fun bucketStarts(from: Instant, to: Instant, interval: Duration): List<Instant> {
+        val starts = mutableListOf<Instant>()
+        var cursor = from
+        while (cursor.isBefore(to)) {
+            starts.add(cursor)
+            cursor = cursor.plus(interval)
+        }
+        return starts
+    }
+}

--- a/systems/observability/observability-domain/src/main/kotlin/hs/kr/entrydsm/observability/domain/service/UserAgentParser.kt
+++ b/systems/observability/observability-domain/src/main/kotlin/hs/kr/entrydsm/observability/domain/service/UserAgentParser.kt
@@ -1,0 +1,32 @@
+package hs.kr.entrydsm.observability.domain.service
+
+/**
+ * 관리자 화면 표시용 브라우저/OS 이름을 최소한으로 추출한다.
+ * ponytail: 정교한 UA 데이터베이스 없이 주요 브라우저/OS만 정규식으로 휴리스틱 인식한다.
+ */
+object UserAgentParser {
+    private val BROWSER_PATTERNS = listOf(
+        "Edge" to Regex("Edg/([0-9]+)"),
+        "Chrome" to Regex("Chrome/([0-9]+)"),
+        "Firefox" to Regex("Firefox/([0-9]+)"),
+        "Safari" to Regex("Version/([0-9]+).*Safari"),
+    )
+    private val OS_PATTERNS = listOf(
+        "Windows" to Regex("Windows NT ([0-9.]+)"),
+        "Android" to Regex("Android ([0-9.]+)"),
+        "iOS" to Regex("(?:iPhone|iPad).*?OS ([0-9_]+)"),
+        "macOS" to Regex("Mac OS X ([0-9_]+)"),
+    )
+
+    fun browser(userAgent: String?): String? = match(userAgent, BROWSER_PATTERNS)
+
+    fun os(userAgent: String?): String? = match(userAgent, OS_PATTERNS)?.replace('_', '.')
+
+    private fun match(userAgent: String?, patterns: List<Pair<String, Regex>>): String? {
+        val ua = userAgent ?: return null
+        for ((name, pattern) in patterns) {
+            pattern.find(ua)?.let { return "$name ${it.groupValues[1]}" }
+        }
+        return null
+    }
+}

--- a/systems/observability/observability-domain/src/test/kotlin/hs/kr/entrydsm/TestMain.kt
+++ b/systems/observability/observability-domain/src/test/kotlin/hs/kr/entrydsm/TestMain.kt
@@ -8,5 +8,6 @@ import org.junit.runners.Suite
     CursorTest::class,
     HealthStatusClassifierTest::class,
     DeviceTypeParserTest::class,
+    FingerprintTest::class,
 )
 class ObservabilityDomainModuleTest

--- a/systems/observability/observability-domain/src/test/kotlin/hs/kr/entrydsm/TestMain.kt
+++ b/systems/observability/observability-domain/src/test/kotlin/hs/kr/entrydsm/TestMain.kt
@@ -9,5 +9,6 @@ import org.junit.runners.Suite
     HealthStatusClassifierTest::class,
     DeviceTypeParserTest::class,
     FingerprintTest::class,
+    TimeBucketerTest::class,
 )
 class ObservabilityDomainModuleTest

--- a/systems/observability/observability-domain/src/test/kotlin/hs/kr/entrydsm/TestMain.kt
+++ b/systems/observability/observability-domain/src/test/kotlin/hs/kr/entrydsm/TestMain.kt
@@ -1,11 +1,11 @@
 package hs.kr.entrydsm.observability.domain
 
-import org.junit.Assert.assertTrue
-import org.junit.Test
+import org.junit.runner.RunWith
+import org.junit.runners.Suite
 
-class ObservabilityDomainModuleTest {
-    @Test
-    fun moduleLoads() {
-        assertTrue(true)
-    }
-}
+@RunWith(Suite::class)
+@Suite.SuiteClasses(
+    CursorTest::class,
+    HealthStatusClassifierTest::class,
+)
+class ObservabilityDomainModuleTest

--- a/systems/observability/observability-domain/src/test/kotlin/hs/kr/entrydsm/TestMain.kt
+++ b/systems/observability/observability-domain/src/test/kotlin/hs/kr/entrydsm/TestMain.kt
@@ -7,5 +7,6 @@ import org.junit.runners.Suite
 @Suite.SuiteClasses(
     CursorTest::class,
     HealthStatusClassifierTest::class,
+    DeviceTypeParserTest::class,
 )
 class ObservabilityDomainModuleTest

--- a/systems/observability/observability-domain/src/test/kotlin/hs/kr/entrydsm/TestMain.kt
+++ b/systems/observability/observability-domain/src/test/kotlin/hs/kr/entrydsm/TestMain.kt
@@ -10,5 +10,6 @@ import org.junit.runners.Suite
     DeviceTypeParserTest::class,
     FingerprintTest::class,
     TimeBucketerTest::class,
+    UserAgentParserTest::class,
 )
 class ObservabilityDomainModuleTest

--- a/systems/observability/observability-domain/src/test/kotlin/hs/kr/entrydsm/observability/domain/CursorTest.kt
+++ b/systems/observability/observability-domain/src/test/kotlin/hs/kr/entrydsm/observability/domain/CursorTest.kt
@@ -1,0 +1,25 @@
+package hs.kr.entrydsm.observability.domain
+
+import hs.kr.entrydsm.observability.domain.exception.MonitorDomainException
+import hs.kr.entrydsm.observability.domain.model.Cursor
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertThrows
+import org.junit.Test
+
+class CursorTest {
+    @Test
+    fun encodesAndDecodesRoundTrip() {
+        val cursor = Cursor(lastScore = 1753679005000, lastId = "7d1b04a2")
+
+        val decoded = Cursor.decode(cursor.encode())
+
+        assertEquals(cursor, decoded)
+    }
+
+    @Test
+    fun rejectsCorruptedCursor() {
+        assertThrows(MonitorDomainException::class.java) {
+            Cursor.decode("not-a-valid-cursor!!")
+        }
+    }
+}

--- a/systems/observability/observability-domain/src/test/kotlin/hs/kr/entrydsm/observability/domain/DeviceTypeParserTest.kt
+++ b/systems/observability/observability-domain/src/test/kotlin/hs/kr/entrydsm/observability/domain/DeviceTypeParserTest.kt
@@ -1,0 +1,29 @@
+package hs.kr.entrydsm.observability.domain
+
+import hs.kr.entrydsm.observability.domain.enum.DeviceType
+import hs.kr.entrydsm.observability.domain.service.DeviceTypeParser
+import org.junit.Assert.assertEquals
+import org.junit.Test
+
+class DeviceTypeParserTest {
+    @Test
+    fun parsesAndroid() {
+        assertEquals(DeviceType.ANDROID, DeviceTypeParser.parse("Mozilla/5.0 (Linux; Android 15)"))
+    }
+
+    @Test
+    fun parsesIos() {
+        assertEquals(DeviceType.IOS, DeviceTypeParser.parse("Mozilla/5.0 (iPhone; CPU iPhone OS 18_0)"))
+    }
+
+    @Test
+    fun parsesWindows() {
+        assertEquals(DeviceType.WINDOWS, DeviceTypeParser.parse("Mozilla/5.0 (Windows NT 10.0)"))
+    }
+
+    @Test
+    fun fallsBackToEtcForUnknownOrMissingUserAgent() {
+        assertEquals(DeviceType.ETC, DeviceTypeParser.parse(null))
+        assertEquals(DeviceType.ETC, DeviceTypeParser.parse("SomeBot/1.0"))
+    }
+}

--- a/systems/observability/observability-domain/src/test/kotlin/hs/kr/entrydsm/observability/domain/FingerprintTest.kt
+++ b/systems/observability/observability-domain/src/test/kotlin/hs/kr/entrydsm/observability/domain/FingerprintTest.kt
@@ -1,0 +1,25 @@
+package hs.kr.entrydsm.observability.domain
+
+import hs.kr.entrydsm.observability.domain.service.Fingerprint
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertNotEquals
+import org.junit.Test
+
+class FingerprintTest {
+    @Test
+    fun sameInputProducesSameFingerprint() {
+        assertEquals(Fingerprint.of("DOM", "boom", "/a"), Fingerprint.of("DOM", "boom", "/a"))
+    }
+
+    @Test
+    fun differentInputProducesDifferentFingerprint() {
+        assertNotEquals(Fingerprint.of("DOM", "boom", "/a"), Fingerprint.of("DOM", "boom", "/b"))
+    }
+
+    @Test
+    fun fingerprintIsEightHexChars() {
+        val fingerprint = Fingerprint.of("DOM", "boom", "/a")
+        assertEquals(8, fingerprint.length)
+        assertEquals(true, fingerprint.matches(Regex("[0-9a-f]{8}")))
+    }
+}

--- a/systems/observability/observability-domain/src/test/kotlin/hs/kr/entrydsm/observability/domain/HealthStatusClassifierTest.kt
+++ b/systems/observability/observability-domain/src/test/kotlin/hs/kr/entrydsm/observability/domain/HealthStatusClassifierTest.kt
@@ -1,0 +1,56 @@
+package hs.kr.entrydsm.observability.domain
+
+import hs.kr.entrydsm.observability.domain.enum.ServiceStatus
+import hs.kr.entrydsm.observability.domain.service.HealthStatusClassifier
+import org.junit.Assert.assertEquals
+import org.junit.Test
+
+class HealthStatusClassifierTest {
+    @Test
+    fun classifiesUpWhenFastAndHealthy() {
+        assertEquals(
+            ServiceStatus.UP,
+            HealthStatusClassifier.classify(responseTimeMs = 12, allDependenciesUp = true),
+        )
+    }
+
+    @Test
+    fun classifiesDegradedWhenSlow() {
+        assertEquals(
+            ServiceStatus.DEGRADED,
+            HealthStatusClassifier.classify(responseTimeMs = 1840, allDependenciesUp = true),
+        )
+    }
+
+    @Test
+    fun classifiesDegradedWhenDependencyDown() {
+        assertEquals(
+            ServiceStatus.DEGRADED,
+            HealthStatusClassifier.classify(responseTimeMs = 12, allDependenciesUp = false),
+        )
+    }
+
+    @Test
+    fun classifiesDownWhenUnreachable() {
+        assertEquals(
+            ServiceStatus.DOWN,
+            HealthStatusClassifier.classify(responseTimeMs = null, allDependenciesUp = true),
+        )
+    }
+
+    @Test
+    fun overallFollowsWorstStatus() {
+        assertEquals(
+            ServiceStatus.DOWN,
+            HealthStatusClassifier.overall(listOf(ServiceStatus.UP, ServiceStatus.DEGRADED, ServiceStatus.DOWN)),
+        )
+        assertEquals(
+            ServiceStatus.DEGRADED,
+            HealthStatusClassifier.overall(listOf(ServiceStatus.UP, ServiceStatus.DEGRADED)),
+        )
+        assertEquals(
+            ServiceStatus.UP,
+            HealthStatusClassifier.overall(listOf(ServiceStatus.UP, ServiceStatus.UP)),
+        )
+    }
+}

--- a/systems/observability/observability-domain/src/test/kotlin/hs/kr/entrydsm/observability/domain/TimeBucketerTest.kt
+++ b/systems/observability/observability-domain/src/test/kotlin/hs/kr/entrydsm/observability/domain/TimeBucketerTest.kt
@@ -1,0 +1,27 @@
+package hs.kr.entrydsm.observability.domain
+
+import hs.kr.entrydsm.observability.domain.service.TimeBucketer
+import java.time.Duration
+import java.time.Instant
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertNull
+import org.junit.Test
+
+class TimeBucketerTest {
+    @Test
+    fun resolvesKnownIntervals() {
+        assertEquals(Duration.ofMinutes(5), TimeBucketer.durationOf("5m"))
+        assertEquals(Duration.ofHours(1), TimeBucketer.durationOf("1h"))
+        assertNull(TimeBucketer.durationOf("2h"))
+    }
+
+    @Test
+    fun bucketStartsCoverWholeRangeWithoutOverflow() {
+        val from = Instant.parse("2026-07-28T00:00:00Z")
+        val to = Instant.parse("2026-07-28T02:00:00Z")
+
+        val buckets = TimeBucketer.bucketStarts(from, to, Duration.ofHours(1))
+
+        assertEquals(listOf(Instant.parse("2026-07-28T00:00:00Z"), Instant.parse("2026-07-28T01:00:00Z")), buckets)
+    }
+}

--- a/systems/observability/observability-domain/src/test/kotlin/hs/kr/entrydsm/observability/domain/UserAgentParserTest.kt
+++ b/systems/observability/observability-domain/src/test/kotlin/hs/kr/entrydsm/observability/domain/UserAgentParserTest.kt
@@ -1,0 +1,30 @@
+package hs.kr.entrydsm.observability.domain
+
+import hs.kr.entrydsm.observability.domain.service.UserAgentParser
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertNull
+import org.junit.Test
+
+class UserAgentParserTest {
+    @Test
+    fun parsesChromeOnAndroid() {
+        val ua = "Mozilla/5.0 (Linux; Android 15) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/138.0.0.0 Mobile Safari/537.36"
+
+        assertEquals("Chrome 138", UserAgentParser.browser(ua))
+        assertEquals("Android 15", UserAgentParser.os(ua))
+    }
+
+    @Test
+    fun parsesSafariOnMac() {
+        val ua = "Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_7) AppleWebKit/605.1.15 (KHTML, like Gecko) Version/17.0 Safari/605.1.15"
+
+        assertEquals("Safari 17", UserAgentParser.browser(ua))
+        assertEquals("macOS 10.15.7", UserAgentParser.os(ua))
+    }
+
+    @Test
+    fun returnsNullForMissingUserAgent() {
+        assertNull(UserAgentParser.browser(null))
+        assertNull(UserAgentParser.os(null))
+    }
+}


### PR DESCRIPTION
## Summary
- monitoring-observability.md 명세에 정의된 관제(observability) API 10종을 구현했습니다.
  (헬스체크, 대시보드 스냅샷, 시간대별 지표, SSE 스트림, 클라이언트/서버 오류 로그,
  스토리지 사용량, 리포트 다운로드, 세션 이벤트 수집, 클라이언트 로그 수집)

## Related Issue
- Closes #29 

## Scope
- In scope: `systems/observability` 전 계층(domain/application/adapter-in/adapter-out/bootstrap) 신규 구현, Redis/JWT/POI 의존성 추가
- Out of scope: 다른 서비스가 이 시스템으로 서버 오류·API 요청 지표를 실제로 보고하는 연동(수집 경로가 문서에 없음),   identity의 정식 Spring Security/JWT 인증 병합

## Implementation
- 헥사고날 아키텍처(identity/configuration 컨벤션 준용): domain enum/exception/model → application port-in/out +       service → adapter-in DTO/controller → adapter
- 세션·트래픽 집계(동시접속자, 총방문자, 체류시간, 기기분포, 시간대별 방문자)는 Redis ZSet/Set/Hash로 실집계           - 헬스체크는 JDK `HttpClient`로 각 서비스의 ` 출해 UP/DEGRADED/DOWN 판정
- 클라이언트 오류 로그는 fingerprint(SHA-256) 그룹핑 Redis 저장소로 수집 → 조회까지 실제 동작                          - 리포트는 대시보드 스냅샷을 POI(xlsx)/CSV로 만료 토큰(5분)으로 S3 presigned URL을 대체
- SSE는 `SseEmitter` + `@Scheduled`로 문서 명세의 모든 이벤트(snapshot/traffic/api/business/service/resource/log/ping) 브로드캐스트
- 인증은 identity의 정식 JWT가 아직 미병합이라 자체 경량 `HandlerInterceptor`로 Bearer 토큰 + `role=ADMIN` 검증(설정   키 이름은 identity와 통일해 추후 시크릿만 맞
                                                                                                                       ### 의도적으로 비워둔 부분 (코드 주석으로 근
- 서버 API 오류 로그·API 요청 수(`dashboard.api`, `metrics/series`의 API_REQUEST)는 수집 경로가 문서에 없어 조회 API만 동작하고 데이터는 항상 0/빈 값
- 리포트 생성은 동기 방식만 지원(202 GENERATING/폴링 큐 없음) — 데이터량이 적어 실익 없음
- SSE 팬아웃, 세션/레이트리밋 카운터는 단일  평 확장 시 Redis Pub/Sub 등으로 교체 필요

## Testing
- [x] Unit tests — domain 순수 로직(HealthStatusClassifier, TimeBucketer, Fingerprint, DeviceTypeParser,
UserAgentParser, Cursor), application 서비스 그/리포트/헬스),adapter-in(GlobalExceptionHandler, JwtAuthInterceptor 서명·만료·role 검증)
- [x] `bazel build //...`, `bazel test //syst 른 시스템 영향 없음)
- [ ] Manual verification — 로컬 Redis 필요, 이번 세션에서는 미실행 (요청 시 진행)

## Deployment Notes
- Feature flag: 없음
- Migration required: 없음 (Redis 키만 새로 생성, 스키마 마이그레이션 불필요)
- Rollout considerations: `spring.data.redis.r`, `monitor.services.*.base-url`,`monitor.round.*`, `monitor.report.storage-dir` 환경변수 설정 필요 (dev 기본값은 application.yaml에 있음)

## Checklist
- [x] API 단위로 커밋 분리 (총 13개 커밋)
- [ ] 실제 서비스 기동 후 curl 스모크 테스트 (Redis 필요, 요청 시 진행)
- [ ] 코드 리뷰