### PR TITLE
fix(configuration): S3 object key에 dsm_Entry/Backend 루트 prefix 적용 #26

### DIFF
--- a/systems/configuration/configuration-adapter-in/src/test/kotlin/hs/kr/entrydsm/configuration/adapterin/document/DocumentControllerTest.kt
+++ b/systems/configuration/configuration-adapter-in/src/test/kotlin/hs/kr/entrydsm/configuration/adapterin/document/DocumentControllerTest.kt
@@ -45,7 +45,7 @@ class DocumentControllerTest {
             .andExpect(status().isOk)
             .andExpect(jsonPath("$.success").value(true))
             .andExpect(jsonPath("$.data.fileName").value("application_1001.pdf"))
-            .andExpect(jsonPath("$.data.key").value("application/application_1001.pdf"))
+            .andExpect(jsonPath("$.data.key").value("dsm_Entry/Backend/application/application_1001.pdf"))
 
         assertEquals(FileCategory.APPLICATION, upload.lastCommand?.category)
         assertEquals("application_1001.pdf", upload.lastCommand?.fileName)
@@ -66,8 +66,8 @@ class DocumentControllerTest {
 
     @Test
     fun `지원서 조회는 같은 수험번호의 여러 형식 중 최근 업로드본을 돌려준다`() {
-        read.put(stored("application/application_1001.pdf", Instant.parse("2026-01-01T00:00:00Z")))
-        read.put(stored("application/application_1001.hwp", Instant.parse("2026-02-01T00:00:00Z")))
+        read.put(stored("dsm_Entry/Backend/application/application_1001.pdf", Instant.parse("2026-01-01T00:00:00Z")))
+        read.put(stored("dsm_Entry/Backend/application/application_1001.hwp", Instant.parse("2026-02-01T00:00:00Z")))
 
         mockMvc(applicationController())
             .perform(get("/api/document/v11/application").param("receiptCode", "1001"))
@@ -83,7 +83,7 @@ class DocumentControllerTest {
             .andExpect(status().isOk)
             .andExpect(jsonPath("$.data.exists").value(false))
             .andExpect(jsonPath("$.data.fileName").value("application_1001.pdf"))
-            .andExpect(jsonPath("$.data.key").value("application/application_1001.pdf"))
+            .andExpect(jsonPath("$.data.key").value("dsm_Entry/Backend/application/application_1001.pdf"))
     }
 
     @Test

--- a/systems/configuration/configuration-application/src/test/kotlin/hs/kr/entrydsm/configuration/application/FileDocumentServiceTest.kt
+++ b/systems/configuration/configuration-application/src/test/kotlin/hs/kr/entrydsm/configuration/application/FileDocumentServiceTest.kt
@@ -28,10 +28,10 @@ class FileDocumentServiceTest {
     fun `업로드는 카테고리 키로 저장하고 저장된 메타데이터를 돌려준다`() {
         val saved = service.upload(command(), content())
 
-        assertEquals("application/application_1001.pdf", saved.objectKey)
+        assertEquals("dsm_Entry/Backend/application/application_1001.pdf", saved.objectKey)
         assertEquals("application/pdf", saved.contentType)
         assertEquals("지원서.pdf", saved.originalName)
-        assertEquals(listOf("application/application_1001.pdf"), storage.uploaded)
+        assertEquals(listOf("dsm_Entry/Backend/application/application_1001.pdf"), storage.uploaded)
         assertEquals(1, repository.saved.size)
     }
 
@@ -61,12 +61,12 @@ class FileDocumentServiceTest {
 
         runCatching { service.upload(command(), content()) }
 
-        assertEquals(listOf("application/application_1001.pdf"), storage.deleted)
+        assertEquals(listOf("dsm_Entry/Backend/application/application_1001.pdf"), storage.deleted)
     }
 
     @Test
     fun `덮어쓴 객체는 메타데이터 저장이 실패해도 지우지 않는다`() {
-        storage.existingKeys += "application/application_1001.pdf"
+        storage.existingKeys += "dsm_Entry/Backend/application/application_1001.pdf"
         repository.failOnSave = true
 
         runCatching { service.upload(command(), content()) }
@@ -86,14 +86,14 @@ class FileDocumentServiceTest {
 
     @Test
     fun `파일명으로 다운로드 URL을 발급한다`() {
-        storage.existingKeys += "application/application_1001.pdf"
+        storage.existingKeys += "dsm_Entry/Backend/application/application_1001.pdf"
 
         val downloadUrl = service.issueByCommand(
             IssueDownloadUrlCommand(FileCategory.APPLICATION, "application_1001.pdf"),
         )
 
         assertEquals("application_1001.pdf", downloadUrl.fileName)
-        assertEquals("https://s3/application/application_1001.pdf?expires=300", downloadUrl.downloadUrl)
+        assertEquals("https://s3/dsm_Entry/Backend/application/application_1001.pdf?expires=300", downloadUrl.downloadUrl)
         assertEquals(300L, downloadUrl.expiresIn)
     }
 
@@ -130,7 +130,7 @@ class FileDocumentServiceTest {
         repository.saved += FileDocument(
             id = 1,
             originalName = "지원서.pdf",
-            objectKey = "application/application_1001.pdf",
+            objectKey = "dsm_Entry/Backend/application/application_1001.pdf",
             bucket = "entrydsm",
             contentType = "application/pdf",
             sizeBytes = 10,

--- a/systems/configuration/configuration-domain/src/main/kotlin/hs/kr/entrydsm/configuration/domain/document/FileCategory.kt
+++ b/systems/configuration/configuration-domain/src/main/kotlin/hs/kr/entrydsm/configuration/domain/document/FileCategory.kt
@@ -21,5 +21,10 @@ enum class FileCategory(
 
     fun exceedsMaxSize(sizeBytes: Long): Boolean = sizeBytes > maxSizeBytes
 
-    fun objectKeyOf(fileName: String): String = "$prefix/${FileNaming.requireSafeFileName(fileName)}"
+    fun objectKeyOf(fileName: String): String =
+        "$KEY_ROOT$prefix/${FileNaming.requireSafeFileName(fileName)}"
+
+    companion object {
+        const val KEY_ROOT = "dsm_Entry/Backend/"
+    }
 }

--- a/systems/configuration/configuration-domain/src/test/kotlin/hs/kr/entrydsm/configuration/domain/document/DocumentDomainTest.kt
+++ b/systems/configuration/configuration-domain/src/test/kotlin/hs/kr/entrydsm/configuration/domain/document/DocumentDomainTest.kt
@@ -45,9 +45,9 @@ class DocumentDomainTest {
     }
 
     @Test
-    fun `object key는 카테고리 prefix를 붙인다`() {
+    fun `object key는 루트 prefix와 카테고리 prefix를 붙인다`() {
         assertEquals(
-            "admission-ticket/admission_ticket_1001.pdf",
+            "dsm_Entry/Backend/admission-ticket/admission_ticket_1001.pdf",
             FileCategory.ADMISSION_TICKET.objectKeyOf("admission_ticket_1001.pdf"),
         )
     }


### PR DESCRIPTION
## 문제

버킷 내에서 `dsm_Entry/Backend/` prefix만 사용하기로 했는데, 코드는 카테고리 prefix만 붙이고 있었습니다.

```
현재:  application/application_1001.pdf      ← 버킷 루트에 바로 생성
변경:  dsm_Entry/Backend/application/application_1001.pdf
```

## 변경

키 생성 지점은 `FileCategory.objectKeyOf` 한 곳이라 여기만 수정했습니다.

```kotlin
fun objectKeyOf(fileName: String): String =
    "$KEY_ROOT$prefix/${FileNaming.requireSafeFileName(fileName)}"

companion object {
    const val KEY_ROOT = "dsm_Entry/Backend/"
}
```

- `S3StorageAdapter`는 키를 받아 쓰기만 해서 변경 없음
- `FileDocument.fileName`은 `substringAfterLast('/')`라 그대로 동작
- 나머지는 하드코딩된 키 기대값을 쓰는 테스트 3개 반영

## 확인

`bazel test //systems/configuration/...` → 11/11 통과

## 배포 시 주의

기존 `file_document.object_key` 행은 옛 키를 들고 있어 조회가 어긋납니다. 운영 데이터가 있다면 S3 객체 복사와 함께 아래가 필요합니다.

```sql
UPDATE file_document SET object_key = CONCAT('dsm_Entry/Backend/', object_key);
```

데이터가 아직 없으면 불필요합니다.

🤖 Generated with [Claude Code](https://claude.com/claude-code)